### PR TITLE
/call: avisar en privado a los adivinadores cuando hay pista activa

### DIFF
--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -484,6 +484,12 @@ async def command_call(bot, game):
                 ),
                 parse_mode=ParseMode.MARKDOWN,
             )
+            await bot.send_message(
+                receptor.uid,
+                f"[{game.groupName}] 🔍 Toca adivinar. Pista: *{st.pista_actual}* — {numero_display}. "
+                f"Intentos restantes: {intentos_display}.\nUsa `/pick NUMERO` o `/endturn`.",
+                parse_mode=ParseMode.MARKDOWN,
+            )
         return
 
     if "Pista" in fase:
@@ -521,3 +527,13 @@ async def command_call(bot, game):
             ),
             parse_mode=ParseMode.MARKDOWN,
         )
+        sm = game.get_spymaster(team)
+        equipo = game.board.state.equipo_rojo if team == "Rojo" else game.board.state.equipo_azul
+        for jugador in equipo:
+            if jugador.uid != sm.uid:
+                await bot.send_message(
+                    jugador.uid,
+                    f"[{game.groupName}] 🔍 Toca adivinar, equipo *{team}*. Pista: *{pista}* — {numero_display}. "
+                    f"Intentos restantes: {intentos_display}.\nUsa `/pick NUMERO` o `/endturn`.",
+                    parse_mode=ParseMode.MARKDOWN,
+                )


### PR DESCRIPTION
## Summary
Cuando se ejecuta `/call` durante la fase de adivinar, además del tablero al grupo, ahora se envía notificación privada a quienes deben adivinar.

## Cambios
- **Modo Dúo**: mensaje privado al `receptor` con la pista activa, intentos restantes e instrucciones
- **Modo Competitivo**: mensaje privado a cada miembro del equipo activo (excluyendo al espía) con la misma info

## Formato del mensaje privado
```
[NombreGrupo] 🔍 Toca adivinar. Pista: ANIMAL — 2. Intentos restantes: 3.
Usa /pick NUMERO o /endturn.
```

https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U)_