### PR TITLE
BSG Capas 5-7: crisis de decisión/voto, roster oficial de personajes y ubicaciones/acciones oficiales

### DIFF
--- a/BattlestarGalactica/Boardgamebox/State.py
+++ b/BattlestarGalactica/Boardgamebox/State.py
@@ -44,6 +44,7 @@ class State(BaseState):
 
         # --- Chequeo de habilidad en curso ---
         self.skill_check = None           # dict: {crisis, colores, dificultad, aportes:{uid:[cartas]}, ...}
+        self.crisis_vote = None           # dict: {opciones, votos:{uid:idx}} para crisis de voto
 
         # --- Naves ---
         self.vipers_reserva = 8

--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -158,7 +158,8 @@ async def command_accion(update: Update, context: CallbackContext):
         return
 
     player = game.playerlist[uid]
-    if player.en_calabozo:
+    # En el calabozo solo se permite el intento de fuga (chequeo del Calabozo).
+    if player.en_calabozo and player.ubicacion != "brig":
         await bot.send_message(cid, "Estás en el calabozo y no puedes realizar acciones.")
         return
 
@@ -209,6 +210,24 @@ async def callback_bsg_accion(update: Update, context: CallbackContext):
             await callback.answer("No es tu acción.")
             return
 
+        # Acciones que requieren elegir un personaje objetivo → mostrar botonera
+        if accion in BSGController.ACCIONES_CON_OBJETIVO:
+            await callback.answer()
+            btns = []
+            for p_uid, p in game.playerlist.items():
+                if accion == "brig_check" and (p.en_calabozo or p.revealed):
+                    continue
+                btns.append([InlineKeyboardButton(p.name, callback_data=f"{cid}*bsgTarget*{accion}*{p_uid}")])
+            if not btns:
+                await bot.send_message(cid, "No hay objetivos válidos.")
+                return
+            try:
+                await bot.edit_message_text("Elige el objetivo:", cid, callback.message.message_id,
+                                            reply_markup=InlineKeyboardMarkup(btns))
+            except Exception:
+                await bot.send_message(cid, "Elige el objetivo:", reply_markup=InlineKeyboardMarkup(btns))
+            return
+
         await callback.answer("Acción realizada.")
         try:
             await bot.edit_message_text("Acción elegida.", cid, callback.message.message_id)
@@ -219,7 +238,7 @@ async def callback_bsg_accion(update: Update, context: CallbackContext):
             await BSGController.ejecutar_accion_ubicacion(bot, game, presser, accion)
         else:
             await bot.send_message(cid, f"{game.playerlist[presser].name} pasa su acción.")
-        if not st.ganador:
+        if not st.ganador and not st.skill_check:
             await bot.send_message(cid, "Ahora se revela la *Crisis*. Usa `/crisis`.", parse_mode=ParseMode.MARKDOWN)
     except Exception as e:
         logger.error(f"callback_bsg_accion error: {e}")
@@ -228,6 +247,42 @@ async def callback_bsg_accion(update: Update, context: CallbackContext):
         except Exception:
             pass
         await bot.send_message(ADMIN[0], f"BSG accion error: {e}")
+
+
+async def callback_bsg_target(update: Update, context: CallbackContext):
+    """Selección de objetivo para una acción de ubicación con chequeo."""
+    bot = context.bot
+    callback = update.callback_query
+    presser = callback.from_user.id
+    try:
+        regex = re.search(r"(-?[0-9]*)\*bsgTarget\*([a-z0-9_]*)\*(-?[0-9]*)", callback.data)
+        cid = int(regex.group(1))
+        accion = regex.group(2)
+        objetivo = int(regex.group(3))
+        game = get_game(cid)
+        if not _validar(game):
+            await callback.answer("Partida no encontrada.")
+            return
+        st = game.board.state
+        if not st.active_player or st.active_player.uid != presser:
+            await callback.answer("No es tu acción.")
+            return
+        if objetivo not in game.playerlist:
+            await callback.answer("Objetivo inválido.")
+            return
+        await callback.answer("Objetivo elegido.")
+        try:
+            await bot.edit_message_text(f"Objetivo: {game.playerlist[objetivo].name}", cid, callback.message.message_id)
+        except Exception:
+            pass
+        await BSGController.ejecutar_accion_ubicacion(bot, game, presser, accion, objetivo=objetivo)
+    except Exception as e:
+        logger.error(f"callback_bsg_target error: {e}")
+        try:
+            await callback.answer("Error.")
+        except Exception:
+            pass
+        await bot.send_message(ADMIN[0], f"BSG target error: {e}")
 
 
 async def command_mover(update: Update, context: CallbackContext):

--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -307,10 +307,87 @@ async def command_crisis(update: Update, context: CallbackContext):
     if st.skill_check:
         await bot.send_message(cid, "Ya hay un chequeo abierto. Resuélvelo con `/resolver`.")
         return
+    if st.crisis_actual:
+        await bot.send_message(cid, "Ya hay una crisis pendiente de resolver.")
+        return
     if st.active_player and st.active_player.uid != uid and uid not in ADMIN:
         await bot.send_message(cid, "Solo el jugador activo (o un admin) revela la crisis.")
         return
     await BSGController.robar_crisis(bot, game)
+
+
+async def callback_bsg_eleccion(update: Update, context: CallbackContext):
+    """El decisor de una crisis de decisión elige una opción."""
+    bot = context.bot
+    callback = update.callback_query
+    presser = callback.from_user.id
+    try:
+        regex = re.search(r"(-?[0-9]*)\*bsgEleccion\*([0-9]*)\*(-?[0-9]*)", callback.data)
+        cid = int(regex.group(1))
+        indice = int(regex.group(2))
+        decisor = int(regex.group(3))
+        game = get_game(cid)
+        if not _validar(game):
+            await callback.answer("Partida no encontrada.")
+            return
+        st = game.board.state
+        if not st.crisis_actual or st.crisis_actual.get("tipo") != "eleccion":
+            await callback.answer("Ya no hay decisión pendiente.")
+            return
+        if presser != decisor and presser not in ADMIN:
+            await callback.answer("No te toca decidir.")
+            return
+        await callback.answer("Decisión tomada.")
+        try:
+            await bot.edit_message_text("Decisión tomada.", cid, callback.message.message_id)
+        except Exception:
+            pass
+        await BSGController.resolver_eleccion(bot, game, indice)
+    except Exception as e:
+        logger.error(f"callback_bsg_eleccion error: {e}")
+        try:
+            await callback.answer("Error.")
+        except Exception:
+            pass
+        await bot.send_message(ADMIN[0], f"BSG eleccion error: {e}")
+
+
+async def callback_bsg_crisis_voto(update: Update, context: CallbackContext):
+    """Voto de un jugador en una crisis de voto."""
+    bot = context.bot
+    callback = update.callback_query
+    voter = callback.from_user.id
+    try:
+        regex = re.search(r"(-?[0-9]*)\*bsgCrisisVoto\*([0-9]*)\*(-?[0-9]*)", callback.data)
+        cid = int(regex.group(1))
+        indice = int(regex.group(2))
+        game = get_game(cid)
+        if not _validar(game):
+            await callback.answer("Partida no encontrada.")
+            return
+        st = game.board.state
+        if not st.crisis_vote:
+            await callback.answer("La votación ya terminó.")
+            return
+        p = game.playerlist.get(voter)
+        if not p:
+            await callback.answer("No estás en la partida.")
+            return
+        if p.en_calabozo or p.revealed:
+            await callback.answer("No puedes votar.")
+            return
+        if voter in st.crisis_vote["votos"]:
+            await callback.answer("Ya votaste.")
+            return
+        await callback.answer("Voto registrado.")
+        await BSGController.registrar_voto_crisis(bot, game, voter, indice)
+    except Exception as e:
+        logger.error(f"callback_bsg_crisis_voto error: {e}")
+        try:
+            await callback.answer("Error.")
+        except Exception:
+            pass
+        await bot.send_message(ADMIN[0], f"BSG crisis voto error: {e}")
 
 
 async def command_aportar(update: Update, context: CallbackContext):

