### PR TITLE
feat: mejorar imagen de tablero Dúo con colores y marcas visuales

### DIFF
--- a/Codenames/Boardgamebox/Board.py
+++ b/Codenames/Boardgamebox/Board.py
@@ -100,7 +100,8 @@ class Board(BaseBoard):
 
     def render_key_image(self, game, jugador_label):
         key = self.state.key_a if jugador_label == "A" else self.state.key_b
-        return render_board(self.state.tablero, mode="duo_key", key=key)
+        partner_key = self.state.key_b if jugador_label == "A" else self.state.key_a
+        return render_board(self.state.tablero, mode="duo_key", key=key, partner_key=partner_key)
 
     def render_duo_board_image(self, game):
         return render_board(self.state.tablero, mode="duo_public")

--- a/Codenames/Controller.py
+++ b/Codenames/Controller.py
@@ -314,10 +314,12 @@ async def process_pick_duo(bot, game, uid, numero: int):
 
     tipo_a = st.key_a[numero]
     tipo_b = st.key_b[numero]
+    tipo_hinter_pre = tipo_a if st.dador_actual == "A" else tipo_b
 
     # Si es asesino en CUALQUIERA de las dos claves → derrota inmediata
     # Esto incluye la trampa: asesino de B que A ve como agente (verde)
     if tipo_a == "asesino" or tipo_b == "asesino":
+        card["tipo"] = "asesino"
         quien = "compartido" if tipo_a == "asesino" and tipo_b == "asesino" else (
             "de A (B lo veía gris)" if tipo_a == "asesino" else "de B (A lo veía verde ⚠️)"
         )
@@ -330,7 +332,7 @@ async def process_pick_duo(bot, game, uid, numero: int):
         return
 
     # Resultado según la clave de quien da la pista
-    tipo_hinter = tipo_a if st.dador_actual == "A" else tipo_b
+    tipo_hinter = tipo_hinter_pre
     emoji_map = {"agente": "🟩", "neutral": "⬜"}
     await bot.send_message(
         game.cid,
@@ -339,6 +341,7 @@ async def process_pick_duo(bot, game, uid, numero: int):
     )
 
     if tipo_hinter == "agente":
+        card["tipo"] = "agente"
         st.agentes_revelados += 1
         if st.agentes_revelados >= st.total_agentes_duo:
             await end_game_duo(bot, game, victoria=True, razon="agentes")
@@ -356,6 +359,7 @@ async def process_pick_duo(bot, game, uid, numero: int):
             )
             await save(bot, game.cid)
     else:
+        card["tipo"] = "neutral"
         st.pistas_restantes -= 1
         await bot.send_message(
             game.cid,

--- a/Codenames/render.py
+++ b/Codenames/render.py
@@ -13,22 +13,29 @@ _FONT_PATH = "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf"
 
 # (background_hex, text_hex)
 _PALETTE = {
+    # Competitivo — sin revelar
     "unrevealed":    ("#E8E8E8", "#1A1A1A"),
     "rojo":          ("#C0392B", "#FFFFFF"),
     "azul":          ("#1A5276", "#FFFFFF"),
     "neutral":       ("#797D7F", "#FFFFFF"),
     "asesino":       ("#1C2833", "#FFFFFF"),
-    "agente":        ("#1E8449", "#FFFFFF"),
-    "revealed_rojo":    ("#F1948A", "#5D0000"),
-    "revealed_azul":    ("#7FB3D3", "#0A2942"),
-    "revealed_neutral": ("#CACFD2", "#3D3D3D"),
-    "revealed_asesino": ("#4D5656", "#CCCCCC"),
-    "revealed_agente":  ("#82E0AA", "#0A3D1F"),
+    # Dúo — sin revelar
+    "agente":        ("#1E8449", "#FFFFFF"),       # mi agente (verde)
+    "partner_agente": ("#1A6B8A", "#FFFFFF"),      # mi gris, pero agente del compañero (teal)
+    # Reveladas — cualquier modo
+    "revealed_rojo":     ("#F1948A", "#5D0000"),
+    "revealed_azul":     ("#7FB3D3", "#0A2942"),
+    "revealed_neutral":  ("#CACFD2", "#3D3D3D"),
+    "revealed_asesino":  ("#4D5656", "#CCCCCC"),
+    "revealed_agente":   ("#27AE60", "#FFFFFF"),   # agente encontrado → verde sólido
+    "revealed_miss":     ("#95A5A6", "#FFFFFF"),   # neutral pisado → gris oscuro
 }
 _BG = "#2C3E50"
 
 
 def _hex_rgb(h):
+    if isinstance(h, tuple):
+        return h
     h = h.lstrip("#")
     return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
 
@@ -41,7 +48,6 @@ def _load_font(size):
 
 
 def _fit_text(draw, text, font_size, max_w):
-    """Retorna (font, text_to_draw) reduciendo fuente o truncando si no entra."""
     for size in range(font_size, 7, -1):
         font = _load_font(size)
         try:
@@ -54,7 +60,10 @@ def _fit_text(draw, text, font_size, max_w):
     return _load_font(8), text[:12] + "…"
 
 
-def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, revealed=False):
+def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, mark=None):
+    """
+    mark: None | "check" (agente encontrado) | "miss" (neutral pisado) | "partner" (agente compañero)
+    """
     bg = _hex_rgb(bg_hex)
     fg = _hex_rgb(fg_hex)
     draw.rectangle([x, y, x + CELL_W - 1, y + CELL_H - 1], fill=bg, outline=_hex_rgb("#FFFFFF"), width=1)
