### PR TITLE
Fix some wavelength rules

### DIFF
--- a/Wavelength/Boardgamebox/Game.py
+++ b/Wavelength/Boardgamebox/Game.py
@@ -73,3 +73,10 @@ class Game(BaseGame):
 		import Wavelength.Commands as WavelengthCommands
 		if self.board is not None:
     			WavelengthCommands.command_call(context.bot, self)
+
+	# We use this method to ensure existing games without the suddenDeath attr
+	# does not fail
+	def getSuddenDeath(self):
+		if not hasattr(self, 'suddenDeath'):
+			self.suddenDeath = -1
+		return self.suddenDeath

--- a/Wavelength/Boardgamebox/Game.py
+++ b/Wavelength/Boardgamebox/Game.py
@@ -15,6 +15,7 @@ class Game(BaseGame):
 		BaseGame.__init__(self, cid, initiator, groupName, tipo, modo)
 		self.turncount = 0
 		self.code_length = 5
+		self.suddenDeath = -1
 	# Creacion de player de Say Anything.
 	def add_player(self, uid, name):
 		self.playerlist[uid] = Player(name, uid)

--- a/Wavelength/Boardgamebox/Game.py
+++ b/Wavelength/Boardgamebox/Game.py
@@ -26,11 +26,11 @@ class Game(BaseGame):
 				self.board.state.teams[0].player_sequence.append(self.playerlist[uid])
 			else:
 				self.board.state.teams[randint(0, 1)].player_sequence.append(self.playerlist[uid])
-	
+
 	def create_board(self):
 		player_number = len(self.playerlist)
 		self.board = Board(player_number, self)
-	
+
 	def create_teams(self, amount_teams):
 		splited_teams = self.split_in_teams(self.player_sequence, amount_teams)
 		i = 1
@@ -38,26 +38,26 @@ class Game(BaseGame):
 		for team in splited_teams[::-1]:
 			self.board.state.teams.append(Team("Equipo {}".format(i), team))
 			i += 1
-			
+
 		# Marco al equipo activo.
 		self.board.state.active_team = self.board.state.teams[self.board.state.team_counter]
 		self.board.state.active_team.player_counter = 0
 		self.board.state.active_team.active_player = self.board.state.active_team.player_sequence[self.board.state.active_team.player_counter]
 		self.board.state.inactive_team = self.board.state.teams[1 if self.board.state.team_counter == 0 else 0]
-		
+
 	def split_in_teams(self, lst,n):
 		return [lst[i::n] for i in range(n)]
-	
+
 	def verify_turn(self, uid):
-		
+
 		if self.board.state.fase_actual == "Set_Reference" and uid == self.board.state.active_team.active_player.uid:
 			return True
 		if self.board.state.fase_actual == "Predict" and self.board.state.active_team.belongs(uid) and self.board.state.active_team.active_player.uid != uid:
 			return True
 		if self.board.state.fase_actual == "Predict_Opp_LR" and self.board.state.inactive_team.belongs(uid):
-			return True 
+			return True
 		return False
-	
+
 	def myturn_message(self, uid):
 		game = self
 		group_link_name = "[{0}]({1})".format(game.groupName, get_config_data(game, "link"))
@@ -66,7 +66,7 @@ class Game(BaseGame):
 		if game.board.state.fase_actual == "Predict" and game.board.state.active_team.belongs(uid) and game.board.state.active_team.active_player.uid != uid:
 			return "Partida: {} de Wavelength tienes que actuar".format(group_link_name)
 		if game.board.state.fase_actual == "Predict_Opp_LR" and game.board.state.inactive_team.belongs(uid):
-			return "Partida: {} de Wavelength tienes que actuar".format(group_link_name) 
+			return "Partida: {} de Wavelength tienes que actuar".format(group_link_name)
 		return "Partida: {} de Wavelength tienes que actuar".format(group_link_name)
 	def call(self, context):
 		import Wavelength.Commands as WavelengthCommands

