### PR TITLE
feat: comando /adminmenu con menú de juegos y estadísticas

### DIFF
--- a/Commands.py
+++ b/Commands.py
@@ -1321,6 +1321,111 @@ def chunk_dict(d: dict, size: int):
         yield chunk
 
 @restricted
+async def command_admin_menu(update: Update, context: CallbackContext):
+    bot = context.bot
+    uid = update.effective_user.id
+    opciones = {
+        "tipos": "📋 Ver Juegos Por Tipo",
+        "stats": "📊 Estadísticas",
+    }
+    await simple_choose_buttons(bot, uid, uid, uid, "adminMenuOpc", "🔧 *Menú Admin*", opciones)
+
+
+async def callback_admin_menu_opc(update: Update, context: CallbackContext):
+    bot = context.bot
+    callback = update.callback_query
+    regex = re.search(r"(-?[0-9]*)\*adminMenuOpc\*(.*)\*(-?[0-9]*)", callback.data)
+    uid = int(regex.group(3))
+    opcion = regex.group(2)
+
+    if opcion == "tipos":
+        all_games = MainController.getGamesByTipo("Todos") or {}
+        tipos_con_juegos = {}
+        for game in all_games.values():
+            if game.tipo not in tipos_con_juegos:
+                tipos_con_juegos[game.tipo] = game.tipo
+        if not tipos_con_juegos:
+            await bot.edit_message_text("No hay juegos activos.", callback.message.chat_id, callback.message.message_id)
+            return
+        await bot.edit_message_text("Elige un tipo de juego:", callback.message.chat_id, callback.message.message_id)
+        await simple_choose_buttons(bot, uid, uid, uid, "adminMenuTipo", "🎮 *Tipos de juego activos:*", tipos_con_juegos)
+
+    elif opcion == "stats":
+        opciones_stats = {
+            "tipos": "🎮 Tipos de Juegos",
+            "jugadores": "👥 Jugadores",
+            "cantidad": "🔢 Cantidad",
+        }
+        await bot.edit_message_text("Elige una estadística:", callback.message.chat_id, callback.message.message_id)
+        await simple_choose_buttons(bot, uid, uid, uid, "adminMenuStats", "📊 *Estadísticas:*", opciones_stats)
+
+
+async def callback_admin_menu_tipo(update: Update, context: CallbackContext):
+    bot = context.bot
+    callback = update.callback_query
+    regex = re.search(r"(-?[0-9]*)\*adminMenuTipo\*(.*)\*(-?[0-9]*)", callback.data)
+    uid = int(regex.group(3))
+    tipo = regex.group(2)
+
+    all_games = MainController.getGamesByTipo(tipo) or {}
+    if not all_games:
+        await bot.edit_message_text(f"No hay juegos de tipo *{tipo}*.", callback.message.chat_id, callback.message.message_id, parse_mode=ParseMode.MARKDOWN)
+        return
+
+    lines = [f"📋 *Juegos de tipo {tipo}:*\n"]
+    for game in all_games.values():
+        last = getattr(game, 'last_activity', None)
+        last_str = last.strftime("%d/%m/%Y %H:%M") if last else "—"
+        lines.append(f"• *{game.groupName}* (`{game.cid}`)\n  ⏱ Última actividad: {last_str}")
+
+    await bot.edit_message_text("\n".join(lines), callback.message.chat_id, callback.message.message_id, parse_mode=ParseMode.MARKDOWN)
+
+
+async def callback_admin_menu_stats(update: Update, context: CallbackContext):
+    bot = context.bot
+    callback = update.callback_query
+    regex = re.search(r"(-?[0-9]*)\*adminMenuStats\*(.*)\*(-?[0-9]*)", callback.data)
+    uid = int(regex.group(3))
+    opcion = regex.group(2)
+
+    all_games = MainController.getGamesByTipo("Todos") or {}
+
+    if opcion == "tipos":
+        contador = {}
+        for game in all_games.values():
+            contador[game.tipo] = contador.get(game.tipo, 0) + 1
+        ordenado = sorted(contador.items(), key=lambda x: x[1], reverse=True)
+        lines = ["📊 *Juegos activos por tipo:*\n"]
+        for tipo, count in ordenado:
+            lines.append(f"• {tipo}: *{count}*")
+        if not ordenado:
+            lines.append("_No hay juegos activos._")
+        await bot.edit_message_text("\n".join(lines), callback.message.chat_id, callback.message.message_id, parse_mode=ParseMode.MARKDOWN)
+
+    elif opcion == "jugadores":
+        lines = ["👥 *Jugadores en partidas activas:*\n"]
+        for game in all_games.values():
+            if game.playerlist:
+                nombres = ", ".join(p.name for p in game.playerlist.values())
+                lines.append(f"• *{game.groupName}* ({game.tipo}): {nombres}")
+        if len(lines) == 1:
+            lines.append("_No hay jugadores en partidas activas._")
+        await bot.edit_message_text("\n".join(lines), callback.message.chat_id, callback.message.message_id, parse_mode=ParseMode.MARKDOWN)
+
+    elif opcion == "cantidad":
+        total_juegos = len(all_games)
+        total_jugadores = sum(len(game.playerlist) for game in all_games.values())
+        tipos = set(game.tipo for game in all_games.values())
+        lines = [
+            "🔢 *Resumen:*\n",
+            f"🎮 Juegos activos: *{total_juegos}*",
+            f"👥 Jugadores totales: *{total_jugadores}*",
+            f"🗂 Tipos en juego: *{len(tipos)}*",
+        ]
+        await bot.edit_message_text("\n".join(lines), callback.message.chat_id, callback.message.message_id, parse_mode=ParseMode.MARKDOWN)
+
+
+@restricted
 async def command_admin_games(update: Update, context: CallbackContext):
     bot = context.bot
     cid = update.message.chat_id