--- a/BattlestarGalactica/Constants/Characters.py
+++ b/BattlestarGalactica/Constants/Characters.py
@@ -1,22 +1,14 @@
 # -*- coding: utf-8 -*-
 """
-Roster oficial de personajes del juego base de Battlestar Galactica.
+Roster oficial de personajes del JUEGO BASE de Battlestar Galactica.
+Datos transcritos del set oficial (hoja "Characters"):
+- tipo (subtype), conjunto de habilidades, ubicación inicial, lealtades y
+  el texto completo de las tres habilidades de cada personaje.
 
-NOTA DE FIDELIDAD: los textos de habilidades y los conjuntos de habilidades
-iniciales (`skill_set`) están transcritos lo más fielmente posible, pero
-DEBEN verificarse contra el reglamento oficial de FFG antes de considerarse
-definitivos. Las claves estructurales (tipo, título, ubicación inicial) sí
-son fiables. Marcado con  # VERIFICAR  donde aplica.
-
-Cada personaje:
-  key          : identificador interno
-  nombre       : nombre mostrado
-  tipo         : "Politico" | "Militar" | "Piloto" | "Apoyo"
-  ubicacion    : ubicación inicial (clave de Locations)
-  titulo       : "Presidente" | "Almirante" | None  (título inicial preferente)
-  skill_set    : lista de colores que roba cada turno (Receive Skills)
-  habilidad    : texto de la habilidad de una vez por partida / pasiva
-  desventaja   : texto de la desventaja (drawback)
+NOTA: el motor implementa la habilidad de "Acción una vez por juego" de forma
+aproximada en algunos casos (ver Controller.usar_habilidad). El texto mostrado
+es el oficial. Las ubicaciones iniciales que no existen aún como ubicación
+jugable propia se mapean a la más cercana (marcado con  # map).
 """
 
 # Colores de habilidad
