### PR TITLE
feat: tarjetas más grandes (190×100) y fuente 27px

### DIFF
--- a/SecretoCodigo/render.py
+++ b/SecretoCodigo/render.py
@@ -3,8 +3,8 @@ from PIL import Image, ImageDraw, ImageFont
 from io import BytesIO
 import os
 
-CELL_W = 150
-CELL_H = 78
+CELL_W = 170
+CELL_H = 90
 PAD = 7
 COLS = 5
 ROWS = 5
@@ -83,7 +83,7 @@ def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, mark=None, revealed=Fal
         draw.polygon(pts, fill=_hex_rgb("#E67E22"))
 
     # Palabra centrada
-    font, label = _fit_text(draw, word.upper(), 22, CELL_W - 16)
+    font, label = _fit_text(draw, word.upper(), 24, CELL_W - 12)
     try:
         bbox = draw.textbbox((0, 0), label, font=font)
         tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]

--- a/SecretoCodigo/render.py
+++ b/SecretoCodigo/render.py
@@ -3,8 +3,8 @@ from PIL import Image, ImageDraw, ImageFont
 from io import BytesIO
 import os
 
-CELL_W = 170
-CELL_H = 90
+CELL_W = 190
+CELL_H = 100
 PAD = 7
 COLS = 5
 ROWS = 5
@@ -83,7 +83,7 @@ def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, mark=None, revealed=Fal
         draw.polygon(pts, fill=_hex_rgb("#E67E22"))
 
     # Palabra centrada
-    font, label = _fit_text(draw, word.upper(), 24, CELL_W - 12)
+    font, label = _fit_text(draw, word.upper(), 27, CELL_W - 12)
     try:
         bbox = draw.textbbox((0, 0), label, font=font)
         tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]


### PR DESCRIPTION
## Summary

- Celdas ampliadas a 190×100px (antes 150×78)
- Fuente de palabras subida a 27px Bold (antes 17px)
- Palabras largas se reducen automáticamente vía `_fit_text`

https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa

---
_Generated by [Claude Code](https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa)_