### PR TITLE
Fix duo board colors lost after DB reload

### DIFF
--- a/Utils/__init__.py
+++ b/Utils/__init__.py
@@ -263,10 +263,18 @@ def load_game(cid):
 			game.board.state.last_votes = temp_last_votes
 		
 		if game.board is not None and game.board.state is not None and hasattr(game.board.state, 'enesperadeaccion'):
-			temp_espera_accion = {}	
+			temp_espera_accion = {}
 			for uid in game.board.state.enesperadeaccion:
 				temp_espera_accion[int(uid)] = game.board.state.enesperadeaccion[uid]
 			game.board.state.enesperadeaccion = temp_espera_accion
+
+		if game.board is not None and game.board.state is not None:
+			for attr in ('key_a', 'key_b'):
+				if hasattr(game.board.state, attr):
+					raw = getattr(game.board.state, attr)
+					if raw:
+						setattr(game.board.state, attr, {int(k): v for k, v in raw.items()})
+
 		return game
 	else:
 		#log.info("Game Not Found")


### PR DESCRIPTION
## Summary
- `load_game` en `Utils/__init__.py` ya convertía a `int` las claves de `playerlist` y `last_votes` tras `jsonpickle.decode`, pero faltaba hacer lo mismo con `key_a` y `key_b`
- Consecuencia: el renderer buscaba `key.get(3)` (int) pero el dict tenía `"3"` (string) → siempre `None` → todas las cartas en beige después de recargar el juego desde DB

https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM

---
_Generated by [Claude Code](https://claude.ai/code/session_013F1BgzK1uirdstAQCTkjtM)_