@@ -31,13 +23,16 @@ PERSONAJES = {
     "baltar": {
         "nombre": "Gaius Baltar",
         "tipo": "Politico",
-        "ubicacion": "sickbay",
+        "ubicacion": "research",
         "titulo": None,
-        "skill_set": [POLITICA, POLITICA, LIDERAZGO, INGENIERIA],  # VERIFICAR
-        "habilidad": "Recibe una carta de lealtad adicional al inicio. Una vez por juego "
-                     "puede mirar una de sus cartas de lealtad y, si quiere, barajarla de nuevo "
-                     "en el mazo de lealtad.",  # VERIFICAR
-        "desventaja": "Su carta de lealtad extra aumenta su probabilidad de ser Cylon.",
+        "skill_set": [POLITICA, POLITICA, LIDERAZGO, INGENIERIA],
+        "abilities": (
+            "Intuición Delirante: tras robar una carta de Crisis, roba 1 carta de habilidad "
+            "de tu elección (puede ser de fuera de tu set).\n"
+            "Detector de Cylons (Acción, 1/juego): mira todas las cartas de lealtad de otro jugador.\n"
+            "Cobarde: empiezas con 2 cartas de lealtad (en vez de 1)."
+        ),
+        "desventaja": "Cobarde: 2 cartas de lealtad iniciales (más chance de ser Cylon).",
         "loyalty_extra": 1,
     },
     "roslin": {
@@ -45,96 +40,134 @@ PERSONAJES = {
         "tipo": "Politico",
         "ubicacion": "president_office",
         "titulo": "Presidente",
-        "skill_set": [POLITICA, POLITICA, LIDERAZGO, LIDERAZGO],  # VERIFICAR
-        "habilidad": "Al inicio del juego roba 2 cartas de Quórum adicionales (Mandato Ejecutivo).",  # VERIFICAR
-        "desventaja": "Enferma: no puede mover salvo por habilidades especiales (Diagnóstico Terminal).",  # VERIFICAR
+        "skill_set": [POLITICA, POLITICA, POLITICA, LIDERAZGO, LIDERAZGO],
+        "abilities": (
+            "Visiones Religiosas: al robar cartas de Crisis, roba 2 y elige 1 para resolver; la otra al fondo.\n"
+            "Política Habilidosa (Acción, 1/juego): roba 4 cartas de Quórum, juega 1 y el resto al fondo. "
+            "No necesitas ser Presidenta.\n"
+            "Enfermedad Terminal: para activar una ubicación debes descartar antes 2 cartas de habilidad."
+        ),
+        "desventaja": "Enfermedad Terminal: activar ubicaciones cuesta 2 cartas de habilidad.",
     },
     "zarek": {
         "nombre": "Tom Zarek",
         "tipo": "Politico",
-        "ubicacion": "president_office",
+        "ubicacion": "press_room",  # map: Administración (Colonial One)
         "titulo": None,
-        "skill_set": [POLITICA, POLITICA, LIDERAZGO, TACTICA],  # VERIFICAR
-        "habilidad": "Una vez por juego puede provocar una votación para destituir al Presidente "
-                     "actual (Filibustero / Agenda política).",  # VERIFICAR
-        "desventaja": "Genera desconfianza: penalización al ser elegido para títulos.",
+        "skill_set": [POLITICA, POLITICA, LIDERAZGO, LIDERAZGO, TACTICA],
+        "abilities": (
+            "Amigos en las Sombras: cuando alguien activa 'Administración' o el 'Calabozo', "
+            "puedes reducir o aumentar la dificultad en 2.\n"
+            "Tácticas Heterodoxas (Acción, 1/juego): pierde 1 población para ganar 1 de cualquier otro recurso.\n"
+            "Criminal Convicto: no puedes activar ubicaciones ocupadas por otros personajes (excepto el Calabozo)."
+        ),
+        "desventaja": "Criminal Convicto: no activa ubicaciones ocupadas por otros.",
     },
 
     # ---------------- LÍDERES MILITARES ----------------
     "adama": {
         "nombre": "William Adama",
         "tipo": "Militar",
-        "ubicacion": "command",
+        "ubicacion": "admiral_quarters",
         "titulo": "Almirante",
-        "skill_set": [LIDERAZGO, LIDERAZGO, TACTICA, POLITICA],  # VERIFICAR
-        "habilidad": "Una vez por juego puede mover a cualquier jugador a una ubicación adyacente "
-                     "y +1 a una tirada de habilidad militar (Cadena de Mando).",  # VERIFICAR
-        "desventaja": "Cylon Hatred: tendencia a enviar sospechosos al calabozo.",
+        "skill_set": [LIDERAZGO, LIDERAZGO, LIDERAZGO, TACTICA, TACTICA],
+        "abilities": (
+            "Líder Inspirador: al robar una carta de Crisis, todas las cartas de habilidad de fuerza 1 "
+            "cuentan en positivo en el chequeo.\n"
+            "Autoridad de Mando (Acción, 1/juego): tras resolver un chequeo, en vez de descartar las cartas "
+            "usadas, róbalas a tu mano.\n"
+            "Apego Emocional: no puedes activar la ubicación 'Camarote del Almirante'."
+        ),
+        "desventaja": "Apego Emocional: no puede activar el Camarote del Almirante.",
     },
     "tigh": {
         "nombre": "Saul Tigh",
         "tipo": "Militar",
         "ubicacion": "command",
         "titulo": None,
-        "skill_set": [LIDERAZGO, TACTICA, TACTICA, INGENIERIA],  # VERIFICAR
-        "habilidad": "Una vez por juego, todos los jugadores deben descartar una carta de habilidad "
-                     "(Declarar Emergencia).",  # VERIFICAR
-        "desventaja": "Cylon Hatred: -1 a chequeos políticos.",  # VERIFICAR
+        "skill_set": [LIDERAZGO, LIDERAZGO, TACTICA, TACTICA, TACTICA],
+        "abilities": (
+            "Odio a los Cylons: cuando alguien activa el 'Camarote del Almirante', puedes reducir la dificultad en 3.\n"
+            "Declarar Ley Marcial (Acción, 1/juego): entrega el título de Presidente al Almirante.\n"
+            "Alcohólico: al inicio del turno de cualquier jugador, si tienes exactamente 1 carta de habilidad, descártala."
+        ),
+        "desventaja": "Alcohólico: descarta si te queda exactamente 1 carta de habilidad.",
+    },
+    "helo": {
+        "nombre": "Karl \"Helo\" Agathon",
+        "tipo": "Militar",
+        "ubicacion": "command",  # map: Varado en Caprica (entra en su 2º turno)
+        "titulo": None,
+        "skill_set": [LIDERAZGO, LIDERAZGO, TACTICA, TACTICA, PILOTAJE],
+        "abilities": (
+            "Oficial ECO: en tu turno puedes repetir una tirada de dado recién hecha (1/turno); usas el nuevo resultado.\n"
+            "Brújula Moral (Acción, 1/juego): tras una elección de una carta de Crisis, puedes cambiarla.\n"
+            "Varado: no empiezas en el tablero; al inicio de tu 2º turno te colocas en la Cubierta de Hangar."
+        ),
+        "desventaja": "Varado: entra al tablero recién en su 2º turno.",
     },
 
     # ---------------- PILOTOS ----------------
     "apollo": {
         "nombre": "Lee \"Apollo\" Adama",
         "tipo": "Piloto",
-        "ubicacion": "hangar",
+        "ubicacion": "hangar",  # map: Sector 5/6 (empieza pilotando un Viper)
         "titulo": None,
-        "skill_set": [PILOTAJE, PILOTAJE, TACTICA, LIDERAZGO],  # VERIFICAR
-        "habilidad": "Una vez por juego puede lanzarse en un Viper y +1 a un chequeo de pilotaje "
-                     "(A la altura de la leyenda).",  # VERIFICAR
-        "desventaja": "Ninguna relevante.",
+        "skill_set": [PILOTAJE, PILOTAJE, TACTICA, POLITICA, LIDERAZGO],
+        "abilities": (
+            "Piloto de Viper Alerta: cuando se coloca un Viper desde la reserva, puedes pilotarlo y tomar 1 acción "
+            "(estando en una ubicación de Galactica, salvo el calabozo).\n"
+            "CAG (Acción, 1/juego): activa hasta 6 Vipers sin tripular.\n"
+            "Cabezadura: cuando te obligan a descartar cartas de habilidad, descartas al azar."
+        ),
+        "desventaja": "Cabezadura: descartes forzados son al azar.",
     },
     "starbuck": {
         "nombre": "Kara \"Starbuck\" Thrace",
         "tipo": "Piloto",
         "ubicacion": "hangar",
         "titulo": None,
-        "skill_set": [PILOTAJE, PILOTAJE, TACTICA, TACTICA],  # VERIFICAR
-        "habilidad": "Top Gun: una vez por juego puede relanzar su Viper tras ser destruido "
-                     "y +1 al ataque desde un Viper.",  # VERIFICAR
-        "desventaja": "Imprudente (Reckless): a veces obligada a actuar agresivamente.",
+        "skill_set": [PILOTAJE, PILOTAJE, TACTICA, TACTICA, LIDERAZGO, INGENIERIA],
+        "abilities": (
+            "Piloto Experta: si empiezas tu turno pilotando un Viper, tomas 2 acciones en tu paso de Acción.\n"
+            "Destino Secreto (Acción, 1/juego): justo tras revelar una carta de Crisis, descártala y roba otra.\n"
+            "Insubordinada: cuando te eligen con el 'Camarote del Almirante', reduce la dificultad en 3."
+        ),
+        "desventaja": "Insubordinada: -3 dificultad al chequeo del Camarote del Almirante sobre ella.",
     },
     "boomer": {
         "nombre": "Sharon \"Boomer\" Valerii",
         "tipo": "Piloto",
-        "ubicacion": "hangar",
+        "ubicacion": "hangar",  # map: Armería
         "titulo": None,
-        "skill_set": [PILOTAJE, PILOTAJE, INGENIERIA, TACTICA],  # VERIFICAR
-        "habilidad": "Piloto Natural: una vez por juego puede mover su Viper hasta 2 áreas "
-                     "y atacar.",  # VERIFICAR
-        "desventaja": "Aumenta su probabilidad de ser Cylon (se añade 1 carta 'No eres Cylon' por ella).",
-        "loyalty_not_cylon_extra": 1,
+        "skill_set": [PILOTAJE, PILOTAJE, TACTICA, TACTICA, INGENIERIA],
+        "abilities": (
+            "Reconocimiento: al final de tu turno, mira la carta superior del mazo de Crisis y déjala arriba o abajo.\n"
+            "Intuición Misteriosa (Acción, 1/juego): antes de resolver un chequeo de una Crisis, elige el resultado "
+            "(Éxito o Fracaso) en vez de resolverlo normalmente.\n"
+            "Agente Durmiente: en la Fase del Agente Durmiente recibes 2 cartas de lealtad (en vez de 1) y "
+            "te trasladan al Calabozo."
+        ),
+        "desventaja": "Agente Durmiente: 2 cartas de lealtad en la fase durmiente y va al Calabozo.",
+        "sleeper_extra": 1,
+        "sleeper_to_brig": True,
     },
 
     # ---------------- APOYO ----------------
     "tyrol": {
-        "nombre": "Galen Tyrol",
+        "nombre": "Galen \"Chief\" Tyrol",
         "tipo": "Apoyo",
         "ubicacion": "hangar",
         "titulo": None,
-        "skill_set": [INGENIERIA, INGENIERIA, LIDERAZGO, PILOTAJE],  # VERIFICAR
-        "habilidad": "Jefe de Cubierta: una vez por juego puede reparar todos los Vipers dañados "
-                     "(moverlos de dañado a la reserva).",  # VERIFICAR
-        "desventaja": "Cabeza caliente (Hothead): puede iniciar peleas en su ubicación.",  # VERIFICAR
-    },
-    "helo": {
-        "nombre": "Karl \"Helo\" Agathon",
-        "tipo": "Apoyo",
-        "ubicacion": "command",
-        "titulo": None,
-        "skill_set": [TACTICA, LIDERAZGO, INGENIERIA, POLITICA],  # VERIFICAR
-        "habilidad": "Brújula Moral: una vez por juego puede impedir que un jugador sea enviado "
-                     "al calabozo, o sacar a alguien del calabozo.",  # VERIFICAR
-        "desventaja": "Demasiado confiado: penalización al sospechar de otros.",
+        "skill_set": [POLITICA, LIDERAZGO, LIDERAZGO, INGENIERIA, INGENIERIA],
+        "abilities": (
+            "Ingeniero de Mantenimiento: en tu turno, tras usar una carta de habilidad 'Reparación', "
+            "puedes tomar otra acción (1/turno).\n"
+            "Devoción Ciega (Acción, 1/juego): tras añadir las cartas a un chequeo (antes de revelarlas), "
+            "elige un tipo de habilidad; todas las cartas de ese tipo cuentan fuerza 0.\n"
+            "Imprudente: tu límite de mano es 8 (en vez de 10)."
+        ),
+        "desventaja": "Imprudente: límite de mano de 8 cartas.",
     },
 }
 

--- a/BattlestarGalactica/Constants/Crisis.py
+++ b/BattlestarGalactica/Constants/Crisis.py
@@ -166,6 +166,72 @@ CRISIS_DECK = [
         "jump": 1,
         "activar_cylons": True,
     },
+
+    # ---- Crisis de DECISIÓN (el decisor elige una opción) ----
+    {
+        "id": "reparto_recursos",
+        "titulo": "Reparto de Recursos",
+        "texto": "El gobierno debe decidir qué priorizar.",
+        "tipo": "eleccion",
+        "decisor": "presidente",
+        "opciones": [
+            {"label": "🍞 Priorizar comida",
+             "efectos": [{"tipo": "recurso", "recurso": "comida", "delta": 1},
+                         {"tipo": "recurso", "recurso": "moral", "delta": -1}]},
+            {"label": "🙂 Priorizar moral",
+             "efectos": [{"tipo": "recurso", "recurso": "moral", "delta": 1},
+                         {"tipo": "recurso", "recurso": "comida", "delta": -1}]},
+        ],
+        "jump": 1,
+        "activar_cylons": False,
+    },
+    {
+        "id": "ruta_arriesgada",
+        "titulo": "Ruta Arriesgada",
+        "texto": "El jugador al mando elige la ruta de salto.",
+        "tipo": "eleccion",
+        "decisor": "activo",
+        "opciones": [
+            {"label": "⚡ Ruta corta (-2 combustible)",
+             "efectos": [{"tipo": "recurso", "recurso": "combustible", "delta": -2}]},
+            {"label": "🛡️ Ruta segura (aparecen 2 Raiders)",
+             "efectos": [{"tipo": "raiders", "cantidad": 2}]},
+        ],
+        "jump": 0,
+        "activar_cylons": True,
+    },
+
+    # ---- Crisis de VOTO (todos votan; gana la mayoría) ----
+    {
+        "id": "ley_emergencia",
+        "titulo": "Ley de Emergencia",
+        "texto": "El Quórum vota una medida drástica para levantar el ánimo.",
+        "tipo": "voto",
+        "opciones": [
+            {"label": "✅ A favor",
+             "efectos": [{"tipo": "recurso", "recurso": "moral", "delta": 2},
+                         {"tipo": "recurso", "recurso": "poblacion", "delta": -1}]},
+            {"label": "❌ En contra",
+             "efectos": [{"tipo": "mensaje", "texto": "La medida se rechaza; todo sigue igual."}]},
+        ],
+        "jump": 1,
+        "activar_cylons": False,
+    },
+    {
+        "id": "evacuacion",
+        "titulo": "Evacuación de Emergencia",
+        "texto": "¿Sacrificar combustible para salvar vidas?",
+        "tipo": "voto",
+        "opciones": [
+            {"label": "🚀 Evacuar (-2 combustible, +1 población)",
+             "efectos": [{"tipo": "recurso", "recurso": "combustible", "delta": -2},
+                         {"tipo": "recurso", "recurso": "poblacion", "delta": 1}]},
+            {"label": "⛔ No evacuar (-1 moral)",
+             "efectos": [{"tipo": "recurso", "recurso": "moral", "delta": -1}]},
+        ],
+        "jump": 0,
+        "activar_cylons": True,
+    },
 ]
 
 

