### PR TITLE
fix: corregir 'coroutine has no attribute status' en command_startgame

### DIFF
--- a/Commands.py
+++ b/Commands.py
@@ -724,7 +724,7 @@ async def command_join(update: Update, context: CallbackContext):
 				
 				# Si se ha alcanzado el minimo o superado, y no esta ya empezado
 				if len(game.playerlist) == max_jugadores and not game.board:
-					await command_startgame(update, context)
+					await command_startgame(update, context, auto_start=True)
 				elif len(game.playerlist) >= min_jugadores:
 					if game.board:
 						await bot.send_message(game.cid, fname + " se ha unido al juego. Hay %s/%s jugadores." % (str(len(game.playerlist)), max_jugadores))
@@ -739,7 +739,7 @@ async def command_join(update: Update, context: CallbackContext):
 			await bot.send_message(game.cid,
 				fname + ", no puedo mandarte mensajes privados o hubo un error. Por favor anda a @MultiGamesByLevibot y hace click en \"Start\".\nLuego tiene que hacer /join de nuevo." + str(e))
 
-async def command_startgame(update: Update, context: CallbackContext):
+async def command_startgame(update: Update, context: CallbackContext, auto_start: bool = False):
 	bot = context.bot
 	log.info('command_startgame called')
 	cid = update.message.chat_id
@@ -748,7 +748,7 @@ async def command_startgame(update: Update, context: CallbackContext):
 		await bot.send_message(cid, "There is no game in this chat. Create a new game with /newgame")
 	#elif game.board:
 	#	await bot.send_message(cid, "The game is already running!")
-	elif update.message.from_user.id not in ADMIN and update.message.from_user.id != game.initiator and bot.getChatMember(cid, update.message.from_user.id).status not in ("administrator", "creator"):
+	elif not auto_start and update.message.from_user.id not in ADMIN and update.message.from_user.id != game.initiator and (await bot.get_chat_member(cid, update.message.from_user.id)).status not in ("administrator", "creator"):
 		await bot.send_message(game.cid, "Solo el creador del juego o un admin puede iniciar con /startgame")	
 	elif game.board:
 		await bot.send_message(cid, "El juego ya empezo!")


### PR DESCRIPTION
## Resumen

- **`await bot.get_chat_member()`** — la llamada a `getChatMember` dentro de `command_startgame` no tenía `await`, lo que devolvía un coroutine en vez del objeto miembro; acceder a `.status` en el coroutine lanzaba `AttributeError: 'coroutine' object has no attribute 'status'`.
- **Parámetro `auto_start=True`** — cuando `command_join` llama automáticamente a `command_startgame` al alcanzar el máximo de jugadores, se pasa `auto_start=True` para saltear el check de permisos de iniciador/admin, que no aplica en ese flujo.

## Archivos modificados

- `Commands.py` — firma de `command_startgame` + guard `not auto_start and` + `await bot.get_chat_member()`

## Test plan

- [ ] `/join` con la sala llena no muestra el error `'coroutine' object has no attribute 'status'`
- [ ] El juego inicia automáticamente cuando se alcanza el máximo de jugadores
- [ ] `/startgame` manual sigue validando que sea el creador o un admin

---
_Generated by [Claude Code](https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa)_