### PR TITLE
feat: /demotablero y celdas cuadradas 160×160

### DIFF
--- a/MainController.py
+++ b/MainController.py
@@ -769,6 +769,7 @@ def main(stop_event):
 	app.add_handler(CommandHandler("hint", SecretoCodigoCommands.command_hint))
 	app.add_handler(CommandHandler("endturn", SecretoCodigoCommands.command_endturn))
 	app.add_handler(CommandHandler("history", SecretoCodigoCommands.command_history))
+	app.add_handler(CommandHandler("demotablero", SecretoCodigoCommands.command_demotablero))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*choosediccCN\*(.*)\*([0-9]*)", callback=SecretoCodigoController.callback_finish_config_cn))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*choosegamehintCN\*(.*)\*([0-9]*)", callback=SecretoCodigoCommands.callback_choose_game_hint_cn))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*chooseendCN\*(.*)\*([0-9]*)", callback=SecretoCodigoController.callback_finish_game_buttons_cn))

--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -241,6 +241,28 @@ async def command_endturn(update: Update, context: CallbackContext):
     await SecretoCodigoController.end_turn(bot, game)
 
 
+async def command_demotablero(update: Update, context: CallbackContext):
+    bot = context.bot
+    cid = update.message.chat_id
+    import SecretoCodigo.render as render_mod
+    sample_words = [
+        "GRANADA", "UNICORNIO", "MONTAÑA", "LANZA", "MOTOR",
+        "RIO", "LEONA", "INTERNET", "POLO", "CEREBRO",
+        "ARMA", "ROBOT", "GATO", "TIGRE", "HORMIGA",
+        "PAPA", "ESTADO", "LINCE", "SATELITE", "MERCADO",
+        "FALCON", "LATIGO", "CHOCOLATE", "DIETA", "SENADO",
+    ]
+    tipos = ["rojo"] * 9 + ["azul"] * 8 + ["neutral"] * 7 + ["asesino"] * 1
+    import random as _random
+    _random.shuffle(tipos)
+    tablero = [
+        {"word": w, "tipo": tipos[i], "revealed": i in (0, 5, 10, 17, 24), "numero": i + 1}
+        for i, w in enumerate(sample_words)
+    ]
+    buf = render_mod.render_board(tablero, mode="public")
+    await bot.send_photo(cid, photo=buf, caption="🎲 Tablero de demo (modo público)")
+
+
 async def command_history(update: Update, context: CallbackContext):
     bot = context.bot
     cid = update.message.chat_id

--- a/SecretoCodigo/render.py
+++ b/SecretoCodigo/render.py
@@ -4,8 +4,8 @@ from io import BytesIO
 import os
 import time
 
-CELL_W = 200
-CELL_H = 120
+CELL_W = 160
+CELL_H = 160
 PAD = 8
 COLS = 5
 ROWS = 5
@@ -84,7 +84,7 @@ def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, mark=None, revealed=Fal
         draw.polygon(pts, fill=_hex_rgb("#E67E22"))
 
     # Palabra centrada
-    font, label = _fit_text(draw, word.upper(), 30, CELL_W - 14)
+    font, label = _fit_text(draw, word.upper(), 36, CELL_W - 16)
     try:
         bbox = draw.textbbox((0, 0), label, font=font)
         tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]


### PR DESCRIPTION
## Summary

- `/demotablero`: nuevo comando que genera un tablero de muestra con palabras y cartas de todos los colores, sin necesitar una partida activa. Útil para previsualizar cambios de render.
- Celdas cuadradas 160×160px, fuente 36px Bold — imagen 848×848 (cuadrada, se ve grande en móvil)

https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa

---
_Generated by [Claude Code](https://claude.ai/code/session_0124kmwjHyvHpzQY6BjYWbVa)_