### PR TITLE
/hint: mensaje gracioso al superar 30 caracteres

### DIFF
--- a/SecretoCodigo/Controller.py
+++ b/SecretoCodigo/Controller.py
@@ -304,7 +304,7 @@ async def process_hint_duo(bot, game, uid, word: str, number: int):
         await bot.send_message(uid, "La pista debe ser una sola palabra sin espacios.")
         return
     if len(word) > 30:
-        await bot.send_message(uid, f"La pista es demasiado larga ({len(word)} caracteres). Máximo 30.")
+        await bot.send_message(uid, "Ni los alemanes se animan a escribir una palabra tan larga, intenta de nuevo por favor... (Max 30 caracteres)")
         return
     if not (-1 <= number <= 9):
         await bot.send_message(uid, "El número debe ser entre -1 y 9. Usa -1 para pista infinita.")


### PR DESCRIPTION
## Summary
Cambia el mensaje de error al superar 30 caracteres en `/hint` por uno con humor:

> "Ni los alemanes se animan a escribir una palabra tan larga, intenta de nuevo por favor... (Max 30 caracteres)"

Aplica en ambos modos (dúo y competitivo).

https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U)_