### PR TITLE
Fix /demotablero3: path explícito de Chrome

### DIFF
--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -316,7 +316,7 @@ async def command_demotablero3(update: Update, context: CallbackContext):
     effective_size = font_size if font_size is not None else render_mod.FONT_SIZE
     html, canvas = render_mod.render_board_html(tablero, mode="public", font_size=font_size)
     with tempfile.TemporaryDirectory() as tmpdir:
-        hti = Html2Image(output_path=tmpdir, size=(canvas, canvas))
+        hti = Html2Image(output_path=tmpdir, size=(canvas, canvas), browser_executable="/usr/bin/google-chrome-stable")
         path_saved = hti.screenshot(html_str=html, save_as="tablero3.png")
         with open(path_saved[0], "rb") as f:
             await bot.send_document(cid, document=f, filename="tablero3.png",


### PR DESCRIPTION
Especifica `/usr/bin/google-chrome-stable` como executable en Html2Image para evitar el error de Chrome no encontrado.

---
_Generated by [Claude Code](https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM)_