### PR TITLE
Revert: restaurar CI/CD trigger a main

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -2,7 +2,7 @@ name: Fly Deploy
 on:
   push:
     branches:
-      - develop
+      - main
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ There is no test suite. `MainTest.py` is a standalone runner for isolated manual
 
 ## Deployment
 
-- **CI/CD**: Push to `develop` triggers `.github/workflows/fly.yml`, which deploys to Fly.io (`flyctl deploy --remote-only`).
+- **CI/CD**: Push to `main` triggers `.github/workflows/fly.yml`, which deploys to Fly.io (`flyctl deploy --remote-only`).
 - **Docker**: `CMD ["python", "Main.py"]` — includes Google Chrome (used by `html2image` for rendering).
 - **Database**: PostgreSQL, schema in `DBCreate.sql`. Key table: `games` (id, groupName, tipojuego, data TEXT — JSON-serialized game object via `jsonpickle`).
 


### PR DESCRIPTION
Revierte el cambio no autorizado al CI/CD — restaura fly.yml y CLAUDE.md a `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM)_