### PR TITLE
Duo: enviar tablero clave al dador al inicio de su turno de pista

### DIFF
--- a/SecretoCodigo/Controller.py
+++ b/SecretoCodigo/Controller.py
@@ -273,11 +273,14 @@ async def start_turn_duo(bot, game, dador_label: str):
         ),
         parse_mode=ParseMode.MARKDOWN,
     )
-    await bot.send_message(
+    await bot.send_photo(
         dador.uid,
-        "Es tu turno de dar pista. Usa `/hint PALABRA NUMERO` aquí.\n"
-        "• `0` → adivina sin límite\n"
-        "• `-1` → pista infinita (también sin límite)",
+        photo=game.board.render_key_image(game, dador_label),
+        caption=(
+            "Es tu turno de dar pista. Usa `/hint PALABRA NUMERO` aquí.\n"
+            "• `0` → adivina sin límite\n"
+            "• `-1` → pista infinita (también sin límite)"
+        ),
         parse_mode=ParseMode.MARKDOWN,
     )
     await save(bot, game.cid)


### PR DESCRIPTION
## Summary
- Al iniciar el turno de pista en modo dúo, el dador recibía solo un mensaje de texto en privado sin ver su tablero
- Ahora recibe la imagen de su clave personal (`render_key_image`) como foto con el texto de instrucciones como caption
- Mismo patrón que ya usa el handler de `/tablero` en `Commands.py`

## Cambio
`start_turn_duo` en `Controller.py`: `send_message` → `send_photo` con `game.board.render_key_image(game, dador_label)`.

https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U)_