### PR TITLE
feat: tablero de Codenames como imagen PNG

### DIFF
--- a/Codenames/Boardgamebox/Board.py
+++ b/Codenames/Boardgamebox/Board.py
@@ -1,5 +1,6 @@
 from Boardgamebox.Board import Board as BaseBoard
 from Codenames.Boardgamebox.State import State
+from Codenames.render import render_board
 
 
 REVEAL_EMOJIS = {
@@ -88,3 +89,18 @@ class Board(BaseBoard):
             if (i + 1) % 5 == 0:
                 board = board.rstrip() + "\n"
         return board
+
+    # --- Métodos de imagen ---
+
+    def render_board_image(self, game):
+        return render_board(self.state.tablero, mode="public")
+
+    def render_spymaster_image(self, game):
+        return render_board(self.state.tablero, mode="spymaster")
+
+    def render_key_image(self, game, jugador_label):
+        key = self.state.key_a if jugador_label == "A" else self.state.key_b
+        return render_board(self.state.tablero, mode="duo_key", key=key)
+
+    def render_duo_board_image(self, game):
+        return render_board(self.state.tablero, mode="duo_public")

--- a/Codenames/Commands.py
+++ b/Codenames/Commands.py
@@ -268,7 +268,15 @@ async def command_call(bot, game):
                 f"Intentos restantes: {st.intentos_restantes}.\nUsa `/pick NUMERO` o `/endturn`.",
                 parse_mode=ParseMode.MARKDOWN,
             )
-            await bot.send_message(game.cid, game.board.print_board_duo(game), parse_mode=ParseMode.MARKDOWN)
+            await bot.send_photo(
+                game.cid,
+                photo=game.board.render_duo_board_image(game),
+                caption=(
+                    f"{player_call(receptor)}: pista *{st.pista_actual}* — {st.numero_pista}. "
+                    f"Intentos restantes: {st.intentos_restantes}.\nUsa `/pick NUMERO` o `/endturn`."
+                ),
+                parse_mode=ParseMode.MARKDOWN,
+            )
         return
 
     if "Pista" in fase:
@@ -286,9 +294,12 @@ async def command_call(bot, game):
         pista = game.board.state.pista_actual
         numero = game.board.state.numero_pista
         intentos = game.board.state.intentos_restantes
-        await bot.send_message(
+        await bot.send_photo(
             game.cid,
-            f"Equipo *{team}*: pista *{pista}* — {numero}. Intentos restantes: {intentos}.\nUsa `/pick NUMERO` o `/endturn`.",
+            photo=game.board.render_board_image(game),
+            caption=(
+                f"Equipo *{team}*: pista *{pista}* — {numero}. "
+                f"Intentos restantes: {intentos}.\nUsa `/pick NUMERO` o `/endturn`."
+            ),
             parse_mode=ParseMode.MARKDOWN,
         )
-        await bot.send_message(game.cid, game.board.print_board(game), parse_mode=ParseMode.MARKDOWN)

--- a/Codenames/Controller.py
+++ b/Codenames/Controller.py
@@ -122,12 +122,12 @@ async def assign_teams(bot, game):
     )
     await bot.send_message(game.cid, msg, parse_mode=ParseMode.MARKDOWN)
 
-    tablero_espia = game.board.print_spymaster_board(game)
     for sm, team in [(spymaster_rojo, "Rojo"), (spymaster_azul, "Azul")]:
         emoji = "🔴" if team == "Rojo" else "🔵"
