### PR TITLE
Duo: anteponer nombre del grupo en mensajes privados al espía

### DIFF
--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -460,7 +460,7 @@ async def command_call(bot, game):
                 dador.uid,
                 photo=game.board.render_key_image(game, st.dador_actual),
                 caption=(
-                    "Es tu turno de dar pista. Usa `/hint PALABRA NUMERO` aquí.\n"
+                    f"[{game.groupName}] Es tu turno de dar pista. Usa `/hint PALABRA NUMERO` aquí.\n"
                     "• `0` → adivina sin límite\n"
                     "• `-1` → pista infinita (también sin límite)"
                 ),

--- a/SecretoCodigo/Controller.py
+++ b/SecretoCodigo/Controller.py
@@ -241,12 +241,12 @@ async def setup_duo(bot, game):
     await bot.send_photo(
         jugador_a.uid,
         photo=game.board.render_key_image(game, "A"),
-        caption="🟩 Tu clave (Jugador A) — verde=agente, negro=asesino, gris=neutral",
+        caption=f"[{game.groupName}] 🟩 Tu clave (Jugador A) — verde=agente, negro=asesino, gris=neutral",
     )
     await bot.send_photo(
         jugador_b.uid,
         photo=game.board.render_key_image(game, "B"),
-        caption="🟩 Tu clave (Jugador B) — verde=agente, negro=asesino, gris=neutral",
+        caption=f"[{game.groupName}] 🟩 Tu clave (Jugador B) — verde=agente, negro=asesino, gris=neutral",
     )
 
     await start_turn_duo(bot, game, "A")
@@ -277,7 +277,7 @@ async def start_turn_duo(bot, game, dador_label: str):
         dador.uid,
         photo=game.board.render_key_image(game, dador_label),
         caption=(
-            "Es tu turno de dar pista. Usa `/hint PALABRA NUMERO` aquí.\n"
+            f"[{game.groupName}] Es tu turno de dar pista. Usa `/hint PALABRA NUMERO` aquí.\n"
             "• `0` → adivina sin límite\n"
             "• `-1` → pista infinita (también sin límite)"
         ),


### PR DESCRIPTION
## Summary
- Los mensajes privados al espía (clave inicial y turno de pista) no indicaban a qué partida pertenecían
- Ahora todos llevan `[nombre del grupo]` al inicio del caption

## Cambios
- `Controller.py` `setup_duo`: captions de `send_photo` a jugador A y B al inicio del juego
- `Controller.py` `start_turn_duo`: caption de `send_photo` al dador al empezar su turno
- `Commands.py` handler de `/tablero`: caption de `send_photo` al dador cuando pide el tablero

Resultado: el jugador ve algo como `[Mi Grupo] Es tu turno de dar pista...` en su chat privado.

https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U)_