@@ -62,6 +71,16 @@ def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, revealed=False):
     # Número pequeño arriba-izquierda
     num_font = _load_font(11)
     draw.text((x + 5, y + 4), str(numero), font=num_font, fill=fg)
+
+    # Marca arriba-derecha
+    if mark == "check":
+        draw.text((x + CELL_W - 18, y + 3), "✓", font=num_font, fill=fg)
+    elif mark == "miss":
+        draw.text((x + CELL_W - 14, y + 3), "✕", font=num_font, fill=fg)
+    elif mark == "partner":
+        # Pequeño triángulo de borde en la esquina superior derecha para indicar "del compañero"
+        pts = [(x + CELL_W - 14, y + 1), (x + CELL_W - 1, y + 1), (x + CELL_W - 1, y + 14)]
+        draw.polygon(pts, fill=_hex_rgb("#82E0AA"))
 
     # Palabra centrada
     font, label = _fit_text(draw, word.upper(), 17, CELL_W - 16)
@@ -72,17 +91,12 @@ def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, revealed=False):
         tw, th = draw.textsize(label, font=font)
     draw.text((x + (CELL_W - tw) // 2, y + (CELL_H - th) // 2 + 4), label, font=font, fill=fg)
 
-    # Tachado si ya fue revelada
-    if revealed:
-        mid_y = y + CELL_H // 2
-        draw.line([(x + 6, mid_y), (x + CELL_W - 6, mid_y)], fill=fg, width=2)
 
-
-def render_board(tablero, mode="public", key=None):
+def render_board(tablero, mode="public", key=None, partner_key=None):
     """
-    mode: "public" | "spymaster" | "duo_key"
-    key: dict {numero: tipo_str} — requerido para duo_key
-    Retorna BytesIO con imagen PNG.
+    mode        : "public" | "spymaster" | "duo_key" | "duo_public"
+    key         : {numero: tipo_str} — clave del jugador (duo_key)
+    partner_key : {numero: tipo_str} — clave del compañero (duo_key), para marcar sus agentes
     """
     canvas_w = COLS * CELL_W + (COLS + 1) * PAD
     canvas_h = ROWS * CELL_H + (ROWS + 1) * PAD
@@ -96,32 +110,62 @@ def render_board(tablero, mode="public", key=None):
         x = PAD + col * (CELL_W + PAD)
         y = PAD + row * (CELL_H + PAD)
 
-        word = card["word"]
-        numero = card["numero"]
+        word    = card["word"]
+        numero  = card["numero"]
         revealed = card["revealed"]
-        tipo = card.get("tipo") or "neutral"
+        tipo    = card.get("tipo") or "neutral"
+        mark    = None
 
         if mode in ("public", "duo_public"):
             if revealed:
-                key_tipo = tipo if tipo else "neutral"
-                bg, fg = _PALETTE.get(f"revealed_{key_tipo}", _PALETTE["revealed_neutral"])
+                if tipo == "agente":
+                    bg, fg = _PALETTE["revealed_agente"]
+                    mark = "check"
+                elif tipo == "asesino":
+                    bg, fg = _PALETTE["revealed_asesino"]
+                else:
+                    bg, fg = _PALETTE["revealed_miss"]
+                    mark = "miss"
             else:
                 bg, fg = _PALETTE["unrevealed"]
+
         elif mode == "spymaster":
             if revealed:
                 bg, fg = _PALETTE.get(f"revealed_{tipo}", _PALETTE["revealed_neutral"])
+                mark = "check" if tipo == "agente" else ("miss" if tipo == "neutral" else None)
             else:
                 bg, fg = _PALETTE.get(tipo, _PALETTE["unrevealed"])
+
         elif mode == "duo_key" and key:
-            tipo_key = key.get(numero, "neutral")
+            tipo_mine = key.get(numero, "neutral")
+            tipo_partner = partner_key.get(numero, "neutral") if partner_key else "neutral"
+
             if revealed:
-                bg, fg = _PALETTE.get(f"revealed_{tipo_key}", _PALETTE["revealed_neutral"])
+                # Verde si fue encontrado como agente, gris si fue un miss
+                if tipo == "agente":
+                    bg, fg = _PALETTE["revealed_agente"]
+                    mark = "check"
+                elif tipo == "asesino":
+                    bg, fg = _PALETTE["revealed_asesino"]
+                else:
+                    bg, fg = _PALETTE["revealed_miss"]
+                    mark = "miss"
             else:
-                bg, fg = _PALETTE.get(tipo_key, _PALETTE["unrevealed"])
+                if tipo_mine == "agente":
+                    bg, fg = _PALETTE["agente"]
+                elif tipo_mine == "asesino":
+                    bg, fg = _PALETTE["asesino"]
+                else:
+                    # neutral para mí — ¿es agente del compañero?
+                    if tipo_partner == "agente":
+                        bg, fg = _PALETTE["partner_agente"]
+                        mark = "partner"
+                    else:
+                        bg, fg = _PALETTE["neutral"]
         else:
             bg, fg = _PALETTE["unrevealed"]
 
-        _draw_cell(draw, x, y, word, numero, bg, fg, revealed=revealed)
+        _draw_cell(draw, x, y, word, numero, bg, fg, mark=mark)
 
     buf = BytesIO()
     img.save(buf, format="PNG")


### PR DESCRIPTION
- Verde brillante + ✓ para agentes encontrados correctamente
- Gris oscuro + ✕ para neutrales pisados
- Teal + triángulo para cartas grises del jugador que son agentes del compañero
- `card["tipo"]` se establece al revelar en modo Dúo para colores correctos en tablero público
- `render_key_image` pasa `partner_key` al renderer

---
_Generated by [Claude Code](https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa)_