--- a/BattlestarGalactica/Constants/Locations.py
+++ b/BattlestarGalactica/Constants/Locations.py
@@ -1,102 +1,126 @@
 # -*- coding: utf-8 -*-
 """
-Ubicaciones del tablero (juego base).
+Ubicaciones del juego base — acciones oficiales (hoja Reference del set real).
 
-NOTA: los textos de acción son descriptivos y deben verificarse contra el
-reglamento oficial. Las claves estructurales (a qué nave pertenece cada
-ubicación, cuáles son ubicaciones Cylon) son fiables.
+Códigos de color de los chequeos de ubicación:
+  G=Política, P=Liderazgo, Y=Ingeniería, R=Táctica, B=Pilotaje
+
+Algunas ubicaciones tienen una acción que es un *chequeo de habilidad*
+(campo "check": {colores, dificultad, efecto}). Otras tienen acción directa.
 """
 
-# Naves / zonas
 GALACTICA = "Galactica"
 COLONIAL_ONE = "Colonial One"
 CYLON = "Cylon"
 
+POLITICA = "Politica"
+LIDERAZGO = "Liderazgo"
+TACTICA = "Tactica"
+PILOTAJE = "Pilotaje"
+INGENIERIA = "Ingenieria"
+
 UBICACIONES = {
     # ---------------- GALACTICA ----------------
-    "command": {
-        "nombre": "Comando (Galactica)",
+    "ftl": {
+        "nombre": "Control FTL (Galactica)",
         "nave": GALACTICA,
-        "accion": "Activar un punto de salto / mover naves. Acción de mando.",  # VERIFICAR
+        "accion": "Saltar la flota si el track de salto no está en zona roja (puede perder población).",
     },
     "weapons": {
         "nombre": "Control de Armas (Galactica)",
         "nave": GALACTICA,
-        "accion": "Disparar a un Raider o Basestar adyacente a Galactica.",  # VERIFICAR
+        "accion": "Atacar 1 nave Cylon con Galactica.",
     },
-    "ftl": {
-        "nombre": "Control FTL (Galactica)",
+    "command": {
+        "nombre": "Comando (Galactica)",
         "nave": GALACTICA,
-        "accion": "Avanzar la preparación de salto (Jump Prep).",  # VERIFICAR
+        "accion": "Activar hasta 2 Vipers sin tripular (mover/atacar).",
+    },
+    "communications": {
+        "nombre": "Comunicaciones (Galactica)",
+        "nave": GALACTICA,
+        "accion": "Mirar el reverso de 2 naves civiles; puedes moverlas.",
     },
     "admiral_quarters": {
         "nombre": "Camarote del Almirante (Galactica)",
         "nave": GALACTICA,
-        "accion": "El Almirante puede ejecutar un salto si el track está listo.",  # VERIFICAR
-    },
-    "hangar": {
-        "nombre": "Cubierta de Hangar (Galactica)",
-        "nave": GALACTICA,
-        "accion": "Lanzar un Viper (subirse a un Viper en un área de espacio).",  # VERIFICAR
+        "accion": "Chequeo (dif. 7, Política+Liderazgo): elige un personaje y, si pasa, va al Calabozo.",
+        "check": {"colores": [POLITICA, LIDERAZGO], "dificultad": 7, "efecto": "brig"},
     },
     "research": {
         "nombre": "Laboratorio de Investigación (Galactica)",
         "nave": GALACTICA,
-        "accion": "Robar 2 cartas de habilidad de los colores indicados.",  # VERIFICAR
+        "accion": "Robar 1 carta de Ingeniería o 1 de Táctica.",
+    },
+    "hangar": {
+        "nombre": "Cubierta de Hangar (Galactica)",
+        "nave": GALACTICA,
+        "accion": "Lanzarte en un Viper (y tomar 1 acción más).",
+    },
+    "armory": {
+        "nombre": "Armería (Galactica)",
+        "nave": GALACTICA,
+        "accion": "Atacar a un centurión del track de abordaje (destruido con 7-8).",
     },
     "sickbay": {
         "nombre": "Enfermería (Galactica)",
         "nave": GALACTICA,
-        "accion": "Curarse / acción de enfermería.",  # VERIFICAR
+        "accion": "Solo robas 1 carta de habilidad en tu paso de Recibir Habilidades (sin acción activa).",
     },
     "brig": {
         "nombre": "Calabozo (Galactica)",
         "nave": GALACTICA,
-        "accion": "Ubicación de prisión: los jugadores enviados aquí no pueden actuar normalmente.",
+        "accion": "No puedes mover, robar Crisis ni aportar más de 1 carta. "
+                  "Acción: chequeo (dif. 7, Ingeniería+Liderazgo) para moverte a cualquier ubicación.",
+        "check": {"colores": [INGENIERIA, LIDERAZGO], "dificultad": 7, "efecto": "escape"},
         "es_prision": True,
     },
 
     # ---------------- COLONIAL ONE ----------------
-    "president_office": {
-        "nombre": "Oficina del Presidente (Colonial One)",
-        "nave": COLONIAL_ONE,
-        "accion": "El Presidente puede jugar/usar cartas de Quórum.",  # VERIFICAR
-    },
     "press_room": {
         "nombre": "Sala de Prensa (Colonial One)",
         "nave": COLONIAL_ONE,
-        "accion": "Robar 1 carta de habilidad y consultar cartas de Crisis.",  # VERIFICAR
+        "accion": "Robar 2 cartas de Política.",
+    },
+    "president_office": {
+        "nombre": "Oficina del Presidente (Colonial One)",
+        "nave": COLONIAL_ONE,
+        "accion": "Si eres Presidente, roba 1 carta de Quórum (y luego roba otra o juega una).",
+    },
+    "administration": {
+        "nombre": "Administración (Colonial One)",
+        "nave": COLONIAL_ONE,
+        "accion": "Chequeo (dif. 5, Ingeniería+Política): elige un personaje y, si pasa, le das el título de Presidente.",
+        "check": {"colores": [INGENIERIA, POLITICA], "dificultad": 5, "efecto": "president"},
     },
 
     # ---------------- UBICACIONES CYLON ----------------
-    # (donde van los jugadores Cylon revelados)
     "caprica": {
         "nombre": "Caprica",
         "nave": CYLON,
-        "accion": "Ubicación Cylon: el Cylon revelado puede actuar contra la flota.",  # VERIFICAR
+        "accion": "Jugar tu Súper Crisis, o robar 2 Crisis y resolver 1.",
         "es_cylon": True,
     },
     "cylon_fleet": {
         "nombre": "Flota Cylon",
         "nave": CYLON,
-        "accion": "Ubicación Cylon: activar/lanzar naves Cylon.",  # VERIFICAR
-        "es_cylon": True,
-    },
-    "resurrection_ship": {
-        "nombre": "Nave de Resurrección",
-        "nave": CYLON,
-        "accion": "Ubicación Cylon.",  # VERIFICAR
+        "accion": "Activar todas las naves Cylon de un tipo, o lanzar 2 Raiders y 1 Heavy Raider por Basestar.",
         "es_cylon": True,
     },
     "human_fleet": {
         "nombre": "Flota Humana (Cylon)",
         "nave": CYLON,
-        "accion": "Ubicación Cylon.",  # VERIFICAR
+        "accion": "Mirar la mano de un jugador y robarle 1 carta; luego tirar dado, 5+ daña Galactica.",
+        "es_cylon": True,
+    },
+    "resurrection_ship": {
+        "nombre": "Nave de Resurrección",
+        "nave": CYLON,
+        "accion": "Descartar tu Súper Crisis para robar otra; si distancia ≤7, dar tu lealtad oculta a otro.",
         "es_cylon": True,
     },
 }
 
-# Áreas de espacio alrededor de Galactica (para naves: vipers, raiders, civiles)
 AREAS_ESPACIO = ["espacio_1", "espacio_2", "espacio_3", "espacio_4", "espacio_5", "espacio_6"]
 
 

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -321,103 +321,174 @@ def _d8():
     return random.randint(1, 8)
 
 
-# Acciones disponibles por ubicación (clave -> lista de acciones)
+# Acciones disponibles por ubicación (clave -> lista de acciones), según el set oficial.
 ACCIONES_UBICACION = {
+    "ftl": ["jump"],
     "weapons": ["shoot_raider", "shoot_basestar"],
-    "hangar": ["launch", "repair"],
-    "command": ["viper_attack", "repel"],
-    "ftl": ["prep"],
-    "admiral_quarters": ["jump", "nuke"],
-    "research": ["draw2"],
-    "press_room": ["draw1"],
+    "command": ["activate_vipers"],
+    "communications": ["peek_civiles"],
+    "admiral_quarters": ["brig_check"],
+    "research": ["draw_eng", "draw_tac"],
+    "hangar": ["launch"],
+    "armory": ["armory_attack"],
+    "sickbay": [],
+    "brig": ["brig_escape"],
+    "press_room": ["draw_politics"],
     "president_office": ["draw_quorum"],
-    "sickbay": ["heal"],
-    "brig": [],
+    "administration": ["president_check"],
 }
+
+# Acciones que requieren elegir un personaje objetivo (abren chequeo de ubicación)
+ACCIONES_CON_OBJETIVO = {"brig_check": "brig", "president_check": "president"}
 
 ETIQUETA_ACCION = {
+    "jump": "🌌 Saltar la flota (FTL)",
     "shoot_raider": "🔫 Disparar a un Raider",
     "shoot_basestar": "💥 Disparar a una Basestar",
-    "launch": "✈️ Lanzar un Viper",
-    "repair": "🔧 Reparar Vipers dañados",
-    "viper_attack": "✈️🔫 Viper ataca a un Raider",
-    "repel": "🪖 Repeler centuriones (-1)",
-    "prep": "⏫ Preparar salto (+1)",
-    "jump": "🌌 Ejecutar salto FTL",
-    "nuke": "☢️ Ataque nuclear",
-    "draw2": "🃏 Robar 2 cartas de habilidad",
-    "draw1": "🃏 Robar 1 carta de habilidad",
+    "activate_vipers": "✈️ Activar Vipers (atacan Raiders)",
+    "peek_civiles": "🔭 Inspeccionar naves civiles",
+    "brig_check": "🚔 Enviar a alguien al Calabozo (chequeo)",
+    "draw_eng": "🟡 Robar 1 carta de Ingeniería",
+    "draw_tac": "🔴 Robar 1 carta de Táctica",
+    "launch": "✈️ Lanzarte en un Viper",
+    "armory_attack": "🪖 Atacar a un centurión",
+    "draw_politics": "🟢 Robar 2 cartas de Política",
     "draw_quorum": "🏛️ Robar una carta de Quórum",
-    "heal": "🩺 Curarse",
+    "president_check": "🏛️ Dar la Presidencia (chequeo)",
 }
 
 
-async def ejecutar_accion_ubicacion(bot, game, uid, accion):
+async def ejecutar_accion_ubicacion(bot, game, uid, accion, objetivo=None):
     """Resuelve la acción de ubicación elegida por el jugador activo."""
     st = game.board.state
     player = game.playerlist[uid]
 
-    if accion == "shoot_raider":
+    if accion == "jump":
+        # FTL Control: saltar si el track no está en zona roja (proxy: prep >= 2)
+        if st.jump_prep < 2:
+            await bot.send_message(game.cid, "El track de salto aún no está listo (necesita avanzar más por crisis).")
+            return
+        await ejecutar_salto(bot, game, auto=False)
+    elif accion == "shoot_raider":
         await _disparar(bot, game, "raider")
     elif accion == "shoot_basestar":
         await _disparar(bot, game, "basestar")
+    elif accion == "activate_vipers":
+        # Comando: activar hasta 2 Vipers sin tripular para atacar
+        await _viper_ataca(bot, game)
+        if st.vipers_espacio > 0 and st.raiders > 0:
+            await _viper_ataca(bot, game)
+    elif accion == "peek_civiles":
+        info = ", ".join(c["recurso"] or "vacía" for c in st.civiles) or "ninguna"
+        await bot.send_message(uid, f"🔭 Cargas de las naves civiles: {info}")
+        await bot.send_message(game.cid, f"🔭 {player.name} inspecciona las naves civiles.")
+    elif accion == "draw_eng":
+        await _robar_color(bot, game, player, Skills.INGENIERIA)
+    elif accion == "draw_tac":
+        await _robar_color(bot, game, player, Skills.TACTICA)
     elif accion == "launch":
         await _lanzar_viper(bot, game)
-    elif accion == "repair":
-        reparados = st.vipers_danados
-        st.vipers_reserva += st.vipers_danados
-        st.vipers_danados = 0
-        await bot.send_message(game.cid, f"🔧 {reparados} Viper(s) reparado(s).")
-    elif accion == "viper_attack":
-        await _viper_ataca(bot, game)
-    elif accion == "repel":
-        if st.centuriones > 0:
-            st.centuriones -= 1
-            await bot.send_message(game.cid, f"🪖 Repeles a los centuriones ({st.centuriones}/{st.centuriones_max}).")
+        await bot.send_message(game.cid, f"✈️ {player.name} se lanza en un Viper.")
+    elif accion == "armory_attack":
+        if st.centuriones <= 0:
+            await bot.send_message(game.cid, "No hay centuriones en el track de abordaje.")
         else:
-            await bot.send_message(game.cid, "No hay centuriones a bordo.")
-    elif accion == "prep":
-        st.jump_prep = min(st.jump_prep_max, st.jump_prep + 1)
-        await bot.send_message(game.cid, f"⏫ Preparación de salto: {st.jump_prep}/{st.jump_prep_max}")
-    elif accion == "jump":
-        if uid != st.almirante_uid and uid not in ADMIN:
-            await bot.send_message(game.cid, "Solo el Almirante puede ejecutar el salto.")
-            return
-        if st.jump_prep < 2:
-            await bot.send_message(game.cid, "La preparación de salto aún no es suficiente (mín. 2).")
-            return
-        await ejecutar_salto(bot, game, auto=False)
-    elif accion == "nuke":
-        if uid != st.almirante_uid and uid not in ADMIN:
-            await bot.send_message(game.cid, "Solo el Almirante puede lanzar el ataque nuclear.")
-            return
-        await _nuke(bot, game)
-    elif accion == "draw2":
-        await _robar_n_skills(bot, game, player, 2)
-    elif accion == "draw1":
-        await _robar_n_skills(bot, game, player, 1)
+            r = _d8()
+            if r >= 7:
+                st.centuriones -= 1
+                await bot.send_message(game.cid, f"🪖 Tirada {r}: ¡centurión destruido! ({st.centuriones}/{st.centuriones_max})")
+            else:
+                await bot.send_message(game.cid, f"🪖 Tirada {r}: el centurión resiste.")
+    elif accion == "draw_politics":
+        await _robar_color(bot, game, player, Skills.POLITICA)
+        await _robar_color(bot, game, player, Skills.POLITICA)
     elif accion == "draw_quorum":
         if uid != st.presidente_uid and uid not in ADMIN:
             await bot.send_message(game.cid, "Solo el Presidente puede robar cartas de Quórum.")
             return
         await robar_quorum(bot, game, uid)
-    elif accion == "heal":
-        await bot.send_message(game.cid, f"🩺 {player.name} se recupera en la enfermería.")
+    elif accion in ("brig_check", "president_check"):
+        await abrir_chequeo_ubicacion(bot, game, uid, accion, objetivo)
+        return  # el chequeo se resuelve aparte; no guardar dos veces
+    elif accion == "brig_escape":
+        await abrir_chequeo_ubicacion(bot, game, uid, accion, uid)
+        return
     else:
         await bot.send_message(game.cid, "Acción no disponible.")
     await save(bot, game.cid)
 
 
-async def _robar_n_skills(bot, game, player, n):
-    pj = Characters.PERSONAJES[player.personaje]
-    colores = pj["skill_set"]
-    for i in range(n):
-        color = colores[i % len(colores)]
-        carta = _robar_carta_color(game.board.state, color)
-        if carta:
-            player.skill_hand.append(carta)
-    await bot.send_message(game.cid, f"🃏 {player.name} roba {n} carta(s) de habilidad.")
+async def _robar_color(bot, game, player, color):
+    carta = _robar_carta_color(game.board.state, color)
+    if carta:
+        player.skill_hand.append(carta)
+    await bot.send_message(game.cid, f"🃏 {player.name} roba 1 carta ({color}).")
     await _dm_mano(bot, player)
+
+
+# ---- Chequeos de habilidad asociados a una acción de ubicación ----
+
+async def abrir_chequeo_ubicacion(bot, game, actor_uid, accion, objetivo_uid):
+    st = game.board.state
+    # Determinar ubicación y su check
+    player = game.playerlist[actor_uid]
+    info = Locations.UBICACIONES.get(player.ubicacion, {})
+    check = info.get("check")
+    if not check:
+        await bot.send_message(game.cid, "Aquí no hay un chequeo disponible.")
+        return
+    if st.skill_check:
+        await bot.send_message(game.cid, "Ya hay un chequeo abierto.")
+        return
+    efecto = check["efecto"]
+    st.skill_check = {
+        "ubicacion_accion": efecto,
+        "actor_uid": actor_uid,
+        "objetivo_uid": objetivo_uid,
+        "colores": check["colores"],
+        "dificultad": check["dificultad"],
+        "aportes": {},
+    }
+    emojis = " ".join(Skills.EMOJI_COLOR[c] for c in check["colores"])
+    obj = game.playerlist.get(objetivo_uid)
+    obj_txt = f" sobre *{obj.name}*" if obj and objetivo_uid != actor_uid else ""
+    await bot.send_message(
+        game.cid,
+        f"🎲 *Chequeo de acción*{obj_txt} — dificultad *{check['dificultad']}*.\n"
+        f"Colores positivos: {emojis}.\n"
+        f"Aporten con `/aportar N` y resuelvan con `/resolver`.",
+        parse_mode=ParseMode.MARKDOWN,
+    )
+    await save(bot, game.cid)
+
+
+async def _resolver_chequeo_ubicacion(bot, game, sc, total, exito):
+    """Aplica el resultado de un chequeo asociado a una acción de ubicación."""
+    st = game.board.state
+    efecto = sc["ubicacion_accion"]
+    objetivo = game.playerlist.get(sc.get("objetivo_uid"))
+    st.skill_check = None
+    if not exito:
+        await bot.send_message(game.cid, "❌ El chequeo de acción falla; no ocurre nada.")
+        await save(bot, game.cid)
+        return
+    if efecto == "brig" and objetivo:
+        objetivo.en_calabozo = True
+        objetivo.ubicacion = "brig"
+        await bot.send_message(game.cid, f"🚔 *{objetivo.name}* es enviado al Calabozo.", parse_mode=ParseMode.MARKDOWN)
+    elif efecto == "president" and objetivo:
+        ant = game.playerlist.get(st.presidente_uid)
+        if ant and "Presidente" in ant.titulos:
+            ant.titulos.remove("Presidente")
+        st.presidente_uid = objetivo.uid
+        if "Presidente" not in objetivo.titulos:
+            objetivo.titulos.append("Presidente")
+        await bot.send_message(game.cid, f"🏛️ *{objetivo.name}* recibe el título de Presidente.", parse_mode=ParseMode.MARKDOWN)
+    elif efecto == "escape" and objetivo:
+        objetivo.en_calabozo = False
+        objetivo.ubicacion = "sickbay"
+        await bot.send_message(game.cid, f"🔓 *{objetivo.name}* sale del Calabozo (Enfermería).", parse_mode=ParseMode.MARKDOWN)
+    await save(bot, game.cid)
 
 
 async def _disparar(bot, game, objetivo):
@@ -1004,7 +1075,6 @@ async def resolver_chequeo(bot, game):
         total += bonus
         detalle.append(f"⭐{'+' if bonus>0 else ''}{bonus}")
 
-    crisis = st.crisis_actual
     exito = total >= sc["dificultad"]
     await bot.send_message(
         game.cid,
@@ -1013,6 +1083,13 @@ async def resolver_chequeo(bot, game):
         f"Cartas: {' '.join(detalle) if detalle else '(ninguna)'}",
         parse_mode=ParseMode.MARKDOWN,
     )
+
+    # Chequeo asociado a una acción de ubicación (no es una crisis)
+    if sc.get("ubicacion_accion"):
+        await _resolver_chequeo_ubicacion(bot, game, sc, total, exito)
+        return
+
+    crisis = st.crisis_actual
     st.skill_check = None
     efectos = crisis["exito"] if exito else crisis["fracaso"]
     await aplicar_efectos(bot, game, efectos)

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -134,8 +134,7 @@ async def asignar_personaje(bot, game, uid, key):
     await bot.send_message(
         uid,
         f"{Characters.EMOJI_TIPO[pj['tipo']]} Eres *{pj['nombre']}* ({pj['tipo']}).\n\n"
-        f"*Habilidad:* {pj['habilidad']}\n"
-        f"*Desventaja:* {pj['desventaja']}\n"
+        f"*Habilidades:*\n{pj['abilities']}\n\n"
         f"📍 Ubicación inicial: {Locations.UBICACIONES[pj['ubicacion']]['nombre']}",
         parse_mode=ParseMode.MARKDOWN,
     )
@@ -171,10 +170,8 @@ async def finalizar_setup(bot, game):
     # --- Flota inicial ---
     _colocar_flota_inicial(st)
 
-    # --- Manos de habilidad iniciales ---
-    for player in game.playerlist.values():
-        _robar_skills(st, player)
-        await _dm_mano(bot, player)
+    # En el juego base no se reparte mano inicial: cada jugador roba en el
+    # paso de Recibir Habilidades al comienzo de su turno.
 
     st.fase_actual = "En Juego"
     st.player_counter = 0
@@ -214,9 +211,13 @@ def _asignar_titulos(game):
     game.playerlist[alm].titulos.append("Almirante")
 
 
-def _robar_skills(st, player):
+def _robar_skills(st, player, cantidad=3):
+    """Roba 'cantidad' cartas de habilidad de los colores del set del personaje.
+    En el juego base se roban 3 por turno, repartidas entre los colores permitidos."""
     pj = Characters.PERSONAJES[player.personaje]
-    for color in pj["skill_set"]:
+    pool = pj["skill_set"]
+    for _ in range(cantidad):
+        color = random.choice(pool)
         carta = _robar_carta_color(st, color)
         if carta:
             player.skill_hand.append(carta)
@@ -692,14 +693,16 @@ async def usar_habilidad(bot, game, uid):
                 robadas += 1
         await bot.send_message(game.cid, f"🏛️ *{nombre}* usa su Mandato Ejecutivo y roba {robadas} cartas de Quórum.", parse_mode=ParseMode.MARKDOWN)
     elif pj == "zarek":
-        if st.presidente_uid and st.presidente_uid != uid:
-            antiguo = game.playerlist.get(st.presidente_uid)
-            if antiguo and "Presidente" in antiguo.titulos:
-                antiguo.titulos.remove("Presidente")
-        st.presidente_uid = uid
-        if "Presidente" not in player.titulos:
-            player.titulos.append("Presidente")
-        await bot.send_message(game.cid, f"🏛️ *{nombre}* maniobra políticamente y asume la Presidencia.", parse_mode=ParseMode.MARKDOWN)
+        # Tácticas Heterodoxas: pierde 1 población para ganar 1 de otro recurso (el más bajo).
+        if st.poblacion <= 1:
+            await bot.send_message(uid, "No tienes suficiente población para usar esta habilidad.")
+            aplicada = False
+        else:
+            await modificar_recurso(bot, game, "poblacion", -1)
+            otros = {"comida": st.comida, "combustible": st.combustible, "moral": st.moral}
+            objetivo = min(otros, key=otros.get)
+            await modificar_recurso(bot, game, objetivo, 1)
+            await bot.send_message(game.cid, f"🏛️ *{nombre}* usa Tácticas Heterodoxas (−1 población, +1 {objetivo}).", parse_mode=ParseMode.MARKDOWN)
     elif pj == "adama":
         if st.skill_check:
             st.skill_check["bonus"] = st.skill_check.get("bonus", 0) + 3
@@ -708,13 +711,19 @@ async def usar_habilidad(bot, game, uid):
             await bot.send_message(uid, "No hay un chequeo abierto para potenciar.")
             aplicada = False
     elif pj == "tigh":
-        descartados = 0
-        for p in game.playerlist.values():
-            if p.uid != uid and p.skill_hand:
-                c = p.skill_hand.pop()
-                st.skill_discards.setdefault(c["color"], []).append(c)
-                descartados += 1
-        await bot.send_message(game.cid, f"🎖️ *{nombre}* Declara Emergencia: {descartados} jugador(es) descartan una carta.", parse_mode=ParseMode.MARKDOWN)
+        # Declarar Ley Marcial: entrega el título de Presidente al Almirante.
+        alm = st.almirante_uid
+        if not alm:
+            await bot.send_message(uid, "No hay Almirante al que entregar la Presidencia.")
+            aplicada = False
+        else:
+            ant = game.playerlist.get(st.presidente_uid)
+            if ant and "Presidente" in ant.titulos:
+                ant.titulos.remove("Presidente")
+            st.presidente_uid = alm
+            if "Presidente" not in game.playerlist[alm].titulos:
+                game.playerlist[alm].titulos.append("Presidente")
+            await bot.send_message(game.cid, f"🎖️ *{nombre}* Declara Ley Marcial: la Presidencia pasa al Almirante.", parse_mode=ParseMode.MARKDOWN)
     elif pj == "apollo":
         await _lanzar_viper(bot, game)
         await _viper_ataca(bot, game)
@@ -1137,12 +1146,20 @@ async def fase_durmiente(bot, game):
         parse_mode=ParseMode.MARKDOWN,
     )
     for uid, player in game.playerlist.items():
-        if st.loyalty_deck:
-            carta = st.loyalty_deck.pop()
-            player.loyalty_cards.append(carta)
-            if carta == Loyalty.CYLON and not player.is_cylon:
-                player.is_cylon = True
-            await _dm_lealtad(bot, player)
+        pj = Characters.PERSONAJES.get(player.personaje, {})
+        # Boomer recibe 2 cartas en la fase durmiente y va al Calabozo
+        cantidad = 1 + pj.get("sleeper_extra", 0)
+        for _ in range(cantidad):
+            if st.loyalty_deck:
+                carta = st.loyalty_deck.pop()
+                player.loyalty_cards.append(carta)
+                if carta == Loyalty.CYLON and not player.is_cylon:
+                    player.is_cylon = True
+        if pj.get("sleeper_to_brig") and not player.revealed:
+            player.en_calabozo = True
+            player.ubicacion = "brig"
+            await bot.send_message(game.cid, f"🚔 {player.name} es trasladado al Calabozo (Agente Durmiente).")
+        await _dm_lealtad(bot, player)
 
 
 # ===================== FIN DE PARTIDA =====================

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -817,9 +817,107 @@ async def robar_crisis(bot, game):
 
     if crisis["tipo"] == "chequeo":
         await abrir_chequeo(bot, game, crisis)
+    elif crisis["tipo"] == "eleccion":
+        await abrir_eleccion(bot, game, crisis)
+    elif crisis["tipo"] == "voto":
+        await abrir_voto(bot, game, crisis)
     else:
         await aplicar_efectos(bot, game, crisis.get("efectos", []))
         await cerrar_crisis(bot, game, crisis)
+
+
+# ---- Crisis de decisión ----
+
+async def abrir_eleccion(bot, game, crisis):
+    st = game.board.state
+    if crisis.get("decisor") == "presidente" and st.presidente_uid:
+        decisor = game.playerlist[st.presidente_uid]
+    else:
+        decisor = st.active_player
+    st.skill_check = None
+    btns = [[InlineKeyboardButton(op["label"], callback_data=f"{game.cid}*bsgEleccion*{i}*{decisor.uid}")]
+            for i, op in enumerate(crisis["opciones"])]
+    await bot.send_message(
+        game.cid,
+        f"🤔 *Decisión* — {player_call(decisor)} debe elegir:",
+        reply_markup=InlineKeyboardMarkup(btns),
+        parse_mode=ParseMode.MARKDOWN,
+    )
+    await save(bot, game.cid)
+
+
+async def resolver_eleccion(bot, game, indice):
+    st = game.board.state
+    crisis = st.crisis_actual
+    if not crisis or indice < 0 or indice >= len(crisis["opciones"]):
+        return
+    opcion = crisis["opciones"][indice]
+    await bot.send_message(game.cid, f"➡️ Se elige: *{opcion['label']}*", parse_mode=ParseMode.MARKDOWN)
+    await aplicar_efectos(bot, game, opcion.get("efectos", []))
+    await cerrar_crisis(bot, game, crisis)
+
+
+# ---- Crisis de voto ----
+
+async def abrir_voto(bot, game, crisis):
+    st = game.board.state
+    st.crisis_vote = {"votos": {}, "n_opciones": len(crisis["opciones"])}
+    btns = [[InlineKeyboardButton(op["label"], callback_data=f"{game.cid}*bsgCrisisVoto*{i}*0")]
+            for i, op in enumerate(crisis["opciones"])]
+    await bot.send_message(
+        game.cid,
+        "🗳️ *Votación de crisis* — todos los jugadores (no presos ni Cylons revelados) votan. "
+        "Gana la mayoría:",
+        reply_markup=InlineKeyboardMarkup(btns),
+        parse_mode=ParseMode.MARKDOWN,
+    )
+    await save(bot, game.cid)
+
+
+def _votantes_validos(game):
+    return [p for p in game.playerlist.values() if not p.en_calabozo and not p.revealed]
+
+
+async def registrar_voto_crisis(bot, game, uid, indice):
+    st = game.board.state
+    vote = st.crisis_vote
+    if not vote:
+        return
+    player = game.playerlist.get(uid)
+    if not player or player.en_calabozo or player.revealed:
+        return
+    vote["votos"][uid] = indice
+    if len(vote["votos"]) >= len(_votantes_validos(game)):
+        await resolver_voto_crisis(bot, game)
+    else:
+        await save(bot, game.cid)
+
+
+async def resolver_voto_crisis(bot, game):
+    st = game.board.state
+    crisis = st.crisis_actual
+    vote = st.crisis_vote
+    st.crisis_vote = None
+    if not crisis or not vote:
+        return
+    conteo = {}
+    for idx in vote["votos"].values():
+        conteo[idx] = conteo.get(idx, 0) + 1
+    if not conteo:
+        ganadora = 0
+    else:
+        maxv = max(conteo.values())
+        empatadas = [i for i, c in conteo.items() if c == maxv]
+        # Desempate: el Presidente decide; si no, la primera opción.
+        ganadora = empatadas[0]
+        if len(empatadas) > 1 and st.presidente_uid in vote["votos"]:
+            pres_voto = vote["votos"][st.presidente_uid]
+            if pres_voto in empatadas:
+                ganadora = pres_voto
+    opcion = crisis["opciones"][ganadora]
+    await bot.send_message(game.cid, f"🗳️ Gana la opción: *{opcion['label']}*", parse_mode=ParseMode.MARKDOWN)
+    await aplicar_efectos(bot, game, opcion.get("efectos", []))
+    await cerrar_crisis(bot, game, crisis)
 
 
 async def abrir_chequeo(bot, game, crisis):

--- a/MainController.py
+++ b/MainController.py
@@ -840,6 +840,8 @@ def main(stop_event):
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgBrig\*(-?[0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_brig))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgFree\*(-?[0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_free))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgQuorum\*([0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_quorum))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgEleccion\*([0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_eleccion))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgCrisisVoto\*([0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_crisis_voto))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*chooseendBSG\*(.*)\*([0-9]*)", callback=BSGController.callback_finish_game_buttons_bsg))
 
 	app.add_handler(CommandHandler("status", command_status))

--- a/MainController.py
+++ b/MainController.py
@@ -842,6 +842,7 @@ def main(stop_event):
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgQuorum\*([0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_quorum))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgEleccion\*([0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_eleccion))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgCrisisVoto\*([0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_crisis_voto))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgTarget\*([a-z0-9_]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_target))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*chooseendBSG\*(.*)\*([0-9]*)", callback=BSGController.callback_finish_game_buttons_bsg))
 
 	app.add_handler(CommandHandler("status", command_status))


