### PR TITLE
Secreto Código: usar html2image para todos los renders del tablero

### DIFF
--- a/SecretoCodigo/Boardgamebox/Board.py
+++ b/SecretoCodigo/Boardgamebox/Board.py
@@ -1,6 +1,6 @@
 from Boardgamebox.Board import Board as BaseBoard
 from SecretoCodigo.Boardgamebox.State import State
-from SecretoCodigo.render import render_board
+from SecretoCodigo.render import render_html_to_bytesio
 
 
 REVEAL_EMOJIS = {
@@ -93,14 +93,14 @@ class Board(BaseBoard):
     # --- Métodos de imagen ---
 
     def render_board_image(self, game):
-        return render_board(self.state.tablero, mode="public")
+        return render_html_to_bytesio(self.state.tablero, mode="public")
 
     def render_spymaster_image(self, game):
-        return render_board(self.state.tablero, mode="spymaster")
+        return render_html_to_bytesio(self.state.tablero, mode="spymaster")
 
     def render_key_image(self, game, jugador_label):
         key = self.state.key_a if jugador_label == "A" else self.state.key_b
-        return render_board(self.state.tablero, mode="duo_key", key=key)
+        return render_html_to_bytesio(self.state.tablero, mode="duo_key", key=key)
 
     def render_duo_board_image(self, game):
-        return render_board(self.state.tablero, mode="duo_public")
+        return render_html_to_bytesio(self.state.tablero, mode="duo_public")

--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -295,8 +295,6 @@ async def command_demotablero3(update: Update, context: CallbackContext):
     bot = context.bot
     cid = update.message.chat_id
     import SecretoCodigo.render as render_mod
-    from html2image import Html2Image
-    import tempfile, os
     args = context.args
     font_size = int(args[0]) if args and args[0].isdigit() else None
     sample_words = [
@@ -314,18 +312,8 @@ async def command_demotablero3(update: Update, context: CallbackContext):
         for i, w in enumerate(sample_words)
     ]
     effective_size = font_size if font_size is not None else render_mod.FONT_SIZE
-    html, canvas = render_mod.render_board_html(tablero, mode="public", font_size=font_size)
-    with tempfile.TemporaryDirectory() as tmpdir:
-        hti = Html2Image(
-            output_path=tmpdir,
-            size=(canvas, canvas),
-            browser_executable="/usr/bin/chromium",
-            custom_flags=["--no-sandbox", "--disable-setuid-sandbox", "--disable-gpu"],
-        )
-        path_saved = hti.screenshot(html_str=html, save_as="tablero3.png")
-        with open(path_saved[0], "rb") as f:
-            await bot.send_photo(cid, photo=f,
-                caption=f"🎲 Tablero de demo — html2image | font: {effective_size}px")
+    buf = render_mod.render_html_to_bytesio(tablero, mode="public", font_size=font_size)
+    await bot.send_photo(cid, photo=buf, caption=f"🎲 Tablero de demo — html2image | font: {effective_size}px")
 
 
 async def command_history(update: Update, context: CallbackContext):

--- a/SecretoCodigo/render.py
+++ b/SecretoCodigo/render.py
@@ -3,6 +3,10 @@ from PIL import Image, ImageDraw, ImageFont
 from io import BytesIO
 import os
 import time
+import tempfile
+
+_CHROME = "/usr/bin/chromium"
+_CHROME_FLAGS = ["--no-sandbox", "--disable-setuid-sandbox", "--disable-gpu"]
 
 CELL_W = 200
 CELL_H = 200
@@ -253,3 +257,21 @@ def render_board_html(tablero, mode="public", key=None, font_size=None):
 </div>
 </body></html>"""
     return html, canvas
+
+
+def render_html_to_bytesio(tablero, mode="public", key=None, font_size=None):
+    """Renderiza el tablero con html2image y devuelve BytesIO."""
+    from html2image import Html2Image
+    html, canvas = render_board_html(tablero, mode=mode, key=key, font_size=font_size)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        hti = Html2Image(
+            output_path=tmpdir,
+            size=(canvas, canvas),
+            browser_executable=_CHROME,
+            custom_flags=_CHROME_FLAGS,
+        )
+        paths = hti.screenshot(html_str=html, save_as="board.png")
+        with open(paths[0], "rb") as f:
+            buf = BytesIO(f.read())
+    buf.seek(0)
+    return buf


### PR DESCRIPTION
- Todos los métodos de render del tablero (público, spymaster, duo) usan html2image en lugar de PIL\n- Agrega `render_html_to_bytesio()` como función central reutilizable\n- `/demotablero3` simplificado para usar la misma función\n- El texto se ajusta al tamaño del cuadro automáticamente via CSS

---
_Generated by [Claude Code](https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM)_