### PR TITLE
fix: /board NoneType y anti-caché de imágenes Telegram

### DIFF
--- a/Commands.py
+++ b/Commands.py
@@ -310,6 +310,9 @@ async def command_board(update: Update, context: CallbackContext):
 	bot = context.bot
 	cid = update.message.chat_id
 	game = get_game(cid)
+	if not game:
+		await bot.send_message(cid, "There is no running game in this chat. Please start the game with /startgame")
+		return
 	if game.board:
 		if game.tipo == "SecretoCodigo":
 			fase = game.board.state.fase_actual or ""

--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -247,7 +247,7 @@ async def command_history(update: Update, context: CallbackContext):
     game = get_game(cid)
     if not game or game.tipo != "SecretoCodigo" or not game.board:
         return
-    historial = game.board.state.historial
+    historial = getattr(game.board.state, 'historial', [])
     if not historial:
         await bot.send_message(cid, "No hay pistas registradas aún.", parse_mode=ParseMode.MARKDOWN)
         return

--- a/SecretoCodigo/Controller.py
+++ b/SecretoCodigo/Controller.py
@@ -23,6 +23,13 @@ log.basicConfig(
 logger = log.getLogger(__name__)
 
 
+def _hist(st):
+    """Devuelve st.historial, inicializándolo si el objeto viene de una versión anterior."""
+    if not hasattr(st, 'historial'):
+        st.historial = []
+    return st.historial
+
+
 async def init_game(bot, game):
     try:
         log.info('SecretoCodigo init_game called')
@@ -302,7 +309,7 @@ async def process_hint_duo(bot, game, uid, word: str, number: int):
     st.numero_pista = number
     st.intentos_restantes = 999 if infinito else number + 1
     st.fase_actual = f"Duo {dador_label} - Adivinar"
-    st.historial.append({
+    _hist(st).append({
         "turno": dador_label, "dador": dador.name,
         "pista": word.upper(), "numero": number, "picks": []
     })
@@ -336,8 +343,8 @@ async def process_pick_duo(bot, game, uid, numero: int):
     # Si es asesino en CUALQUIERA de las dos claves → derrota inmediata
     if tipo_a == "asesino" or tipo_b == "asesino":
         card["tipo"] = "asesino"
-        if st.historial:
-            st.historial[-1]["picks"].append({"word": word.upper(), "resultado": "asesino"})
+        if _hist(st):
+            _hist(st)[-1]["picks"].append({"word": word.upper(), "resultado": "asesino"})
         await bot.send_message(
             game.cid,
             f"💀 *¡ASESINO!* *{word.upper()}* era un asesino. El equipo ha perdido.",
@@ -349,8 +356,8 @@ async def process_pick_duo(bot, game, uid, numero: int):
     # Resultado según la clave de quien da la pista
     tipo_hinter = tipo_hinter_pre
     resultado_pick = "agente" if tipo_hinter == "agente" else "neutral"
-    if st.historial:
-        st.historial[-1]["picks"].append({"word": word.upper(), "resultado": resultado_pick})
+    if _hist(st):
+        _hist(st)[-1]["picks"].append({"word": word.upper(), "resultado": resultado_pick})
 
     emoji_map = {"agente": "🟩", "neutral": "⬜"}
     await bot.send_message(
@@ -458,7 +465,7 @@ async def process_hint(bot, game, spymaster_uid, word: str, number: int):
     game.board.state.numero_pista = number
     game.board.state.intentos_restantes = 999 if infinito else number + 1
     game.board.state.fase_actual = f"Turno {team} - Adivinar"
-    game.board.state.historial.append({
+    _hist(game.board.state).append({
         "turno": team, "dador": spymaster.name,
         "pista": word.upper(), "numero": number, "picks": []
     })
@@ -492,7 +499,7 @@ async def process_pick(bot, game, uid, numero: int):
     team = game.board.state.turno_actual
 
     # Registrar en historial
-    if game.board.state.historial:
+    if _hist(game.board.state):
         if tipo == "asesino":
             resultado = "asesino"
         elif tipo == team.lower():
@@ -501,7 +508,7 @@ async def process_pick(bot, game, uid, numero: int):
             resultado = "contrario"
         else:
             resultado = "gris"
-        game.board.state.historial[-1]["picks"].append({"word": word.upper(), "resultado": resultado})
+        _hist(game.board.state)[-1]["picks"].append({"word": word.upper(), "resultado": resultado})
 
     emoji_map = {"rojo": "🟥", "azul": "🟦", "neutral": "⬜", "asesino": "💀"}
     await bot.send_message(

--- a/SecretoCodigo/render.py
+++ b/SecretoCodigo/render.py
@@ -3,8 +3,8 @@ from PIL import Image, ImageDraw, ImageFont
 from io import BytesIO
 import os
 
-CELL_W = 150
-CELL_H = 78
+CELL_W = 170
+CELL_H = 90
 PAD = 7
 COLS = 5
 ROWS = 5
@@ -83,7 +83,7 @@ def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, mark=None, revealed=Fal
         draw.polygon(pts, fill=_hex_rgb("#E67E22"))
 
     # Palabra centrada
-    font, label = _fit_text(draw, word.upper(), 22, CELL_W - 16)
+    font, label = _fit_text(draw, word.upper(), 24, CELL_W - 12)
     try:
         bbox = draw.textbbox((0, 0), label, font=font)
         tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]

--- a/SecretoCodigo/render.py
+++ b/SecretoCodigo/render.py
@@ -3,8 +3,8 @@ from PIL import Image, ImageDraw, ImageFont
 from io import BytesIO
 import os
 
-CELL_W = 170
-CELL_H = 90
+CELL_W = 190
+CELL_H = 100
 PAD = 7
 COLS = 5
 ROWS = 5
@@ -83,7 +83,7 @@ def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, mark=None, revealed=Fal
         draw.polygon(pts, fill=_hex_rgb("#E67E22"))
 
     # Palabra centrada
-    font, label = _fit_text(draw, word.upper(), 24, CELL_W - 12)
+    font, label = _fit_text(draw, word.upper(), 27, CELL_W - 12)
     try:
         bbox = draw.textbbox((0, 0), label, font=font)
         tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]

--- a/SecretoCodigo/render.py
+++ b/SecretoCodigo/render.py
@@ -2,6 +2,7 @@
 from PIL import Image, ImageDraw, ImageFont
 from io import BytesIO
 import os
+import time
 
 CELL_W = 190
 CELL_H = 100
@@ -172,6 +173,11 @@ def render_board(tablero, mode="public", key=None, partner_key=None):
             bg, fg = _PALETTE["unrevealed"]
 
         _draw_cell(draw, x, y, word, numero, bg, fg, mark=mark, revealed=revealed)
+
+    # Pixel único para evitar caché de Telegram (deduplica imágenes idénticas)
+    ts = int(time.time() * 1000) % (256 ** 3)
+    r, g, b = ts >> 16, (ts >> 8) & 0xFF, ts & 0xFF
+    img.putpixel((0, 0), (r, g, b))
 
     buf = BytesIO()
     img.save(buf, format="PNG")


### PR DESCRIPTION
## Summary

- `fix`: `/board` crashaba con `NoneType` cuando no hay partida activa en el chat
- `fix`: imágenes del tablero incluyen pixel único con timestamp para evitar que Telegram reutilice el `file_id` cacheado de imágenes anteriores

https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa

---
_Generated by [Claude Code](https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa)_