-        await bot.send_message(
+        await bot.send_photo(
             sm.uid,
-            f"{emoji} Eres el espía del equipo *{team}*\n\n{tablero_espia}",
+            photo=game.board.render_spymaster_image(game),
+            caption=f"{emoji} Eres el espía del equipo *{team}* — todos los colores visibles",
             parse_mode=ParseMode.MARKDOWN,
         )
 
@@ -145,11 +145,14 @@ async def start_turn(bot, game, team: str):
     spymaster = game.get_spymaster(team)
     emoji = "🔴" if team == "Rojo" else "🔵"
 
-    await bot.send_message(game.cid, game.board.print_board(game), parse_mode=ParseMode.MARKDOWN)
-    await bot.send_message(
-        game.cid,
+    caption_turno = (
         f"{emoji} Turno del equipo *{team}*.\n"
-        f"Espía {player_call(spymaster)}, da tu pista en privado con:\n`/hint PALABRA NUMERO`",
+        f"Espía {player_call(spymaster)}, da tu pista en privado con:\n`/hint PALABRA NUMERO`"
+    )
+    await bot.send_photo(
+        game.cid,
+        photo=game.board.render_board_image(game),
+        caption=caption_turno,
         parse_mode=ParseMode.MARKDOWN,
     )
     await bot.send_message(
@@ -204,8 +207,16 @@ async def setup_duo(bot, game):
         "sin tocar al asesino, ¡antes de quedarse sin pistas!",
         parse_mode=ParseMode.MARKDOWN,
     )
-    await bot.send_message(jugador_a.uid, "Tu clave secreta (Jugador A):\n\n" + game.board.print_key(game, "A"), parse_mode=ParseMode.MARKDOWN)
-    await bot.send_message(jugador_b.uid, "Tu clave secreta (Jugador B):\n\n" + game.board.print_key(game, "B"), parse_mode=ParseMode.MARKDOWN)
+    await bot.send_photo(
+        jugador_a.uid,
+        photo=game.board.render_key_image(game, "A"),
+        caption="🟩 Tu clave secreta (Jugador A) — verde=agente, negro=asesino, gris=neutral",
+    )
+    await bot.send_photo(
+        jugador_b.uid,
+        photo=game.board.render_key_image(game, "B"),
+        caption="🟩 Tu clave secreta (Jugador B) — verde=agente, negro=asesino, gris=neutral",
+    )
 
     await start_turn_duo(bot, game, "A")
 
@@ -222,11 +233,13 @@ async def start_turn_duo(bot, game, dador_label: str):
     dador = game.get_player_by_label(dador_label)
     receptor = game.get_player_by_label(game.get_other_player_label(dador_label))
 
-    await bot.send_message(game.cid, game.board.print_board_duo(game), parse_mode=ParseMode.MARKDOWN)
-    await bot.send_message(
+    await bot.send_photo(
         game.cid,
-        f"🗣️ Turno de pista del Jugador *{dador.name}* (rol {dador_label}).\n"
-        f"{player_call(dador)}, da tu pista en privado con `/hint PALABRA NUMERO`.",
+        photo=game.board.render_duo_board_image(game),
+        caption=(
+            f"🗣️ Turno de pista del Jugador *{dador.name}* (rol {dador_label}).\n"
+            f"{player_call(dador)}, da tu pista en privado con `/hint PALABRA NUMERO`."
+        ),
         parse_mode=ParseMode.MARKDOWN,
     )
     await bot.send_message(dador.uid, "Es tu turno de dar pista. Usa `/hint PALABRA NUMERO` aquí.", parse_mode=ParseMode.MARKDOWN)
@@ -259,14 +272,16 @@ async def process_hint_duo(bot, game, uid, word: str, number: int):
     st.intentos_restantes = number + 1
     st.fase_actual = f"Duo {dador_label} - Adivinar"
 
-    await bot.send_message(
+    await bot.send_photo(
         game.cid,
-        f"💬 Pista de *{dador.name}*: *{word.upper()}* — {number}\n"
-        f"{player_call(receptor)}, usa `/pick NUMERO` para adivinar (en el grupo). "
-        f"Hasta *{number + 1}* intentos o `/endturn` para pasar.",
+        photo=game.board.render_duo_board_image(game),
+        caption=(
+            f"💬 Pista de *{dador.name}*: *{word.upper()}* — {number}\n"
+            f"{player_call(receptor)}, usa `/pick NUMERO` para adivinar (en el grupo). "
+            f"Hasta *{number + 1}* intentos o `/endturn` para pasar."
+        ),
         parse_mode=ParseMode.MARKDOWN,
     )
-    await bot.send_message(game.cid, game.board.print_board_duo(game), parse_mode=ParseMode.MARKDOWN)
     await save(bot, game.cid)
 
 
@@ -303,10 +318,10 @@ async def process_pick_duo(bot, game, uid, numero: int):
             await bot.send_message(game.cid, "Se agotaron los intentos. Cambio de turno.", parse_mode=ParseMode.MARKDOWN)
             await end_turn_duo(bot, game)
         else:
-            await bot.send_message(
+            await bot.send_photo(
                 game.cid,
-                f"✅ *¡Correcto!* Agentes encontrados: {st.agentes_revelados}/{st.total_agentes_duo}. Intentos restantes: {st.intentos_restantes}\n"
-                + game.board.print_board_duo(game),
+                photo=game.board.render_duo_board_image(game),
+                caption=f"✅ *¡Correcto!* Agentes encontrados: {st.agentes_revelados}/{st.total_agentes_duo}. Intentos restantes: {st.intentos_restantes}",
                 parse_mode=ParseMode.MARKDOWN,
             )
             await save(bot, game.cid)
@@ -395,14 +410,17 @@ async def process_hint(bot, game, spymaster_uid, word: str, number: int):
         for p in game.get_team_players(team)
         if not game.is_spymaster(p.uid)
     )
-    await bot.send_message(
-        game.cid,
+    caption_pista = (
         f"💬 Pista del espía *{team}*: *{word.upper()}* — {number}\n"
         f"{field_mentions} usen `/pick NUMERO` para elegir una carta.\n"
-        f"Hasta *{number + 1}* intentos o `/endturn` para pasar.",
+        f"Hasta *{number + 1}* intentos o `/endturn` para pasar."
+    )
+    await bot.send_photo(
+        game.cid,
+        photo=game.board.render_board_image(game),
+        caption=caption_pista,
         parse_mode=ParseMode.MARKDOWN,
     )
-    await bot.send_message(game.cid, game.board.print_board(game), parse_mode=ParseMode.MARKDOWN)
     await save(bot, game.cid)
 
 
@@ -447,10 +465,10 @@ async def process_pick(bot, game, uid, numero: int):
             await bot.send_message(game.cid, "Se agotaron los intentos. Fin del turno.", parse_mode=ParseMode.MARKDOWN)
             await end_turn(bot, game)
         else:
-            await bot.send_message(
+            await bot.send_photo(
                 game.cid,
-                f"✅ *¡Correcto!* Intentos restantes: {game.board.state.intentos_restantes}\n"
-                + game.board.print_board(game),
+                photo=game.board.render_board_image(game),
+                caption=f"✅ *¡Correcto!* Intentos restantes: {game.board.state.intentos_restantes}",
                 parse_mode=ParseMode.MARKDOWN,
             )
             await save(bot, game.cid)

--- a/Codenames/render.py
+++ b/Codenames/render.py
@@ -1,0 +1,129 @@
+"""Genera imágenes PNG del tablero de Codenames."""
+from PIL import Image, ImageDraw, ImageFont
+from io import BytesIO
+import os
+
+CELL_W = 150
+CELL_H = 78
+PAD = 7
+COLS = 5
+ROWS = 5
+
+_FONT_PATH = "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf"
+
+# (background_hex, text_hex)
+_PALETTE = {
+    "unrevealed":    ("#E8E8E8", "#1A1A1A"),
+    "rojo":          ("#C0392B", "#FFFFFF"),
+    "azul":          ("#1A5276", "#FFFFFF"),
+    "neutral":       ("#797D7F", "#FFFFFF"),
+    "asesino":       ("#1C2833", "#FFFFFF"),
+    "agente":        ("#1E8449", "#FFFFFF"),
+    "revealed_rojo":    ("#F1948A", "#5D0000"),
+    "revealed_azul":    ("#7FB3D3", "#0A2942"),
+    "revealed_neutral": ("#CACFD2", "#3D3D3D"),
+    "revealed_asesino": ("#4D5656", "#CCCCCC"),
+    "revealed_agente":  ("#82E0AA", "#0A3D1F"),
+}
+_BG = "#2C3E50"
+
+
+def _hex_rgb(h):
+    h = h.lstrip("#")
+    return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def _load_font(size):
+    try:
+        return ImageFont.truetype(_FONT_PATH, size)
+    except Exception:
+        return ImageFont.load_default()
+
+
+def _fit_text(draw, text, font_size, max_w):
+    """Retorna (font, text_to_draw) reduciendo fuente o truncando si no entra."""
+    for size in range(font_size, 7, -1):
+        font = _load_font(size)
+        try:
+            bbox = draw.textbbox((0, 0), text, font=font)
+            w = bbox[2] - bbox[0]
+        except AttributeError:
+            w, _ = draw.textsize(text, font=font)
+        if w <= max_w:
+            return font, text
+    return _load_font(8), text[:12] + "…"
+
+
+def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, revealed=False):
+    bg = _hex_rgb(bg_hex)
+    fg = _hex_rgb(fg_hex)
+    draw.rectangle([x, y, x + CELL_W - 1, y + CELL_H - 1], fill=bg, outline=_hex_rgb("#FFFFFF"), width=1)
+
+    # Número pequeño arriba-izquierda
+    num_font = _load_font(11)
+    draw.text((x + 5, y + 4), str(numero), font=num_font, fill=fg)
+
+    # Palabra centrada
+    font, label = _fit_text(draw, word.upper(), 17, CELL_W - 16)
+    try:
+        bbox = draw.textbbox((0, 0), label, font=font)
+        tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    except AttributeError:
+        tw, th = draw.textsize(label, font=font)
+    draw.text((x + (CELL_W - tw) // 2, y + (CELL_H - th) // 2 + 4), label, font=font, fill=fg)
+
+    # Tachado si ya fue revelada
+    if revealed:
+        mid_y = y + CELL_H // 2
+        draw.line([(x + 6, mid_y), (x + CELL_W - 6, mid_y)], fill=fg, width=2)
+
+
+def render_board(tablero, mode="public", key=None):
+    """
+    mode: "public" | "spymaster" | "duo_key"
+    key: dict {numero: tipo_str} — requerido para duo_key
+    Retorna BytesIO con imagen PNG.
+    """
+    canvas_w = COLS * CELL_W + (COLS + 1) * PAD
+    canvas_h = ROWS * CELL_H + (ROWS + 1) * PAD
+
+    img = Image.new("RGB", (canvas_w, canvas_h), _hex_rgb(_BG))
+    draw = ImageDraw.Draw(img)
+
+    for i, card in enumerate(tablero):
+        col = i % COLS
+        row = i // COLS
+        x = PAD + col * (CELL_W + PAD)
+        y = PAD + row * (CELL_H + PAD)
+
+        word = card["word"]
+        numero = card["numero"]
+        revealed = card["revealed"]
+        tipo = card.get("tipo") or "neutral"
+
+        if mode in ("public", "duo_public"):
+            if revealed:
+                key_tipo = tipo if tipo else "neutral"
+                bg, fg = _PALETTE.get(f"revealed_{key_tipo}", _PALETTE["revealed_neutral"])
+            else:
+                bg, fg = _PALETTE["unrevealed"]
+        elif mode == "spymaster":
+            if revealed:
+                bg, fg = _PALETTE.get(f"revealed_{tipo}", _PALETTE["revealed_neutral"])
+            else:
+                bg, fg = _PALETTE.get(tipo, _PALETTE["unrevealed"])
+        elif mode == "duo_key" and key:
+            tipo_key = key.get(numero, "neutral")
+            if revealed:
+                bg, fg = _PALETTE.get(f"revealed_{tipo_key}", _PALETTE["revealed_neutral"])
+            else:
+                bg, fg = _PALETTE.get(tipo_key, _PALETTE["unrevealed"])
+        else:
+            bg, fg = _PALETTE["unrevealed"]
+
+        _draw_cell(draw, x, y, word, numero, bg, fg, revealed=revealed)
+
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return buf

--- a/Codenames/test_codenames.py
+++ b/Codenames/test_codenames.py
@@ -80,6 +80,9 @@ class FakeBot:
     async def delete_message(self, chat_id, message_id):
         pass
 
+    async def send_photo(self, chat_id, photo=None, caption=None, parse_mode=None, **kwargs):
+        self.messages.append((chat_id, caption or ""))
+
 
 async def _noop_save(bot, cid, newGroupName=''):
     pass


### PR DESCRIPTION
## Resumen

- Nuevo módulo `Codenames/render.py` que genera imágenes PNG del tablero con Pillow
- El bot ahora envía `send_photo` en lugar de texto para mostrar el tablero

## Modos de imagen

| Modo | Descripción |
|------|-------------|
| `public` | Tablero de todos — palabras visibles, cartas reveladas con color del equipo |
| `spymaster` | Todos los colores visibles desde el inicio; reveladas en versión desteñida |
| `duo_key` | Clave privada Dúo — verde=agente, negro=asesino, gris=neutral |
| `duo_public` | Tablero público Dúo — palabras visibles, reveladas tachadas |

## Archivos modificados

- `Codenames/render.py` — nuevo módulo de renderizado
- `Codenames/Boardgamebox/Board.py` — métodos `render_*_image()`
- `Codenames/Controller.py` — reemplaza `send_message` de tablero por `send_photo`
- `Codenames/Commands.py` — idem en `command_call`
- `Codenames/test_codenames.py` — agrega `send_photo` a FakeBot

## Test plan

- [ ] Al iniciar partida competitiva, el espía recibe imagen con todos los colores
- [ ] Al dar `/hint`, el grupo ve imagen del tablero con la pista en caption
- [ ] Al hacer `/pick`, el grupo ve imagen actualizada con la carta revelada
- [ ] En modo Dúo, cada jugador recibe su clave como imagen en privado
- [ ] `/call` envía imagen del estado actual

---
_Generated by [Claude Code](https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa)_