### PR TITLE
Reduce Secreto Código board font size to 32px

### DIFF
--- a/SecretoCodigo/render.py
+++ b/SecretoCodigo/render.py
@@ -84,7 +84,7 @@ def _draw_cell(draw, x, y, word, numero, bg_hex, fg_hex, mark=None, revealed=Fal
         draw.polygon(pts, fill=_hex_rgb("#E67E22"))
 
     # Palabra centrada
-    font, label = _fit_text(draw, word.upper(), 62, CELL_W - 16)
+    font, label = _fit_text(draw, word.upper(), 32, CELL_W - 16)
     try:
         bbox = draw.textbbox((0, 0), label, font=font)
         tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]


### PR DESCRIPTION
## Summary\n- Reduce word font size from 62px to 32px on the Secreto Código board

---
_Generated by [Claude Code](https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM)_