### PR TITLE
Fix /history no llega en privado en partida de SecretoCodigo

### DIFF
--- a/Commands.py
+++ b/Commands.py
@@ -454,14 +454,14 @@ async def command_call(update: Update, context: CallbackContext):
 		
 async def command_showhistory(update: Update, context: CallbackContext):
 	bot = context.bot
-	#game.pedrote = 3
 	try:
-		#Send message of executing command   
 		cid = update.message.chat_id
-		#Check if there is a current game 
 		game = get_game(cid)
-		if game:			
-			#await bot.send_message(cid, "Current round: " + str(game.board.state.currentround + 1))
+		if game:
+			if game.tipo == "SecretoCodigo":
+				import SecretoCodigo.Commands as SCCommands
+				await SCCommands.command_history(update, context)
+				return
 			uid = update.message.from_user.id
 			for history in game.getHistory(uid):
 				if len(history) > 0:
@@ -470,8 +470,8 @@ async def command_showhistory(update: Update, context: CallbackContext):
 			await bot.send_message(cid, "No hay ninguna partida en este chat.")
 	except Exception as e:
 		await bot.send_message(cid, str(e))
-		log.error("Unknown error: " + str(e))  
-		
+		log.error("Unknown error: " + str(e))
+
 async def command_claim(update: Update, context: CallbackContext):
 	bot = context.bot
 	args = context.args

--- a/MainController.py
+++ b/MainController.py
@@ -773,7 +773,6 @@ def main(stop_event):
 	# Handlers de SecretoCodigo
 	app.add_handler(CommandHandler("hint", SecretoCodigoCommands.command_hint))
 	app.add_handler(CommandHandler("endturn", SecretoCodigoCommands.command_endturn))
-	app.add_handler(CommandHandler("history", SecretoCodigoCommands.command_history))
 	app.add_handler(CommandHandler("demotablero", SecretoCodigoCommands.command_demotablero))
 	app.add_handler(CommandHandler("demotablero2", SecretoCodigoCommands.command_demotablero2))
 	app.add_handler(CommandHandler("demotablero3", SecretoCodigoCommands.command_demotablero3))


### PR DESCRIPTION
## Root cause
Dos handlers registrados para `/history` en `MainController.py`:
- Línea 583: `Commands.command_showhistory` (root) — registrado primero, ganaba siempre
- Línea 776: `SecretoCodigoCommands.command_history` — nunca se ejecutaba

`command_showhistory` llama a `game.getHistory(uid)`, que no existe en SecretoCodigo, así que el usuario no recibía nada en privado.

## Fix
- `Commands.command_showhistory`: si `game.tipo == "SecretoCodigo"`, delega a `SecretoCodigoCommands.command_history(update, context)` y retorna
- `MainController.py`: elimina el registro duplicado de `SecretoCodigoCommands.command_history`

https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmUVqgW1o5XeL8mqwzgq1U)_