### PR TITLE
Fix Dockerfile2: usar chromium de repos Debian

### DIFF
--- a/Dockerfile2
+++ b/Dockerfile2
@@ -5,13 +5,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# Install Chrome
+# Install Chromium (disponible en repos de Debian sin configuración extra)
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends google-chrome-stable \
+    && apt-get install -y --no-install-recommends chromium \
     && rm -rf /var/lib/apt/lists/*
 
 # Install build deps, install python requirements, then remove build tools to keep image small

--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -316,7 +316,7 @@ async def command_demotablero3(update: Update, context: CallbackContext):
     effective_size = font_size if font_size is not None else render_mod.FONT_SIZE
     html, canvas = render_mod.render_board_html(tablero, mode="public", font_size=font_size)
     with tempfile.TemporaryDirectory() as tmpdir:
-        hti = Html2Image(output_path=tmpdir, size=(canvas, canvas), browser_executable="/usr/bin/google-chrome-stable")
+        hti = Html2Image(output_path=tmpdir, size=(canvas, canvas), browser_executable="/usr/bin/chromium")
         path_saved = hti.screenshot(html_str=html, save_as="tablero3.png")
         with open(path_saved[0], "rb") as f:
             await bot.send_document(cid, document=f, filename="tablero3.png",


### PR DESCRIPTION
- Reemplaza `google-chrome-stable` (requería repo de Google + apt-key deprecado) por `chromium` de los repos estándar de Debian\n- Actualiza el path en `/demotablero3` a `/usr/bin/chromium`

---
_Generated by [Claude Code](https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM)_