--- a/Wavelength/Controller.py
+++ b/Wavelength/Controller.py
@@ -188,10 +188,9 @@ def resolve(bot, game, args = []):
 	start_next_round(bot, game)
 
 def start_next_round(bot, game):
-	# Verifico si alguno de los dos equipos ha llegado a los puntos para ganar. Y que la cantidad de turnos haya sido par
-	if (game.board.state.active_team.score >= 15 
-	    or game.board.state.inactive_team.score >= 15) and (
-		game.turncount % 2 == 0):
+	# Verifico si alguno de los dos equipos ha llegado a los puntos para ganar.
+	if (game.board.state.active_team.score >= 10
+	    or game.board.state.inactive_team.score >= 10)
 
 		game.board.print_board(bot, game)
 

--- a/Wavelength/Controller.py
+++ b/Wavelength/Controller.py
@@ -45,7 +45,7 @@ logger = log.getLogger(__name__)
 debugging = False
 
 def init_game(bot, game):
-	log.info('wavelength init called')	
+	log.info('wavelength init called')
 	game.shuffle_player_sequence()
 	game.create_teams(2)
 	start_round(bot, game)
@@ -53,7 +53,7 @@ def init_game(bot, game):
 # Objetivo
 # start_round/send_wavelength -> Set reference -> send_ref ->  send_guess/resolve/start_next_round
 #  ---------------Set_Reference----------------   Predict  ---   Predict_Opp_LR  -------------------
-	
+
 def start_round(bot, game):
 	log.info('start_round_Wave called')
 	cid = game.cid
@@ -65,25 +65,25 @@ def start_round(bot, game):
 		game.turncount = 1
 	game.board.state.fase_actual = "Set_Reference"
 	game.board.new_wave_card()
-	send_wavelength(bot, game)	
-	
-	
+	send_wavelength(bot, game)
+
+
 def send_wavelength(bot, game):
-	game.board.print_board(bot, game)	
+	game.board.print_board(bot, game)
 	msg = "{} tienes que poner una referencia!".format(player_call(game.board.state.active_team.active_player))
 	bot.send_message(game.cid, msg, ParseMode.MARKDOWN)
 	active_wave_card = game.board.state.active_wave_card
 	call_other_players = ""
 	for player in game.board.state.active_team.player_sequence:
 		call_other_players += "{} ".format(player_call(player)) if player.uid != game.board.state.active_team.active_player.uid else ""
-		
+
 	msg = "Partida en el grupo *{}* con tus compañeros {}\n\nLa carta que te ha tocado es: *{}*/*{}*.\nPone tu pista con /ref EJEMPLO EJEMPLO".format(
-		game.groupName, call_other_players, active_wave_card["Izquierda"], active_wave_card["Derecha"])	
-	bot.send_message(game.board.state.active_team.active_player.uid, msg, ParseMode.MARKDOWN)	
+		game.groupName, call_other_players, active_wave_card["Izquierda"], active_wave_card["Derecha"])
+	bot.send_message(game.board.state.active_team.active_player.uid, msg, ParseMode.MARKDOWN)
 	bio = "https://ssl.hq063.com.ar/pbt/imagen.php?angle={}&size=th&text={}|{}&v=201903131425".format(game.board.state.wavelength, active_wave_card["Izquierda"], active_wave_card["Derecha"])
 	bot.send_photo(game.board.state.active_team.active_player.uid, photo=bio, caption="{}-----------------------{}".format(active_wave_card["Izquierda"], active_wave_card["Derecha"]))
 	save(bot, game.cid)
-	
+
 #Active player send reference of wavelength
 def send_ref(bot, game):
 	game.board.print_board(bot, game)
@@ -91,81 +91,81 @@ def send_ref(bot, game):
 	call_other_players = ""
 	for player in game.board.state.active_team.player_sequence:
 		call_other_players += "{} ".format(player_call(player)) if player.uid != game.board.state.active_team.active_player.uid else ""
