### PR TITLE
fix: mostrar palabras en vez de números en tablero privado de Codenames

### DIFF
--- a/Codenames/Boardgamebox/Board.py
+++ b/Codenames/Boardgamebox/Board.py
@@ -49,7 +49,7 @@ class Board(BaseBoard):
         board = "*[VISTA ESPÍA]*\n"
         for i, card in enumerate(self.state.tablero):
             prefix = "✅" if card["revealed"] else ""
-            cell = f"{prefix}{REVEAL_EMOJIS[card['tipo']]}*{card['numero']}*"
+            cell = f"{prefix}{REVEAL_EMOJIS[card['tipo']]}*{card['word']}*"
             board += cell + "  "
             if (i + 1) % 5 == 0:
                 board = board.rstrip() + "\n"
@@ -83,7 +83,7 @@ class Board(BaseBoard):
         for i, card in enumerate(st.tablero):
             numero = card["numero"]
             prefix = "✅" if card["revealed"] else ""
-            cell = f"{prefix}{DUO_EMOJIS[key[numero]]}*{numero}*"
+            cell = f"{prefix}{DUO_EMOJIS[key[numero]]}*{card['word']}*"
             board += cell + "  "
             if (i + 1) % 5 == 0:
                 board = board.rstrip() + "\n"


### PR DESCRIPTION
## Resumen

El tablero privado del espía y la clave del modo Dúo mostraban números (1–25) en vez de las palabras del tablero.

- `print_spymaster_board`: `card['numero']` → `card['word']`
- `print_key`: `numero` → `card['word']`

## Ejemplo

**Antes:**
```
⬜1  ⬜2  🟩3  ⬜4  ⬜5
```

**Después:**
```
⬜GATO  ⬜PERRO  🟩CIELO  ⬜MESA  ⬜LUNA
```

## Archivos modificados

- `Codenames/Boardgamebox/Board.py`

## Test plan

- [ ] El espía recibe el tablero privado con las palabras visibles y sus colores
- [ ] En modo Dúo, la clave de cada jugador muestra las palabras con los emojis correctos (🟩/⬜/💀)

---
_Generated by [Claude Code](https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa)_