### PR TITLE
Add /demotablero2 using send_document for uncompressed board

### DIFF
--- a/MainController.py
+++ b/MainController.py
@@ -770,6 +770,7 @@ def main(stop_event):
 	app.add_handler(CommandHandler("endturn", SecretoCodigoCommands.command_endturn))
 	app.add_handler(CommandHandler("history", SecretoCodigoCommands.command_history))
 	app.add_handler(CommandHandler("demotablero", SecretoCodigoCommands.command_demotablero))
+	app.add_handler(CommandHandler("demotablero2", SecretoCodigoCommands.command_demotablero2))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*choosediccCN\*(.*)\*([0-9]*)", callback=SecretoCodigoController.callback_finish_config_cn))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*choosegamehintCN\*(.*)\*([0-9]*)", callback=SecretoCodigoCommands.callback_choose_game_hint_cn))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*chooseendCN\*(.*)\*([0-9]*)", callback=SecretoCodigoController.callback_finish_game_buttons_cn))

--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -260,7 +260,29 @@ async def command_demotablero(update: Update, context: CallbackContext):
         for i, w in enumerate(sample_words)
     ]
     buf = render_mod.render_board(tablero, mode="public")
-    await bot.send_photo(cid, photo=buf, caption="🎲 Tablero de demo (modo público)")
+    await bot.send_photo(cid, photo=buf, caption="🎲 Tablero de demo — send_photo (modo público)")
+
+
+async def command_demotablero2(update: Update, context: CallbackContext):
+    bot = context.bot
+    cid = update.message.chat_id
+    import SecretoCodigo.render as render_mod
+    sample_words = [
+        "GRANADA", "UNICORNIO", "MONTAÑA", "LANZA", "MOTOR",
+        "RIO", "LEONA", "INTERNET", "POLO", "CEREBRO",
+        "ARMA", "ROBOT", "GATO", "TIGRE", "HORMIGA",
+        "PAPA", "ESTADO", "LINCE", "SATELITE", "MERCADO",
+        "FALCON", "LATIGO", "CHOCOLATE", "DIETA", "SENADO",
+    ]
+    tipos = ["rojo"] * 9 + ["azul"] * 8 + ["neutral"] * 7 + ["asesino"] * 1
+    import random as _random
+    _random.shuffle(tipos)
+    tablero = [
+        {"word": w, "tipo": tipos[i], "revealed": i in (0, 5, 10, 17, 24), "numero": i + 1}
+        for i, w in enumerate(sample_words)
+    ]
+    buf = render_mod.render_board(tablero, mode="public")
+    await bot.send_document(cid, document=buf, filename="tablero.png", caption="🎲 Tablero de demo — send_document (modo público)")
 
 
 async def command_history(update: Update, context: CallbackContext):


### PR DESCRIPTION
## Summary
- `/demotablero` — sends board as photo (Telegram compresses it)
- `/demotablero2` — sends board as document (no compression, full resolution) for comparison

---
_Generated by [Claude Code](https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM)_