### PR TITLE
fix: corregir await en /call y ruta de archivo en Codenames

### DIFF
--- a/Arcana/Boardgamebox/Game.py
+++ b/Arcana/Boardgamebox/Game.py
@@ -14,7 +14,7 @@ class Game(BaseGame):
 	def create_board(self):
 		player_number = len(self.playerlist)
 		self.board = Board(player_number, self)
-	def call(self, context):
+	async def call(self, context):
 		import Arcana.Commands as ArcanaCommands
 		if self.board is not None:
-			ArcanaCommands.command_call(context.bot, self)
+			await ArcanaCommands.command_call(context.bot, self)

--- a/Boardgamebox/Game.py
+++ b/Boardgamebox/Game.py
@@ -74,10 +74,10 @@ class Game(object):
     def get_rules(self):
         return ["LINK_Juego", "No hay reglas agregadas todavias:"]
 
-    def call(self, context):
+    async def call(self, context):
         import JustOne.Commands as JustoneCommands
         if self.board is not None:
-            JustoneCommands.command_call(context.bot, self)
+            await JustoneCommands.command_call(context.bot, self)
 
     def group_link_name(self):
         link_info = None

--- a/Codenames/Boardgamebox/Game.py
+++ b/Codenames/Boardgamebox/Game.py
@@ -57,7 +57,7 @@ class Game(BaseGame):
                     "Comandos: /hint PALABRA NUMERO (quien da la pista, en privado) | /pick NUMERO (quien adivina, en el grupo) | /endturn"]
         return ["Codenames: adivinen las palabras de su equipo con las pistas del espía.\nComandos: /hint PALABRA NUMERO (espía, en privado) | /pick NUMERO (agentes, en el grupo) | /endturn"]
 
-    def call(self, context):
+    async def call(self, context):
         import Codenames.Commands as CodenamesCommands
         if self.board is not None:
-            CodenamesCommands.command_call(context.bot, self)
+            await CodenamesCommands.command_call(context.bot, self)

--- a/Codenames/Controller.py
+++ b/Codenames/Controller.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import logging as log
+import os
 import random
 import re
+
+_TXT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'txt')
 
 from telegram import Update
 from telegram.constants import ParseMode
@@ -65,7 +68,7 @@ async def callback_finish_config_cn(update: Update, context: CallbackContext):
 async def finish_config(bot, game):
     log.info('Codenames finish_config called')
     opcion = game.configs.get('diccionario', 'original')
-    url_palabras = f'/Codenames/txt/spanish-{opcion}.txt'
+    url_palabras = os.path.join(_TXT_DIR, f'spanish-{opcion}.txt')
     with open(url_palabras, 'r') as f:
         palabras_posibles = [w.strip() for w in f.readlines() if w.strip()]
 

--- a/SayAnything/Boardgamebox/Game.py
+++ b/SayAnything/Boardgamebox/Game.py
@@ -20,7 +20,7 @@ class Game(BaseGame):
 	def create_board(self):
 		player_number = len(self.playerlist)
 		self.board = Board(player_number, self)
-	def call(self, context):
+	async def call(self, context):
 		import SayAnything.Commands as SayAnythingCommands
 		if self.board is not None:
-    			SayAnythingCommands.command_call(context.bot, self)
+			await SayAnythingCommands.command_call(context.bot, self)

--- a/Unanimo/Boardgamebox/Game.py
+++ b/Unanimo/Boardgamebox/Game.py
@@ -62,10 +62,10 @@ Si NO se adivino la palabra, los aldeanos votan a ver quien es el lobo. *Si un l
 		for player in self.playerlist.values():
 			player.points = 0
 
-	def call(self, context):
+	async def call(self, context):
 		import Unanimo.Commands as UnanimoCommands
 		if self.board is not None:
-				UnanimoCommands.command_call(context.bot, self)
+			await UnanimoCommands.command_call(context.bot, self)
 				
 	def timer(self, update, context):
 		import Unanimo.Commands as UnanimoCommands

--- a/Unanimo/Commands.py
+++ b/Unanimo/Commands.py
@@ -49,11 +49,11 @@ url = urllib.parse.urlparse(os.environ["DATABASE_URL"])
 async def command_call(bot, game):
 	# Verifico en mi maquina de estados que comando deberia usar para el estado(fase) actual
 	if game.board.state.fase_actual == "Proponiendo Pistas":
-		call_proponiendo_pistas(bot, game)
+		await call_proponiendo_pistas(bot, game)
 	elif game.board.state.fase_actual == "Revisando Pistas":
 		reviewer_player = game.board.state.reviewer_player
 		await bot.send_message(game.cid, "Revisor {0} recorda que tenes que verificar las pistas".format(player_call(reviewer_player)), ParseMode.MARKDOWN)
