### PR TITLE
/hint: rechazar número como primer argumento (la pista)

### DIFF
--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -47,6 +47,9 @@ async def command_hint(update: Update, context: CallbackContext):
         return
 
     word = args[0]
+    if word.lstrip('-').isdigit():
+        await bot.send_message(uid, "La pista debe ser una palabra, no un número. Uso: `/hint PALABRA NUMERO`", parse_mode=ParseMode.MARKDOWN)
+        return
     try:
         number = int(args[1])
     except ValueError:


### PR DESCRIPTION
## Summary
Añade validación en `command_hint`: si el primer argumento es puramente numérico (ej. `/hint 3 ANIMAL` en lugar de `/hint ANIMAL 3`), se rechaza con mensaje de error indicando el uso correcto.

Cubre tanto positivos (`/hint 3 2`) como negativos (`/hint -1 2`) usando `word.lstrip('-').isdigit()`.

https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U)_