### PR TITLE
fix: 3 asesinos compartidos en modo Dúo

### DIFF
--- a/Codenames/Controller.py
+++ b/Codenames/Controller.py
@@ -170,23 +170,19 @@ async def setup_duo(bot, game):
     game.board.state.jugador_a = jugador_a
     game.board.state.jugador_b = jugador_b
 
-    # Layout oficial Codenames Dúo (25 cartas):
-    # 3 agentes compartidos (verde A + verde B)
-    # 6 agentes solo A (verde A + gris B)
-    # 6 agentes solo B (gris A + verde B)
-    # 1 asesino compartido (negro A + negro B)
-    # 1 asesino de A (negro A + gris B)
-    # 1 asesino de B — trampa (VERDE A + negro B)   ← A lo ve como agente!
-    # 7 neutrales (gris A + gris B)
+    # Layout Codenames Dúo (25 cartas):
+    # 3 agentes compartidos  (verde A + verde B)
+    # 6 agentes solo A       (verde A + gris B)
+    # 6 agentes solo B       (gris A + verde B)
+    # 3 asesinos compartidos (negro A + negro B)  ← ambos ven 3 negros
+    # 7 neutrales            (gris A + gris B)
     nums = list(range(1, 26))
     random.shuffle(nums)
 
-    shared_agents  = set(nums[0:3])
-    a_agents       = set(nums[3:9])
-    b_agents       = set(nums[9:15])
-    shared_assassin = nums[15]
-    a_assassin      = nums[16]
-    b_assassin      = nums[17]   # A lo ve como agente, pero es el asesino de B
+    shared_agents    = set(nums[0:3])
+    a_agents         = set(nums[3:9])
+    b_agents         = set(nums[9:15])
+    assassins        = set(nums[15:18])   # 3 asesinos compartidos
 
     key_a = {}
     key_b = {}
@@ -200,14 +196,8 @@ async def setup_duo(bot, game):
         elif n in b_agents:
             key_a[n] = "neutral"
             key_b[n] = "agente"
-        elif n == shared_assassin:
+        elif n in assassins:
             key_a[n] = "asesino"
-            key_b[n] = "asesino"
-        elif n == a_assassin:
-            key_a[n] = "asesino"
-            key_b[n] = "neutral"
-        elif n == b_assassin:
-            key_a[n] = "agente"   # trampa: A lo ve verde, pero es el asesino de B
             key_b[n] = "asesino"
         else:
             key_a[n] = "neutral"
@@ -223,18 +213,18 @@ async def setup_duo(bot, game):
         game.cid,
         f"🤝 *Modo Dúo activado!*\nJugador A: *{jugador_a.name}*\nJugador B: *{jugador_b.name}*\n\n"
         "Cada uno recibirá su clave secreta en privado. Trabajen juntos para encontrar los 15 agentes "
-        "sin tocar al asesino, ¡antes de quedarse sin pistas!",
+        "sin tocar ninguno de los 3 asesinos, ¡antes de quedarse sin pistas!",
         parse_mode=ParseMode.MARKDOWN,
     )
     await bot.send_photo(
         jugador_a.uid,
         photo=game.board.render_key_image(game, "A"),
-        caption="🟩 Tu clave (Jugador A) — verde=agente, negro=asesino, gris=neutral\n⚠️ Cuidado: una carta verde tuya puede ser el asesino de tu compañero.",
+        caption="🟩 Tu clave (Jugador A) — verde=agente, negro=asesino, gris=neutral",
     )
     await bot.send_photo(
         jugador_b.uid,
         photo=game.board.render_key_image(game, "B"),
-        caption="🟩 Tu clave (Jugador B) — verde=agente, negro=asesino, gris=neutral\n⚠️ Cuidado: una carta verde tuya puede ser el asesino de tu compañero.",
+        caption="🟩 Tu clave (Jugador B) — verde=agente, negro=asesino, gris=neutral",
     )
 
     await start_turn_duo(bot, game, "A")

--- a/Codenames/test_codenames.py
+++ b/Codenames/test_codenames.py
@@ -159,26 +159,19 @@ async def play_cooperativo():
     asesinos_a = {n for n, t in st.key_a.items() if t == "asesino"}
     asesinos_b = {n for n, t in st.key_b.items() if t == "asesino"}
 
-    # Reglas Dúo oficiales:
-    # 3 agentes compartidos (verde A + verde B)
+    # 3 agentes compartidos
     shared_agents = agentes_a & agentes_b
     assert_true(len(shared_agents) == 3, f"Debe haber 3 agentes compartidos, hay {len(shared_agents)}")
 
-    # 15 agentes reales = cartas que son agente en alguna clave y asesino en ninguna
+    # 15 agentes totales
     agentes_reales = {n for n in range(1, 26)
                       if (st.key_a[n] == "agente" or st.key_b[n] == "agente")
                       and st.key_a[n] != "asesino" and st.key_b[n] != "asesino"}
     assert_true(len(agentes_reales) == 15, f"Debe haber 15 agentes reales, hay {len(agentes_reales)}")
 
-    # 3 asesinos: 1 compartido, 1 solo A, 1 trampa (verde A + negro B)
-    assert_true(len(asesinos_a) == 2, f"key_a debe tener 2 asesinos, tiene {len(asesinos_a)}")
-    assert_true(len(asesinos_b) == 2, f"key_b debe tener 2 asesinos, tiene {len(asesinos_b)}")
-    shared_assassins = asesinos_a & asesinos_b
-    assert_true(len(shared_assassins) == 1, f"Debe haber 1 asesino compartido, hay {len(shared_assassins)}")
-    # Trampa: asesino de B que A ve como agente
-    trampa = asesinos_b - asesinos_a
-    assert_true(len(trampa) == 1 and st.key_a[next(iter(trampa))] == "agente",
-                "Debe haber 1 trampa: asesino de B visto como agente por A")
+    # 3 asesinos compartidos — ambos jugadores ven exactamente 3 negros
+    assert_true(asesinos_a == asesinos_b, "Los 3 asesinos deben ser compartidos (iguales para A y B)")
+    assert_true(len(asesinos_a) == 3, f"Debe haber 3 asesinos, hay {len(asesinos_a)}")
 
     assert_true(st.fase_actual == "Duo A - Pista", f"Debe iniciar con pista del jugador A, fue {st.fase_actual}")
 


### PR DESCRIPTION
- Los 3 asesinos son ahora compartidos (negro para A y negro para B)
- Cada jugador ve exactamente 3 celdas negras en su clave privada
- La asimetría del juego queda solo en los agentes (3 compartidos, 6 solo A, 6 solo B)
- Eliminado el concepto de "asesino trampa" (verde para un jugador)

---
_Generated by [Claude Code](https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa)_