### PR TITLE
Cambiar deploy trigger de main a develop

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -2,7 +2,7 @@ name: Fly Deploy
 on:
   push:
     branches:
-      - main
+      - develop
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ There is no test suite. `MainTest.py` is a standalone runner for isolated manual
 
 ## Deployment
 
-- **CI/CD**: Push to `main` triggers `.github/workflows/fly.yml`, which deploys to Fly.io (`flyctl deploy --remote-only`).
+- **CI/CD**: Push to `develop` triggers `.github/workflows/fly.yml`, which deploys to Fly.io (`flyctl deploy --remote-only`).
 - **Docker**: `CMD ["python", "Main.py"]` — includes Google Chrome (used by `html2image` for rendering).
 - **Database**: PostgreSQL, schema in `DBCreate.sql`. Key table: `games` (id, groupName, tipojuego, data TEXT — JSON-serialized game object via `jsonpickle`).
 


### PR DESCRIPTION
- Actualiza `fly.yml` para deployar desde `develop` en lugar de `main`\n- Actualiza `CLAUDE.md` para reflejar la regla correcta

---
_Generated by [Claude Code](https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM)_