-	msg = "La referencia es:\n*{}*. {}les toca adivinar!".format(game.board.state.reference, call_other_players)	
-	bot.send_message(game.cid, msg, ParseMode.MARKDOWN)	
+	msg = "La referencia es:\n*{}*. {}les toca adivinar!".format(game.board.state.reference, call_other_players)
+	bot.send_message(game.cid, msg, ParseMode.MARKDOWN)
 	game.board.state.fase_actual = "Predict"
 	save(bot, game.cid)
 	game.board.state.team_choosen_grade = 90
 	draw_choose_needle(bot, game)
 
-#Draws the picture and the needle so the team can select it.	
+#Draws the picture and the needle so the team can select it.
 def draw_choose_needle(bot, game, message_id = None):
 	cid = game.cid
 	active_wave_card = game.board.state.active_wave_card
 	needle = "&needle={}".format(game.board.state.team_choosen_grade)
 	bio = "https://ssl.hq063.com.ar/pbt/imagen.php?size=th{}&text={}|{}&v={}".format(needle, active_wave_card["Izquierda"], active_wave_card["Derecha"], datetime.datetime.now().strftime("%Y%m%d%H"))
-	btnMarkup = create_choose_buttons2(cid, "ChangeGradeWave", CHANGEGRADE, CONFIRMRESTART)	
+	btnMarkup = create_choose_buttons2(cid, "ChangeGradeWave", CHANGEGRADE, CONFIRMRESTART)
 	# Re draw if previous
 	call_other_players = ""
 	for player in game.board.state.active_team.player_sequence:
 		call_other_players += "{} ".format(player_call(player)) if player.uid != game.board.state.active_team.active_player.uid else ""
 	caption = "{}-----------------------{}\n\nLa referencia es: *{}*\nDecidan: {}".format(active_wave_card["Izquierda"], active_wave_card["Derecha"], game.board.state.reference, call_other_players)
-	
+
 	log.info(bio)
-	
+
 	if message_id:
-		#bot.delete_message(chat_id=cid, message_id=message_id)		
+		#bot.delete_message(chat_id=cid, message_id=message_id)
 		bioInputMedia = InputMediaPhoto(media=bio,
-						caption=caption,					       
+						caption=caption,
 						parse_mode=ParseMode.MARKDOWN)
 		#InputMediaPhoto(media=TestInputMediaPhoto.media, caption=TestInputMediaPhoto.caption, parse_mode=TestInputMediaPhoto.parse_mode)