### PR DESCRIPTION
## Resumen

Tres capas acumuladas del juego base de **Battlestar Galactica** sobre las Capas 1-4 ya mergeadas. (El PR quedó pendiente unos días por re-autenticación del GitHub MCP; el código ya estaba en la rama.)

### Capa 5 — Crisis de decisión y votación
- Nuevo tipo `eleccion`: el decisor (Presidente o jugador activo) elige una opción.
- Nuevo tipo `voto`: todos los jugadores válidos votan; gana la mayoría, Presidente desempata.
- Cartas de ejemplo añadidas al mazo.

### Capa 6 — Roster oficial de personajes (datos del XLSX)
- **Tipos corregidos:** Helo es Líder Militar; Tyrol/Chief es el único Apoyo (3/3/3/1).
- Texto oficial completo de las 3 habilidades de cada personaje.
- Skill sets y ubicaciones iniciales oficiales; Baltar empieza con 2 lealtades; Boomer recibe 2 en la fase durmiente y va al Calabozo.
- Recibir Habilidades roba 3 cartas/turno; sin mano inicial de setup (como el base).

### Capa 7 — Ubicaciones y acciones oficiales (hoja Reference)
- Acciones oficiales por ubicación (FTL salta, Armas ataca, Comando activa Vipers, Camarote del Almirante → chequeo a Calabozo, Administración → chequeo dar Presidencia, Armería → centuriones, etc.).
- Se elimina la acción no canónica "preparar salto" (el track avanza por iconos de crisis; FTL ejecuta el salto).
- Nuevo mecanismo de chequeo asociado a acción de ubicación con selección de objetivo.

## Verificación

Tests unitarios de cada mecánica (elección/voto/desempate, fase durmiente de Boomer, los 3 chequeos de ubicación incl. fracaso) y smokes de 25-30 partidas completas sin excepciones. Balance ~40% humanos (fiel).

## Pendiente (próximas capas)

Mazo completo de crisis (159), skill cards con efecto, Quórum oficial (27) y acciones Cylon refinadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMgYi6AeG1HSRBrLcJ2iTQ)_