### PR TITLE
Fix duo private key board — all words showed same color

### DIFF
--- a/SecretoCodigo/render.py
+++ b/SecretoCodigo/render.py
@@ -223,6 +223,22 @@ def render_board_html(tablero, mode="public", key=None, font_size=None):
 
         if mode == "spymaster":
             palette_key = f"revealed_{tipo}" if revealed else tipo
+        elif mode == "duo_key" and key:
+            if revealed:
+                if tipo == "agente":
+                    palette_key = "revealed_agente"
+                elif tipo == "asesino":
+                    palette_key = "revealed_asesino_duo"
+                else:
+                    palette_key = "revealed_miss"
+            else:
+                tipo_mine = key.get(numero, "neutral")
+                if tipo_mine == "agente":
+                    palette_key = "agente"
+                elif tipo_mine == "asesino":
+                    palette_key = "asesino"
+                else:
+                    palette_key = "unrevealed"
         else:
             palette_key = f"revealed_{tipo}" if revealed else "unrevealed"
 


### PR DESCRIPTION
## Summary
- `render_board_html()` had no `duo_key` branch, so all unrevealed cards rendered with `"unrevealed"` (tan) regardless of the player's key
- The `key` dict passed to the function was completely ignored
- The PIL-based `render_board()` already handled this correctly — mirrored its logic into the HTML renderer

## Root cause
`render_html_to_bytesio()` calls `render_board_html()` which only handled `spymaster` mode explicitly. `duo_key` fell through to the generic `else` branch and used `"unrevealed"` for every card.

## Fix
Added `duo_key` branch to `render_board_html()`: green for `agente`, black for `asesino`, tan for neutral — matching the existing PIL renderer logic.

https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U)_