-		bot.edit_message_media(chat_id=cid, 
-				       message_id=message_id, 
-				       media=bioInputMedia, 
+		bot.edit_message_media(chat_id=cid,
+				       message_id=message_id,
+				       media=bioInputMedia,
 				       reply_markup=btnMarkup)
 	# Draw again
 	else:
-		bot.send_photo(cid, photo=bio, 
-			       reply_markup=btnMarkup,			       
+		bot.send_photo(cid, photo=bio,
+			       reply_markup=btnMarkup,
 			       parse_mode=ParseMode.MARKDOWN,
 			       caption=caption)
 	save(bot, game.cid)
-	
-def send_guess(bot, game):	
+
+def send_guess(bot, game):
 	game.board.print_board(bot, game)
 	active_wave_card = game.board.state.active_wave_card
 	call_other_players = ""
 	for player in game.board.state.inactive_team.player_sequence:
-		call_other_players += "{} ".format(player_call(player))	
+		call_other_players += "{} ".format(player_call(player))
 	msg = "La referencia dada fue:\n*{}*\n\nEquipo contrario {} elija si la respuesta correcta esta a la izquierda o derecha.".format(game.board.state.reference, call_other_players)
 	bot.send_message(game.cid, msg, ParseMode.MARKDOWN)
 	game.board.state.fase_actual = "Predict_Opp_LR"
 	save(bot, game.cid)
 	bio = "https://ssl.hq063.com.ar/pbt/imagen.php?needle={}&size=th&text={}|{}&v={}".format(game.board.state.team_choosen_grade, active_wave_card["Izquierda"], active_wave_card["Derecha"], datetime.datetime.now().strftime("%Y%m%d"))
 	btnMarkup = create_choose_buttons(game.cid, "LeftRightWave", RIGHTLEFT, True)
-	bot.send_photo(game.cid, photo=bio, reply_markup=btnMarkup, 
-		       parse_mode=ParseMode.MARKDOWN, 
+	bot.send_photo(game.cid, photo=bio, reply_markup=btnMarkup,
+		       parse_mode=ParseMode.MARKDOWN,
 		       caption="{}-----------------------{}\n\nLa referencia es: *{}*".format(
-			       active_wave_card["Izquierda"], 
-			       active_wave_card["Derecha"], 
+			       active_wave_card["Izquierda"],
+			       active_wave_card["Derecha"],
 			       game.board.state.reference))
 	save(bot, game.cid)
-	
-def resolve(bot, game, args = []):	
+
+def resolve(bot, game, args = []):
 	log.info('resolve_Wave called')
 	# Resolvemos
 	active_wave_card = game.board.state.active_wave_card
-	diff = game.board.state.wavelength - game.board.state.team_choosen_grade 
+	diff = game.board.state.wavelength - game.board.state.team_choosen_grade
 	abs_diff = abs(diff)
 	textCache = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
 	bio = "https://ssl.hq063.com.ar/pbt/imagen.php?needle={}&angle={}&size=th&text={}|{}&v={}".format(game.board.state.team_choosen_grade, game.board.state.wavelength, active_wave_card["Izquierda"], active_wave_card["Derecha"], textCache)
 	log.info(bio)
 	bot.send_photo(game.cid, photo=bio, caption="{}-----------------------{}".format(active_wave_card["Izquierda"], active_wave_card["Derecha"]))
 	msg = "La carta que ha tocado es:\n*{}*------------*{}*.\n\nLa referencia dada fue: *{}*.\n\nEl equipo contrario dijo que estaba: *{}*\n".format(
-		active_wave_card["Izquierda"], 
+		active_wave_card["Izquierda"],
 		active_wave_card["Derecha"],
 		game.board.state.reference,
-		"a la Izquierda" if game.board.state.opponent_team_choosen_left_right == 0 else "a la Derecha")	
+		"a la Izquierda" if game.board.state.opponent_team_choosen_left_right == 0 else "a la Derecha")
 	if abs_diff <= 3:
 		game.board.state.active_team.score += 4
 		msg += "\n*BULLSEYE!!!! 4 PUNTOS!!!*"
@@ -174,27 +174,27 @@ def resolve(bot, game, args = []):
 		msg += "\nEl equipo activo ha adivinado en la franja verde, ha ganado *3 puntos*!"
 	elif abs_diff <= 15:
 		game.board.state.active_team.score += 2
-		msg += "\nEl equipo activo ha adivinado en la franja marrón, ha ganado *2 punto*!"	
+		msg += "\nEl equipo activo ha adivinado en la franja marrón, ha ganado *2 punto*!"
 	opp_choose_l_r = game.board.state.opponent_team_choosen_left_right
 	if ((diff > 0 and opp_choose_l_r == 1) or (diff < 0 and opp_choose_l_r == 0)) and abs_diff > 3:
 		game.board.state.inactive_team.score += 1
 		msg += "\nEl equipo inactivo ha correctamente si estaba a la derecha o izquierda del bulls eye. Ha ganado *1 punto*!"
 	bot.send_message(game.cid, msg, ParseMode.MARKDOWN)
-	msg = "*(Debug data)*\nEl grado elegido es *{}*\nEl equipo contrario eligio *{}*.\n\nEl grado real era *{}*".format(		
+	msg = "*(Debug data)*\nEl grado elegido es *{}*\nEl equipo contrario eligio *{}*.\n\nEl grado real era *{}*".format(
 		game.board.state.team_choosen_grade,
 		"a la Izquierda" if game.board.state.opponent_team_choosen_left_right == 0 else "a la Derecha",
-		game.board.state.wavelength)	
+		game.board.state.wavelength)
 	game.history.append(msg)
 	start_next_round(bot, game)
-		
+
 def start_next_round(bot, game):
 	# Verifico si alguno de los dos equipos ha llegado a los puntos para ganar. Y que la cantidad de turnos haya sido par
 	if (game.board.state.active_team.score >= 15 
 	    or game.board.state.inactive_team.score >= 15) and (
 		game.turncount % 2 == 0):
-		
+
 		game.board.print_board(bot, game)
-		
+
 		# El juego ha terminado!
 		team_diff = game.board.state.active_team.score - game.board.state.inactive_team.score
 		if team_diff > 0:
@@ -215,50 +215,50 @@ def start_next_round(bot, game):
 def continue_playing(bot, game):
 	opciones_botones = { "Nuevo" : "Cambiar jugadores", "Mantener" : "Mismos jugadores" }
 	simple_choose_buttons(bot, game.cid, 1, game.cid, "chooseendWL", "¿Quieres continuar jugando?", opciones_botones)
-	
+
 def callback_finish_game_buttons(update: Update, context: CallbackContext):
 	bot = context.bot
 	callback = update.callback_query
-	try:		
-		#log.info('callback_finish_game_buttons called: %s' % callback.data)	
+	try:
+		#log.info('callback_finish_game_buttons called: %s' % callback.data)
 		regex = re.search(r"(-[0-9]*)\*chooseendWL\*(.*)\*([0-9]*)", callback.data)
 		cid, opcion, uid  = int(regex.group(1)), regex.group(2), int(regex.group(3))
 		mensaje_edit = "Has elegido: {0}".format(opcion)
 		try:
 			bot.edit_message_text(mensaje_edit, cid, callback.message.message_id)
 		except Exception as e:
-			bot.edit_message_text(mensaje_edit, uid, callback.message.message_id)				
+			bot.edit_message_text(mensaje_edit, uid, callback.message.message_id)
 		game = get_game(cid)
-		
+
 		# Obtengo el diccionario actual, primero casos no tendre el config y pondre el community
 		try:
 			diff = game.configs.get('difficultad', 0)
 		except Exception as e:
 			diff = 0
-		
-		# Obtengo datos de juego anterior		
+
+		# Obtengo datos de juego anterior
 		groupName = game.groupName
 		tipojuego = game.tipo
 		modo = game.modo
-		
+
 		# Dependiendo de la opcion veo que como lo inicio
-				
+
 		players = game.playerlist.copy()
-		
+
 		# Creo nuevo juego
 		game = Game(cid, uid, groupName, tipojuego, modo)
 		GamesController.games[cid] = game
 
 		if opcion == "Nuevo":
-			bot.send_message(cid, "Cada jugador puede unirse al juego con el comando /join.\nEl iniciador del juego (o el administrador) pueden unirse tambien y escribir /startgame cuando todos se hayan unido al juego!")			
+			bot.send_message(cid, "Cada jugador puede unirse al juego con el comando /join.\nEl iniciador del juego (o el administrador) pueden unirse tambien y escribir /startgame cuando todos se hayan unido al juego!")
 			return
 
-		# Si no es nuevo entonces los jugadores son agregados y los equipos crados	
-		for uid in players:		
-			game.add_player(uid, players[uid].name)		
+		# Si no es nuevo entonces los jugadores son agregados y los equipos crados
+		for uid in players:
+			game.add_player(uid, players[uid].name)
 		# StartGame
 		player_number = len(game.playerlist)
-		game.board = Board(player_number, game)		
+		game.board = Board(player_number, game)
 		game.player_sequence = []
 
 		init_game(bot, game)
@@ -276,25 +276,25 @@ def create_choose_buttons2(cid, accion, opciones_botones, opciones_botones2):
 	# Creo los botones para elegir al usuario
 	for key, value in opciones_botones.items():
 		txtBoton = value
-		datos = str(cid) + "*" + accion + "*" + str(key) + "*" + str(value)		
+		datos = str(cid) + "*" + accion + "*" + str(key) + "*" + str(value)
 		btns.append(InlineKeyboardButton(txtBoton, callback_data=datos))
-	btnsResult.append(btns)	
-	
+	btnsResult.append(btns)
+
 	for key, value in opciones_botones2.items():
 		txtBoton = value
-		datos = str(cid) + "*" + accion + "*" + str(key) + "*" + str(value)		
+		datos = str(cid) + "*" + accion + "*" + str(key) + "*" + str(value)
 		btns2.append(InlineKeyboardButton(txtBoton, callback_data=datos))
 	btnsResult.append(btns2)
-	
-	return InlineKeyboardMarkup(btnsResult)	
-		
+
+	return InlineKeyboardMarkup(btnsResult)
+
 def create_choose_buttons(cid, accion, opciones_botones, one_line = True):
 	#sleep(3)
 	btns = []
 	# Creo los botones para elegir al usuario
 	for key, value in opciones_botones.items():
 		txtBoton = value
-		datos = str(cid) + "*" + accion + "*" + str(key) + "*" + str(value)		
+		datos = str(cid) + "*" + accion + "*" + str(key) + "*" + str(value)
 		if one_line:
 			btns.append(InlineKeyboardButton(txtBoton, callback_data=datos))
 		else:

--- a/Wavelength/Controller.py
+++ b/Wavelength/Controller.py
@@ -63,7 +63,7 @@ def start_round(bot, game):
 		game.turncount += 1
 	except AttributeError:
 		game.turncount = 1
-	if game.suddenDeath >= 0:
+	if game.getSuddenDeath() >= 0:
 		game.suddenDeath += 1
 	game.board.state.fase_actual = "Set_Reference"
 	game.board.new_wave_card()
@@ -208,7 +208,7 @@ def start_next_round(bot, game, catchup_rule):
 	# O si estan en muerte subita y jugaron una vez cada equipo
 	if (game.board.state.active_team.score >= 10
 	    or game.board.state.inactive_team.score >= 10) or (
-		game.suddenDeath == 2):
+		game.getSuddenDeath() == 2):
 
 		game.board.print_board(bot, game)
 

--- a/Wavelength/Controller.py
+++ b/Wavelength/Controller.py
@@ -134,6 +134,13 @@ def draw_choose_needle(bot, game, message_id = None):
 	save(bot, game.cid)
 
 def send_guess(bot, game):
+	# To improve game pace, we eagerly check if there is a bullseye and prevent
+	# the other team from having to do an useless left/right guess
+	diff = abs(game.board.state.wavelength - game.board.state.team_choosen_grade)
+	if diff < 3:
+		resolve(bot, game)
+		return
+
 	game.board.print_board(bot, game)
 	active_wave_card = game.board.state.active_wave_card
 	call_other_players = ""


### PR DESCRIPTION
When this game was developed on the bot, it was not yet released so we had to guess some of the rules.
At this point, reading the manual, I see there are a few differences. This PR fixes all of them and also adds a small improvement to the game pace by skipping a useless step (that can't be done on a physical game, but is easy and makes sense on digital implementation).

- **Fix end game condition**: The game rules specify 10 points to win (not 15) and no need to have the same number of turns (because it also allows a team to have consecutive turns).
- **Implement sudden death**: According to the rules, if there is a draw and both teams reach 10 points in the same round, they have to play another round, one turn per team. If the draw persists, we do a new sudden death until it's decided.
- **Implement catchup rule**: The game rules provide a catchup mechanism where if after a team does a bullseye they still have fewer points than the other team, they take another turn.
- **Improve game pace by removing useless steps**: When a team does a bullseye, the other team can't score from their left/right guess, so there is no need to ask for that guess.