### PR TITLE
Agrega Chrome a Dockerfile2 para html2image

### DIFF
--- a/Dockerfile2
+++ b/Dockerfile2
@@ -5,6 +5,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# Install Chrome
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install build deps, install python requirements, then remove build tools to keep image small
 COPY requirements.txt ./
 RUN apt-get update \
@@ -17,7 +26,3 @@ RUN apt-get update \
 COPY . /app
 
 CMD ["python", "Main.py"]
-
-# Notes:
-# - The image includes your repository and any .env file that exists at build time.
-# - At container start the entrypoint sources .env and exports its variables into the environment.


### PR DESCRIPTION
Instala `google-chrome-stable` en Dockerfile2 (Python 3.12) para que html2image funcione en producción.

---
_Generated by [Claude Code](https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM)_