--- a/MainController.py
+++ b/MainController.py
@@ -605,7 +605,12 @@ def main(stop_event):
 	app.add_handler(CommandHandler("pass", Commands.command_pass))
 	app.add_handler(CommandHandler("info", Commands.command_info))
 	app.add_handler(CommandHandler("admin", Commands.command_admin_games))
-	
+	app.add_handler(CommandHandler("adminmenu", Commands.command_admin_menu))
+
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*adminMenuOpc\*(.*)\*(-?[0-9]*)", callback=Commands.callback_admin_menu_opc))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*adminMenuTipo\*(.*)\*(-?[0-9]*)", callback=Commands.callback_admin_menu_tipo))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*adminMenuStats\*(.*)\*(-?[0-9]*)", callback=Commands.callback_admin_menu_stats))
+
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameInfo\*(.*)\*(-?[0-9]*)", callback=Commands.callback_info))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameDelete\*(.*)\*(-?[0-9]*)", callback=Commands.callback_game_delete))
 	

--- a/Utils/__init__.py
+++ b/Utils/__init__.py
@@ -6,6 +6,7 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.constants import ParseMode, ChatAction
 from telegram.ext import CallbackContext
 from random import randrange
+from datetime import datetime
 
 import psycopg
 import urllib.parse
@@ -307,10 +308,11 @@ def save_game(cid, groupName, game, gameType):
 		host=url.hostname,
 		port=url.port
 		)
-		cur = conn.cursor()			
+		cur = conn.cursor()
 		#log.info("Searching Game in DB")
 		query = "select * from games where id = %s;"
 		cur.execute(query, [cid])
+		game.last_activity = datetime.now()
 		if cur.rowcount > 0:
 			#log.info('Updating Game')
 			gamejson = jsonpickle.encode(game)


### PR DESCRIPTION
## Summary
Nuevo comando `/adminmenu` exclusivo para el admin, con menú interactivo en privado.

## Flujo

### 📋 Ver Juegos Por Tipo
```
/adminmenu
→ [📋 Ver Juegos Por Tipo] [📊 Estadísticas]
→ Elige tipo: [SecretoCodigo] [JustOne] [Resistance] ...
→ 📋 Juegos de tipo SecretoCodigo:
   • Mi Grupo (-123456789)
     ⏱ Última actividad: 13/06/2026 20:45
```

### 📊 Estadísticas
```
/adminmenu
→ [📋 Ver Juegos Por Tipo] [📊 Estadísticas]
→ [🎮 Tipos de Juegos] [👥 Jugadores] [🔢 Cantidad]

🎮 Tipos → conteo por tipo ordenado de mayor a menor
👥 Jugadores → lista de jugadores en partidas activas por grupo
🔢 Cantidad → resumen: juegos activos, jugadores totales, tipos en juego
```

## Cambios
- `Commands.py`: `command_admin_menu` + 3 callbacks (`callback_admin_menu_opc`, `callback_admin_menu_tipo`, `callback_admin_menu_stats`)
- `MainController.py`: registro del command handler y los 3 callback handlers
- `Utils/__init__.py`: `save_game` ahora guarda `game.last_activity = datetime.now()` antes de serializar, para que "Ver Juegos Por Tipo" muestre la última actividad

https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U)_