### PR TITLE
Add /pickb command for inline word selection in Secreto Código

### DIFF
--- a/MainController.py
+++ b/MainController.py
@@ -772,6 +772,8 @@ def main(stop_event):
 	app.add_handler(CommandHandler("demotablero", SecretoCodigoCommands.command_demotablero))
 	app.add_handler(CommandHandler("demotablero2", SecretoCodigoCommands.command_demotablero2))
 	app.add_handler(CommandHandler("demotablero3", SecretoCodigoCommands.command_demotablero3))
+	app.add_handler(CommandHandler("pickb", SecretoCodigoCommands.command_pickb))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*pickb\*([0-9]*)\*([0-9]*)", callback=SecretoCodigoCommands.callback_pickb))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*choosediccCN\*(.*)\*([0-9]*)", callback=SecretoCodigoController.callback_finish_config_cn))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*choosegamehintCN\*(.*)\*([0-9]*)", callback=SecretoCodigoCommands.callback_choose_game_hint_cn))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*chooseendCN\*(.*)\*([0-9]*)", callback=SecretoCodigoController.callback_finish_game_buttons_cn))

--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -196,6 +196,85 @@ async def command_pick(update: Update, context: CallbackContext):
     await SecretoCodigoController.process_pick(bot, game, uid, numero)
 
 
+async def command_pickb(update: Update, context: CallbackContext):
+    bot = context.bot
+    cid = update.message.chat_id
+    uid = update.message.from_user.id
+
+    game = get_game(cid)
+    if not game or game.tipo != "SecretoCodigo" or not game.board:
+        return
+
+    tablero = game.board.state.tablero
+    strcid = str(cid)
+
+    buttons = []
+    row = []
+    for card in tablero:
+        numero = card["numero"]
+        word = card["word"].upper()
+        label = f"✓" if card["revealed"] else word
+        cb = f"{strcid}*pickb*{numero}*{uid}"
+        row.append(InlineKeyboardButton(label, callback_data=cb))
+        if len(row) == 5:
+            buttons.append(row)
+            row = []
+    if row:
+        buttons.append(row)
+
+    markup = InlineKeyboardMarkup(buttons)
+    await bot.send_message(cid, "🗺 Elegí una carta:", reply_markup=markup)
+
+
+async def callback_pickb(update: Update, context: CallbackContext):
+    bot = context.bot
+    callback = update.callback_query
+    import re
+    regex = re.search(r"(-?[0-9]*)\*pickb\*([0-9]*)\*([0-9]*)", callback.data)
+    cid = int(regex.group(1))
+    numero = int(regex.group(2))
+    uid = callback.from_user.id
+
+    game = get_game(cid)
+    if not game or game.tipo != "SecretoCodigo" or not game.board:
+        await callback.answer("No hay partida activa.")
+        return
+
+    card = next((c for c in game.board.state.tablero if c["numero"] == numero), None)
+    if card is None or card["revealed"]:
+        await callback.answer("Carta ya revelada o inválida.")
+        return
+
+    fase = game.board.state.fase_actual
+
+    if game.modo == "Cooperativo":
+        st = game.board.state
+        receptor_label = game.get_other_player_label(st.dador_actual)
+        receptor = game.get_player_by_label(receptor_label)
+        if fase != f"Duo {st.dador_actual} - Adivinar":
+            await callback.answer("No es el momento de adivinar.")
+            return
+        if not receptor or receptor.uid != uid:
+            await callback.answer("No eres quien debe adivinar ahora.")
+            return
+        await callback.answer()
+        await callback.message.delete()
+        await SecretoCodigoController.process_pick_duo(bot, game, uid, numero)
+        return
+
+    team = game.board.state.turno_actual
+    if fase != f"Turno {team} - Adivinar":
+        await callback.answer("No es el momento de adivinar.")
+        return
+    if not game.is_field_operative(uid, team):
+        await callback.answer("No eres un agente de campo del equipo activo.")
+        return
+
+    await callback.answer()
+    await callback.message.delete()
+    await SecretoCodigoController.process_pick(bot, game, uid, numero)
+
+
 async def command_endturn(update: Update, context: CallbackContext):
     bot = context.bot
     cid = update.message.chat_id


### PR DESCRIPTION
## Summary
- Adds `/pickb` command that sends a 5×5 inline keyboard grid with the board words
- Players tap a word button instead of typing `/pick NUMERO`
- Already-revealed cards show ✓; unrevealed cards show the word
- Handles both competitive mode (validates team + field operative role) and cooperative/duo mode (validates whose turn it is to guess)
- Deletes the keyboard message after a selection is made

## Test plan
- [ ] Start a Secreto Código game and type `/pickb` — bot should reply with a 5×5 button grid
- [ ] Tap a word as the correct guesser — should resolve the pick and remove the keyboard
- [ ] Tap a word as the wrong player — should show "No eres un agente de campo..." toast
- [ ] Tap a word outside the guessing phase — should show "No es el momento de adivinar." toast
- [ ] Tap an already-revealed card button — should show "Carta ya revelada o inválida." toast
- [ ] Test in cooperative/duo mode as well

https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM

---
_Generated by [Claude Code](https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM)_