### PR TITLE
/history: marcar pistas con intentos sin usar

### DIFF
--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -433,6 +433,11 @@ async def command_history(update: Update, context: CallbackContext):
 
         if not entrada["picks"]:
             lines.append("  _(sin intentos)_")
+        elif numero not in (0, -1):
+            exito_key = "agente" if game.modo == "Cooperativo" else "correcto"
+            encontrados = sum(1 for p in entrada["picks"] if p["resultado"] == exito_key)
+            if encontrados < numero:
+                lines.append(f"  ⚠️ _Solo {encontrados}/{numero} encontrados — quedaron intentos sin usar_")
         lines.append("")
 
     await bot.send_message(cid, "\n".join(lines), parse_mode=ParseMode.MARKDOWN)


### PR DESCRIPTION
## Summary
- `/history` ya existía y estaba registrado en `MainController.py`
- Se añade un indicador `⚠️` cuando una pista tuvo número fijo y el turno terminó sin encontrar todos los agentes posibles

## Formato de salida
```
👤 María (Jugador A) — ANIMAL (2)
  ✅ PERRO — agente
  ⚠️ Solo 1/2 encontrados — quedaron intentos sin usar

👤 Juan (Jugador B) — COLOR (1)
  ✅ ROJO — agente
```

Funciona tanto en modo Dúo (`agente`) como en modo competitivo (`correcto`). Pistas con número `0` o `-1` (ilimitadas) no muestran el aviso.

https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U)_