### PR TITLE
feat: /history, /call con tablero para espía, fix /board imagen

### DIFF
--- a/MainController.py
+++ b/MainController.py
@@ -768,6 +768,7 @@ def main(stop_event):
 	# Handlers de SecretoCodigo
 	app.add_handler(CommandHandler("hint", SecretoCodigoCommands.command_hint))
 	app.add_handler(CommandHandler("endturn", SecretoCodigoCommands.command_endturn))
+	app.add_handler(CommandHandler("history", SecretoCodigoCommands.command_history))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*choosediccCN\*(.*)\*([0-9]*)", callback=SecretoCodigoController.callback_finish_config_cn))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*choosegamehintCN\*(.*)\*([0-9]*)", callback=SecretoCodigoCommands.callback_choose_game_hint_cn))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*chooseendCN\*(.*)\*([0-9]*)", callback=SecretoCodigoController.callback_finish_game_buttons_cn))

--- a/SecretoCodigo/Boardgamebox/State.py
+++ b/SecretoCodigo/Boardgamebox/State.py
@@ -32,3 +32,8 @@ class State(BaseState):
         self.total_agentes_duo = 15
         self.pistas_restantes = 9
 
+        # Historial: list[dict]
+        # {"turno": str, "dador": str, "pista": str, "numero": int,
+        #  "picks": [{"word": str, "resultado": str}]}
+        self.historial = []
+

--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -259,11 +259,14 @@ async def command_call(bot, game):
                 f"{player_call(dador)} es tu turno de dar la pista.\nUsa `/hint PALABRA NUMERO` en privado.",
                 parse_mode=ParseMode.MARKDOWN,
             )
-            await bot.send_message(
+            await bot.send_photo(
                 dador.uid,
-                "Es tu turno de dar pista. Usa `/hint PALABRA NUMERO` aquí.\n"
-                "• `0` → adivina sin límite\n"
-                "• `-1` → pista infinita (también sin límite)",
+                photo=game.board.render_key_image(game, st.dador_actual),
+                caption=(
+                    "Es tu turno de dar pista. Usa `/hint PALABRA NUMERO` aquí.\n"
+                    "• `0` → adivina sin límite\n"
+                    "• `-1` → pista infinita (también sin límite)"
+                ),
                 parse_mode=ParseMode.MARKDOWN,
             )
         elif "Adivinar" in fase:
@@ -288,11 +291,14 @@ async def command_call(bot, game):
             f"{player_call(sm)} es tu turno de dar la pista del equipo *{team}*.\nUsa `/hint PALABRA NUMERO` en privado.",
             parse_mode=ParseMode.MARKDOWN,
         )
