### PR TITLE
Fix Secreto Código board font size

### DIFF
--- a/SecretoCodigo/render.py
+++ b/SecretoCodigo/render.py
@@ -4,8 +4,8 @@ from io import BytesIO
 import os
 import time
 
-CELL_W = 230
-CELL_H = 230
+CELL_W = 200
+CELL_H = 200
 PAD = 10
 COLS = 5
 ROWS = 5
@@ -84,7 +84,7 @@ def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, mark=None, revealed=Fal
         draw.polygon(pts, fill=_hex_rgb("#E67E22"))
 
     # Palabra centrada
-    font, label = _fit_text(draw, word.upper(), 56, CELL_W - 20)
+    font, label = _fit_text(draw, word.upper(), 62, CELL_W - 16)
     try:
         bbox = draw.textbbox((0, 0), label, font=font)
         tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]


### PR DESCRIPTION
## Summary
- Revert cell size back to 200×200 (larger canvas caused Telegram to scale down the image, making text appear smaller)
- Increase word font size from 46px to 62px for genuinely bigger text

---
_Generated by [Claude Code](https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM)_