### PR TITLE
fix: corregir setup del modo Dúo con las reglas oficiales de Codenames

### DIFF
--- a/Codenames/Controller.py
+++ b/Codenames/Controller.py
@@ -170,26 +170,45 @@ async def setup_duo(bot, game):
     game.board.state.jugador_a = jugador_a
     game.board.state.jugador_b = jugador_b
 
-    posiciones = list(range(1, 26))
-    random.shuffle(posiciones)
-    agentes = posiciones[:15]
-    resto = posiciones[15:]
-    grupo_a = set(agentes[:8])
-    grupo_b = set(agentes[8:])
-    asesino = resto[0]
+    # Layout oficial Codenames Dúo (25 cartas):
+    # 3 agentes compartidos (verde A + verde B)
+    # 6 agentes solo A (verde A + gris B)
+    # 6 agentes solo B (gris A + verde B)
+    # 1 asesino compartido (negro A + negro B)
+    # 1 asesino de A (negro A + gris B)
+    # 1 asesino de B — trampa (VERDE A + negro B)   ← A lo ve como agente!
+    # 7 neutrales (gris A + gris B)
+    nums = list(range(1, 26))
+    random.shuffle(nums)
+
+    shared_agents  = set(nums[0:3])
+    a_agents       = set(nums[3:9])
+    b_agents       = set(nums[9:15])
+    shared_assassin = nums[15]
+    a_assassin      = nums[16]
+    b_assassin      = nums[17]   # A lo ve como agente, pero es el asesino de B
 
     key_a = {}
     key_b = {}
     for n in range(1, 26):
-        if n == asesino:
-            key_a[n] = "asesino"
-            key_b[n] = "asesino"
-        elif n in grupo_a:
+        if n in shared_agents:
+            key_a[n] = "agente"
+            key_b[n] = "agente"
+        elif n in a_agents:
             key_a[n] = "agente"
             key_b[n] = "neutral"
-        elif n in grupo_b:
+        elif n in b_agents:
             key_a[n] = "neutral"
             key_b[n] = "agente"
+        elif n == shared_assassin:
+            key_a[n] = "asesino"
+            key_b[n] = "asesino"
+        elif n == a_assassin:
+            key_a[n] = "asesino"
+            key_b[n] = "neutral"
+        elif n == b_assassin:
+            key_a[n] = "agente"   # trampa: A lo ve verde, pero es el asesino de B
+            key_b[n] = "asesino"
         else:
             key_a[n] = "neutral"
             key_b[n] = "neutral"
@@ -210,12 +229,12 @@ async def setup_duo(bot, game):
     await bot.send_photo(
         jugador_a.uid,
         photo=game.board.render_key_image(game, "A"),
-        caption="🟩 Tu clave secreta (Jugador A) — verde=agente, negro=asesino, gris=neutral",
+        caption="🟩 Tu clave (Jugador A) — verde=agente, negro=asesino, gris=neutral\n⚠️ Cuidado: una carta verde tuya puede ser el asesino de tu compañero.",
     )
     await bot.send_photo(
         jugador_b.uid,
         photo=game.board.render_key_image(game, "B"),
-        caption="🟩 Tu clave secreta (Jugador B) — verde=agente, negro=asesino, gris=neutral",
+        caption="🟩 Tu clave (Jugador B) — verde=agente, negro=asesino, gris=neutral\n⚠️ Cuidado: una carta verde tuya puede ser el asesino de tu compañero.",
     )
 
     await start_turn_duo(bot, game, "A")
@@ -293,22 +312,33 @@ async def process_pick_duo(bot, game, uid, numero: int):
     card["revealed"] = True
     word = card["word"]
 
-    key_dador = st.key_a if st.dador_actual == "A" else st.key_b
-    tipo_real = key_dador[numero]
+    tipo_a = st.key_a[numero]
+    tipo_b = st.key_b[numero]
 
-    emoji_map = {"agente": "🟩", "neutral": "⬜", "asesino": "💀"}
-    await bot.send_message(
-        game.cid,
-        f"Carta {numero} revelada: *{word.upper()}* {emoji_map[tipo_real]}",
-        parse_mode=ParseMode.MARKDOWN,
-    )
-
-    if tipo_real == "asesino":
-        await bot.send_message(game.cid, "💀 *¡ASESINO!* El equipo ha perdido.", parse_mode=ParseMode.MARKDOWN)
+    # Si es asesino en CUALQUIERA de las dos claves → derrota inmediata
+    # Esto incluye la trampa: asesino de B que A ve como agente (verde)
+    if tipo_a == "asesino" or tipo_b == "asesino":
+        quien = "compartido" if tipo_a == "asesino" and tipo_b == "asesino" else (
+            "de A (B lo veía gris)" if tipo_a == "asesino" else "de B (A lo veía verde ⚠️)"
+        )
+        await bot.send_message(
+            game.cid,
+            f"💀 *¡ASESINO!* *{word.upper()}* era el asesino {quien}. El equipo ha perdido.",
+            parse_mode=ParseMode.MARKDOWN,
+        )
         await end_game_duo(bot, game, victoria=False, razon="asesino")
         return
 