-        await bot.send_message(
+        await bot.send_photo(
             sm.uid,
-            "Es tu turno. Usa `/hint PALABRA NUMERO` aquí.\n"
-            "• `0` → adivina sin límite\n"
-            "• `-1` → pista infinita (también sin límite)",
+            photo=game.board.render_spymaster_image(game),
+            caption=(
+                f"Es tu turno ({team}). Usa `/hint PALABRA NUMERO` aquí.\n"
+                "• `0` → adivina sin límite\n"
+                "• `-1` → pista infinita (también sin límite)"
+            ),
             parse_mode=ParseMode.MARKDOWN,
         )
 

--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -241,6 +241,49 @@ async def command_endturn(update: Update, context: CallbackContext):
     await SecretoCodigoController.end_turn(bot, game)
 
 
+async def command_history(update: Update, context: CallbackContext):
+    bot = context.bot
+    cid = update.message.chat_id
+    game = get_game(cid)
+    if not game or game.tipo != "SecretoCodigo" or not game.board:
+        return
+    historial = game.board.state.historial
+    if not historial:
+        await bot.send_message(cid, "No hay pistas registradas aún.", parse_mode=ParseMode.MARKDOWN)
+        return
+
+    if game.modo == "Cooperativo":
+        emoji_resultado = {"agente": "✅", "neutral": "⬜", "asesino": "💀"}
+        desc_resultado = {"agente": "agente", "neutral": "neutral pisado", "asesino": "asesino"}
+    else:
+        emoji_resultado = {"correcto": "✅", "gris": "⬜", "contrario": "❌", "asesino": "💀"}
+        desc_resultado = {"correcto": "correcto", "gris": "neutral", "contrario": "equipo contrario", "asesino": "asesino"}
+
+    lines = ["📋 *Historial de pistas:*\n"]
+    for entrada in historial:
+        turno = entrada["turno"]
+        dador = entrada["dador"]
+        pista = entrada["pista"]
+        numero = entrada["numero"]
+        numero_str = "∞" if numero in (0, -1) else str(numero)
+
+        if game.modo == "Cooperativo":
+            lines.append(f"👤 *{dador}* (Jugador {turno}) — *{pista}* ({numero_str})")
+        else:
+            emoji_eq = "🔴" if turno == "Rojo" else "🔵"
+            lines.append(f"{emoji_eq} *{dador}* ({turno}) — *{pista}* ({numero_str})")
+
+        for pick in entrada["picks"]:
+            r = pick["resultado"]
+            lines.append(f"  {emoji_resultado.get(r, '?')} *{pick['word']}* — {desc_resultado.get(r, r)}")
+
+        if not entrada["picks"]:
+            lines.append("  _(sin intentos)_")
+        lines.append("")
+
+    await bot.send_message(cid, "\n".join(lines), parse_mode=ParseMode.MARKDOWN)
+
+
 async def command_call(bot, game):
     fase = game.board.state.fase_actual
     if not fase:

--- a/SecretoCodigo/Controller.py
+++ b/SecretoCodigo/Controller.py
@@ -302,6 +302,10 @@ async def process_hint_duo(bot, game, uid, word: str, number: int):
     st.numero_pista = number
     st.intentos_restantes = 999 if infinito else number + 1
     st.fase_actual = f"Duo {dador_label} - Adivinar"
+    st.historial.append({
+        "turno": dador_label, "dador": dador.name,
+        "pista": word.upper(), "numero": number, "picks": []
+    })
 
     intentos_str = "∞" if infinito else str(number + 1)
     await bot.send_photo(
@@ -330,9 +334,10 @@ async def process_pick_duo(bot, game, uid, numero: int):
     tipo_hinter_pre = tipo_a if st.dador_actual == "A" else tipo_b
 
     # Si es asesino en CUALQUIERA de las dos claves → derrota inmediata
-    # Esto incluye la trampa: asesino de B que A ve como agente (verde)
     if tipo_a == "asesino" or tipo_b == "asesino":
         card["tipo"] = "asesino"
+        if st.historial:
+            st.historial[-1]["picks"].append({"word": word.upper(), "resultado": "asesino"})
         await bot.send_message(
             game.cid,
             f"💀 *¡ASESINO!* *{word.upper()}* era un asesino. El equipo ha perdido.",
@@ -343,6 +348,10 @@ async def process_pick_duo(bot, game, uid, numero: int):
 
     # Resultado según la clave de quien da la pista
     tipo_hinter = tipo_hinter_pre
+    resultado_pick = "agente" if tipo_hinter == "agente" else "neutral"
+    if st.historial:
+        st.historial[-1]["picks"].append({"word": word.upper(), "resultado": resultado_pick})
+
     emoji_map = {"agente": "🟩", "neutral": "⬜"}
     await bot.send_message(
         game.cid,
@@ -449,6 +458,10 @@ async def process_hint(bot, game, spymaster_uid, word: str, number: int):
     game.board.state.numero_pista = number
     game.board.state.intentos_restantes = 999 if infinito else number + 1
     game.board.state.fase_actual = f"Turno {team} - Adivinar"
+    game.board.state.historial.append({
+        "turno": team, "dador": spymaster.name,
+        "pista": word.upper(), "numero": number, "picks": []
+    })
 
     intentos_str = "∞" if infinito else str(number + 1)
     field_mentions = " ".join(
@@ -477,6 +490,18 @@ async def process_pick(bot, game, uid, numero: int):
     tipo = card["tipo"]
     word = card["word"]
     team = game.board.state.turno_actual
+
+    # Registrar en historial
+    if game.board.state.historial:
+        if tipo == "asesino":
+            resultado = "asesino"
+        elif tipo == team.lower():
+            resultado = "correcto"
+        elif tipo in ("rojo", "azul"):
+            resultado = "contrario"
+        else:
+            resultado = "gris"
+        game.board.state.historial[-1]["picks"].append({"word": word.upper(), "resultado": resultado})
 
     emoji_map = {"rojo": "🟥", "azul": "🟦", "neutral": "⬜", "asesino": "💀"}
     await bot.send_message(


### PR DESCRIPTION
## Summary

- `/history`: nuevo comando que muestra historial de pistas con resultado de cada intento (correcto, neutral, contrario, asesino)
- `/call` en turno de pista: envía el tablero espía (competitivo) o clave privada (dúo) al chat privado del dador
- `/board`: envía imagen PNG en partidas de Secreto Código en lugar del tablero de texto

https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa

---
_Generated by [Claude Code](https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa)_