-		UnanimoController.send_reviewer_buttons(bot, game)
+		await UnanimoController.send_reviewer_buttons(bot, game)
 	elif game.board.state.fase_actual == "Adivinando":
 		active_player = game.board.state.active_player
 		await bot.send_message(game.cid, "{0} estamos esperando para que hagas /guess EJEMPLO o /pass".format(player_call(active_player)), ParseMode.MARKDOWN)
@@ -84,7 +84,7 @@ async def call_proponiendo_pistas(bot, game):
 				await bot.send_message(game.cid, history_text, ParseMode.MARKDOWN)
 			# Se pone >= ya que si un jugador se va del partido y ya puso pista entonces vale
 			if game.board.num_players != 3 and len(game.board.state.last_votes) >= len(game.player_sequence):
-				UnanimoController.review_clues(bot, game)			
+				await UnanimoController.review_clues(bot, game)
 		else:
 			await bot.send_message(game.cid, "5 minutos deben pasar para llamar a call") 
 
@@ -114,7 +114,7 @@ async def set_words(bot, args):
 			await bot.send_message(game.cid, "El jugador *%s* ha puesto una pista." % game.playerlist[uid].name, ParseMode.MARKDOWN)
 			
 			if len(game.board.state.last_votes) == len(game.player_sequence):
-				UnanimoController.review_clues(bot, game)
+				await UnanimoController.review_clues(bot, game)
 			# if game.board.num_players != 3:
 			# 	if len(game.board.state.last_votes) == len(game.player_sequence)-1:
 			# 		UnanimoController.review_clues(bot, game)
@@ -270,34 +270,14 @@ async def replace_accent(txt):
 
 async def command_continue(bot, game, uid):
 	try:
-		
-		# Verifico en mi maquina de estados que comando deberia usar para el estado(fase) actual
 		if game.board.state.fase_actual == "Proponiendo Pistas":
-			# Vuelvo a mandar la pista
-			UnanimoController.call_players_to_clue(bot, game)
+			await UnanimoController.call_players_to_clue(bot, game)
 		elif game.board.state.fase_actual == "Revisando Pistas":
-			UnanimoController.review_clues(bot, game)
+			await UnanimoController.review_clues(bot, game)
 		elif game.board.state.fase_actual == "Adivinando":
 			active_player = game.board.state.active_player
 			await bot.send_message(game.cid, "{0} estamos esperando para que hagas /guess EJEMPLO o /pass".format(player_call(active_player)), ParseMode.MARKDOWN)
 		elif game.board.state.fase_actual == "Finalizado":
-			UnanimoController.continue_playing(bot, game)
-	except Exception as e:
-		await bot.send_message(game.cid, str(e))
-		
-async def command_continue(bot, game, uid):
-	try:
-		
-		# Verifico en mi maquina de estados que comando deberia usar para el estado(fase) actual
-		if game.board.state.fase_actual == "Proponiendo Pistas":
-			# Vuelvo a mandar la pista
-			UnanimoController.call_players_to_clue(bot, game)
-		elif game.board.state.fase_actual == "Revisando Pistas":
-			UnanimoController.review_clues(bot, game)
-		elif game.board.state.fase_actual == "Adivinando":
-			active_player = game.board.state.active_player
-			await bot.send_message(game.cid, "{0} estamos esperando para que hagas /guess EJEMPLO o /pass".format(player_call(active_player)), ParseMode.MARKDOWN)
-		elif game.board.state.fase_actual == "Finalizado":
-			UnanimoController.continue_playing(bot, game)
+			await UnanimoController.continue_playing(bot, game)
 	except Exception as e:
 		await bot.send_message(game.cid, str(e))


### PR DESCRIPTION
## Resumen

Dos fixes encontrados en testing:

### 1. Error "NoneType can't be used in 'await' expression" en `/call`
`await game.call(context)` fallaba porque `call()` era síncrono y retornaba `None`.

**Archivos corregidos** — se convirtió `def call()` a `async def call()` con `await`:
- `Unanimo/Boardgamebox/Game.py`
- `Arcana/Boardgamebox/Game.py`
- `SayAnything/Boardgamebox/Game.py`
- `Codenames/Boardgamebox/Game.py`
- `Boardgamebox/Game.py` (clase base — afecta a JustOne)

**`Unanimo/Commands.py`** — se agregaron los `await` faltantes en `command_call`, `call_proponiendo_pistas`, `command_continue` y se eliminó la definición duplicada de `command_continue`.

### 2. FileNotFoundError al iniciar Codenames (`callback_finish_config_cn`)
`/Codenames/txt/spanish-original.txt` no resolvía correctamente en el servidor.

**`Codenames/Controller.py`** — reemplazada la ruta absoluta hardcodeada por una ruta relativa al archivo usando `os.path.dirname(__file__)`. Funciona en cualquier entorno independientemente del working directory.

## Verificación
- `python -m Codenames.test_codenames` — 3 tests pasan
- `/call` en Unanimo ya no arroja el error

https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa

---
_Generated by [Claude Code](https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa)_