-    if tipo_real == "agente":
+    # Resultado según la clave de quien da la pista
+    tipo_hinter = tipo_a if st.dador_actual == "A" else tipo_b
+    emoji_map = {"agente": "🟩", "neutral": "⬜"}
+    await bot.send_message(
+        game.cid,
+        f"Carta {numero} revelada: *{word.upper()}* {emoji_map.get(tipo_hinter, '⬜')}",
+        parse_mode=ParseMode.MARKDOWN,
+    )
+
+    if tipo_hinter == "agente":
         st.agentes_revelados += 1
         if st.agentes_revelados >= st.total_agentes_duo:
             await end_game_duo(bot, game, victoria=True, razon="agentes")

--- a/Codenames/test_codenames.py
+++ b/Codenames/test_codenames.py
@@ -156,12 +156,29 @@ async def play_cooperativo():
 
     agentes_a = {n for n, t in st.key_a.items() if t == "agente"}
     agentes_b = {n for n, t in st.key_b.items() if t == "agente"}
-    assert_true(len(agentes_a & agentes_b) == 0, "Las cartas de agente de A y B no deben solaparse")
-    assert_true(len(agentes_a) + len(agentes_b) == 15, "Debe haber 15 agentes en total")
+    asesinos_a = {n for n, t in st.key_a.items() if t == "asesino"}
+    asesinos_b = {n for n, t in st.key_b.items() if t == "asesino"}
 
-    asesinos = {n for n, t in st.key_a.items() if t == "asesino"}
-    assert_true(asesinos == {n for n, t in st.key_b.items() if t == "asesino"}, "El asesino debe ser el mismo para ambos")
-    assert_true(len(asesinos) == 1, "Debe haber exactamente un asesino")
+    # Reglas Dúo oficiales:
+    # 3 agentes compartidos (verde A + verde B)
+    shared_agents = agentes_a & agentes_b
+    assert_true(len(shared_agents) == 3, f"Debe haber 3 agentes compartidos, hay {len(shared_agents)}")
+
+    # 15 agentes reales = cartas que son agente en alguna clave y asesino en ninguna
+    agentes_reales = {n for n in range(1, 26)
+                      if (st.key_a[n] == "agente" or st.key_b[n] == "agente")
+                      and st.key_a[n] != "asesino" and st.key_b[n] != "asesino"}
+    assert_true(len(agentes_reales) == 15, f"Debe haber 15 agentes reales, hay {len(agentes_reales)}")
+
+    # 3 asesinos: 1 compartido, 1 solo A, 1 trampa (verde A + negro B)
+    assert_true(len(asesinos_a) == 2, f"key_a debe tener 2 asesinos, tiene {len(asesinos_a)}")
+    assert_true(len(asesinos_b) == 2, f"key_b debe tener 2 asesinos, tiene {len(asesinos_b)}")
+    shared_assassins = asesinos_a & asesinos_b
+    assert_true(len(shared_assassins) == 1, f"Debe haber 1 asesino compartido, hay {len(shared_assassins)}")
+    # Trampa: asesino de B que A ve como agente
+    trampa = asesinos_b - asesinos_a
+    assert_true(len(trampa) == 1 and st.key_a[next(iter(trampa))] == "agente",
+                "Debe haber 1 trampa: asesino de B visto como agente por A")
 
     assert_true(st.fase_actual == "Duo A - Pista", f"Debe iniciar con pista del jugador A, fue {st.fase_actual}")
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,4 +2,9 @@
 set -e
 
 git pull
-docker compose up -d --build
+
+if docker compose version &>/dev/null; then
+    docker compose up -d --build
+else
+    docker-compose up -d --build
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+git pull
+docker compose up -d --build


### PR DESCRIPTION
## Resumen

Corrección del setup del modo Cooperativo (Dúo) para seguir las reglas oficiales de Codenames Dúo.

## Distribución correcta de las 25 cartas

| Tipo | key_a | key_b | Cantidad |
|------|-------|-------|----------|
| Agentes compartidos | agente | agente | 3 |
| Solo A | agente | neutral | 6 |
| Solo B | neutral | agente | 6 |
| Asesino compartido | asesino | asesino | 1 |
| Asesino de A | asesino | neutral | 1 |
| Trampa (asesino de B) | **agente** ⚠️ | asesino | 1 |
| Neutral | neutral | neutral | 7 |

**Total agentes reales: 15** ✓

## La trampa

El asesino de B se ve como carta verde (agente) en la clave de A. Si A da una pista que apunta a esa carta y el receptor la elige, el equipo pierde — aunque A la veía como un agente válido.

## Cambios

- `Controller.py` — `setup_duo`: nueva distribución con 3 asesinos asimétricos y 3 agentes compartidos
- `Controller.py` — `process_pick_duo`: chequea asesino en **ambas** claves; el mensaje de derrota indica qué tipo de asesino fue tocado
- `test_codenames.py`: assertions actualizadas para verificar las nuevas reglas

## Test plan

- [ ] Cada jugador recibe clave con la advertencia de la trampa
- [ ] Hay exactamente 3 agentes verdes en ambas claves (compartidos)
- [ ] Tocar el asesino compartido pierde
- [ ] Tocar el asesino de A (que B ve gris) pierde
- [ ] Tocar la trampa (verde para A, negro para B) pierde con mensaje `"de B (A lo veía verde ⚠️)"`
- [ ] Los 15 agentes reales se pueden encontrar sin perder

---
_Generated by [Claude Code](https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa)_