### PR TITLE
BSG Capa 10: mazo de Quórum oficial (13 cartas del juego base)

### DIFF
--- a/BattlestarGalactica/Boardgamebox/State.py
+++ b/BattlestarGalactica/Boardgamebox/State.py
@@ -41,6 +41,7 @@ class State(BaseState):
         self.super_crisis_deck = []       # mazo de súper crisis (Cylons revelados)
         self.quorum_deck = []             # mazo de Quórum (Presidente)
         self.quorum_discard = []
+        self.quorum_pendiente = None      # carta de Quórum esperando elección de objetivo
 
         # --- Chequeo de habilidad en curso ---
         self.skill_check = None           # dict: {crisis, colores, dificultad, aportes:{uid:[cartas]}, ...}

--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -657,6 +657,25 @@ async def callback_bsg_quorum(update: Update, context: CallbackContext):
         except Exception:
             pass
         await BSGController.jugar_quorum(bot, game, presser, indice)
+        # Si la carta requiere objetivo, mostrar botonera
+        carta = st.quorum_pendiente
+        if carta:
+            ef = carta.get("target_efecto")
+            btns = []
+            for p_uid, p in game.playerlist.items():
+                if ef == "pardon" and not p.en_calabozo:
+                    continue
+                if ef == "brig" and (p.en_calabozo or p.revealed):
+                    continue
+                if ef == "mutiny" and (p_uid == st.almirante_uid or p.revealed):
+                    continue
+                btns.append([InlineKeyboardButton(p.name, callback_data=f"{cid}*bsgQTarget*x*{p_uid}")])
+            if not btns:
+                await bot.send_message(cid, "No hay objetivos válidos; la carta se descarta.")
+                st.quorum_discard.append(carta); st.quorum_pendiente = None
+            else:
+                await bot.send_message(cid, "🏛️ Elige el objetivo de la carta de Quórum:",
+                                       reply_markup=InlineKeyboardMarkup(btns))
     except Exception as e:
         logger.error(f"callback_bsg_quorum error: {e}")
         try:
@@ -664,6 +683,44 @@ async def callback_bsg_quorum(update: Update, context: CallbackContext):
         except Exception:
             pass
         await bot.send_message(ADMIN[0], f"BSG quorum error: {e}")
+
+
+async def callback_bsg_qtarget(update: Update, context: CallbackContext):
+    """Objetivo elegido para una carta de Quórum dirigida."""
+    bot = context.bot
+    callback = update.callback_query
+    presser = callback.from_user.id
+    try:
+        regex = re.search(r"(-?[0-9]*)\*bsgQTarget\*[a-z]*\*(-?[0-9]*)", callback.data)
+        cid = int(regex.group(1))
+        objetivo = int(regex.group(2))
+        game = get_game(cid)
+        if not _validar(game):
+            await callback.answer("Partida no encontrada.")
+            return
+        st = game.board.state
+        if presser != st.presidente_uid and presser not in ADMIN:
+            await callback.answer("Solo el Presidente.")
+            return
+        if not st.quorum_pendiente:
+            await callback.answer("No hay carta pendiente.")
+            return
+        if objetivo not in game.playerlist:
+            await callback.answer("Objetivo inválido.")
+            return
+        await callback.answer("Objetivo elegido.")
+        try:
+            await bot.edit_message_text(f"Objetivo: {game.playerlist[objetivo].name}", cid, callback.message.message_id)
+        except Exception:
+            pass
+        await BSGController.resolver_quorum_objetivo(bot, game, objetivo)
+    except Exception as e:
+        logger.error(f"callback_bsg_qtarget error: {e}")
+        try:
+            await callback.answer("Error.")
+        except Exception:
+            pass
+        await bot.send_message(ADMIN[0], f"BSG qtarget error: {e}")
 
 
 async def command_encarcelar(update: Update, context: CallbackContext):

--- a/BattlestarGalactica/Constants/Quorum.py
+++ b/BattlestarGalactica/Constants/Quorum.py
@@ -1,61 +1,116 @@
 # -*- coding: utf-8 -*-
 """
-Mazo de Quórum (juego base) — SET INICIAL representativo.
+Mazo de Quórum del JUEGO BASE (hoja "Quorum Cards", Module=B).
 
-Las cartas de Quórum las roba/juega el Presidente. Aquí se modelan con
-efectos globales que el motor ya entiende (recursos, naves, centuriones).
-El roster completo y los efectos dirigidos a jugadores se completarán en
-una capa posterior.  # VERIFICAR / COMPLETAR
+Cada carta:
+  id, titulo, texto (oficial)
+  draw_politics : (opcional) nº de cartas de Política que roba el Presidente al jugarla
+  target_efecto : (opcional) "brig" | "pardon" | "mutiny" | "mugshots" → requiere objetivo
+  efectos       : (opcional) lista de efectos inmediatos (soporta "roll")
+  keep          : (opcional) True si la carta permanece en juego (efecto continuo
+                  descrito en el texto; no totalmente modelado)
 
-Esquema:
-  id      : identificador
-  titulo  : nombre
-  texto   : descripción
-  efectos : lista de efectos (ver aplicar_efectos en el Controller)
+Efecto "roll": {"tipo":"roll","rango":[min,max],"exito":[...],"fracaso":[...]}
+  Tira 1d8; aplica 'exito' si cae en [min,max] (inclusive), si no 'fracaso'.
 """
 
 QUORUM_DECK = [
     {
-        "id": "voto_confianza",
-        "titulo": "Voto de Confianza",
-        "texto": "El Quórum respalda al gobierno.",
-        "efectos": [{"tipo": "recurso", "recurso": "moral", "delta": 1}],
+        "id": "inspirational_speech",
+        "titulo": "Discurso Inspirador",
+        "texto": "Tira 1d8: con 6-8, +1 Moral.",
+        "efectos": [{"tipo": "roll", "rango": [6, 8],
+                     "exito": [{"tipo": "recurso", "recurso": "moral", "delta": 1}],
+                     "fracaso": [{"tipo": "mensaje", "texto": "El discurso no cala."}]}],
     },
     {
-        "id": "racionamiento",
-        "titulo": "Racionamiento Eficiente",
-        "texto": "Se optimizan las reservas de comida.",
-        "efectos": [{"tipo": "recurso", "recurso": "comida", "delta": 1}],
+        "id": "inspirational_speech_2",
+        "titulo": "Discurso Inspirador",
+        "texto": "Tira 1d8: con 6-8, +1 Moral.",
+        "efectos": [{"tipo": "roll", "rango": [6, 8],
+                     "exito": [{"tipo": "recurso", "recurso": "moral", "delta": 1}],
+                     "fracaso": [{"tipo": "mensaje", "texto": "El discurso no cala."}]}],
     },
     {
-        "id": "reabastecimiento",
-        "titulo": "Reabastecimiento de Tylium",
-        "texto": "Una operación minera recupera combustible.",
-        "efectos": [{"tipo": "recurso", "recurso": "combustible", "delta": 1}],
+        "id": "food_rationing",
+        "titulo": "Racionamiento de Comida",
+        "texto": "Tira 1d8: con 6-8, +1 Comida.",
+        "efectos": [{"tipo": "roll", "rango": [6, 8],
+                     "exito": [{"tipo": "recurso", "recurso": "comida", "delta": 1}],
+                     "fracaso": [{"tipo": "mensaje", "texto": "El racionamiento no rinde."}]}],
     },
     {
-        "id": "contraataque",
-        "titulo": "Orden de Contraataque",
-        "texto": "La flota repele a los cazas Cylon.",
-        "efectos": [{"tipo": "raiders", "cantidad": -2}],
+        "id": "brutal_force",
+        "titulo": "Autorización de Fuerza Brutal",
+        "texto": "Destruye 3 Raiders (o 1 centurión). Tira 1d8: con 1-2, -1 Población.",
+        "efectos": [{"tipo": "raiders", "cantidad": -3},
+                    {"tipo": "roll", "rango": [1, 2],
+                     "exito": [{"tipo": "recurso", "recurso": "poblacion", "delta": -1}],
+                     "fracaso": [{"tipo": "mensaje", "texto": "Sin bajas civiles."}]}],
     },
     {
-        "id": "refuerzo_vipers",
-        "titulo": "Refuerzo de Vipers",
-        "texto": "Llegan Vipers de reserva.",
-        "efectos": [{"tipo": "vipers", "cantidad": 2}],
+        "id": "brutal_force_2",
+        "titulo": "Autorización de Fuerza Brutal",
+        "texto": "Destruye 3 Raiders (o 1 centurión). Tira 1d8: con 1-2, -1 Población.",
+        "efectos": [{"tipo": "raiders", "cantidad": -3},
+                    {"tipo": "roll", "rango": [1, 2],
+                     "exito": [{"tipo": "recurso", "recurso": "poblacion", "delta": -1}],
+                     "fracaso": [{"tipo": "mensaje", "texto": "Sin bajas civiles."}]}],
     },
     {
-        "id": "ley_marcial",
-        "titulo": "Ley Marcial",
-        "texto": "Se refuerza la seguridad interna de Galactica.",
-        "efectos": [{"tipo": "centuriones", "delta": -1}],
+        "id": "arrest_order",
+        "titulo": "Orden de Arresto",
+        "texto": "Envía a un personaje al Calabozo.",
+        "target_efecto": "brig",
     },
     {
-        "id": "asignacion_recursos",
-        "titulo": "Asignación de Recursos",
-        "texto": "El gobierno coordina la moral de la flota.",
-        "efectos": [{"tipo": "recurso", "recurso": "moral", "delta": 1},
-                    {"tipo": "recurso", "recurso": "poblacion", "delta": 1}],
+        "id": "presidential_pardon",
+        "titulo": "Indulto Presidencial",
+        "texto": "Saca a otro personaje del Calabozo a una ubicación de Galactica.",
+        "target_efecto": "pardon",
+    },
+    {
+        "id": "encourage_mutiny",
+        "titulo": "Fomentar Motín",
+        "texto": "Elige a un jugador (no Almirante). Tira 1d8: con 1-2, -1 Moral; con 3-8, se vuelve Almirante.",
+        "target_efecto": "mutiny",
+    },
+    {
+        "id": "release_mugshots",
+        "titulo": "Difundir Fichas Cylon",
+        "texto": "Elige un jugador y mira 1 de sus cartas de lealtad al azar. Tira 1d8: con 1-3, -1 Moral.",
+        "target_efecto": "mugshots",
+    },
+    {
+        "id": "accept_prophecy",
+        "titulo": "Aceptar la Profecía",
+        "texto": "Roba 1 carta de habilidad. (Permanece en juego: la próxima activación de "
+                 "Administración o del Camarote del Almirante para nombrar Presidente tiene +2 dificultad.)",
+        "draw_politics": 1,
+        "keep": True,
+    },
+    {
+        "id": "assign_mission_specialist",
+        "titulo": "Asignar Especialista de Misión",
+        "texto": "Roba 2 cartas de Política y asigna un Especialista. En el próximo salto, el "
+                 "Especialista elige el destino en lugar del Almirante. (Permanece en juego.)",
+        "draw_politics": 2,
+        "keep": True,
+    },
+    {
+        "id": "assign_arbitrator",
+        "titulo": "Asignar Árbitro",
+        "texto": "Roba 2 cartas de Política y elige a otro jugador (Árbitro). Cuando alguien active el "
+                 "Camarote del Almirante, el Árbitro puede mover la dificultad ±3. (Permanece en juego.)",
+        "draw_politics": 2,
+        "keep": True,
+    },
+    {
+        "id": "assign_vice_president",
+        "titulo": "Asignar Vicepresidente",
+        "texto": "Roba 2 cartas de Política y nombra un Vicepresidente. Solo el VP puede llegar a "
+                 "Presidente vía Administración. (Permanece en juego.)",
+        "draw_politics": 2,
+        "keep": True,
     },
 ]

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -869,7 +869,69 @@ async def jugar_quorum(bot, game, uid, indice):
         f"🏛️ *Quórum: {carta['titulo']}*\n_{carta['texto']}_",
         parse_mode=ParseMode.MARKDOWN,
     )
+
+    # Robar cartas de Política para el Presidente (cartas de asignación)
+    if carta.get("draw_politics"):
+        for _ in range(carta["draw_politics"]):
+            await _robar_color(bot, game, player, Skills.POLITICA)
+
+    # Carta con objetivo: esperar selección
+    if carta.get("target_efecto"):
+        st.quorum_pendiente = carta
+        await save(bot, game.cid)
+        return  # el resto se resuelve al elegir objetivo
+
     await aplicar_efectos(bot, game, carta.get("efectos", []))
+    if carta.get("keep"):
+        await bot.send_message(game.cid, "📌 (Esta carta permanece en juego; su efecto continuo se adjudica según el texto.)")
+    else:
+        st.quorum_discard.append(carta)
+    await save(bot, game.cid)
+    await _chequear_fin(bot, game)
+
+
+async def resolver_quorum_objetivo(bot, game, objetivo_uid):
+    """Aplica el efecto de una carta de Quórum dirigida a un objetivo."""
+    st = game.board.state
+    carta = st.quorum_pendiente
+    st.quorum_pendiente = None
+    if not carta:
+        return
+    objetivo = game.playerlist.get(objetivo_uid)
+    if not objetivo:
+        return
+    ef = carta["target_efecto"]
+    if ef == "brig":
+        objetivo.en_calabozo = True
+        objetivo.ubicacion = "brig"
+        await bot.send_message(game.cid, f"🚔 *{objetivo.name}* es enviado al Calabozo.", parse_mode=ParseMode.MARKDOWN)
+    elif ef == "pardon":
+        objetivo.en_calabozo = False
+        objetivo.ubicacion = "command"
+        await bot.send_message(game.cid, f"🔓 *{objetivo.name}* es indultado y sale del Calabozo.", parse_mode=ParseMode.MARKDOWN)
+    elif ef == "mutiny":
+        r = _d8()
+        if r <= 2:
+            await bot.send_message(game.cid, f"🎲 Tirada {r}: el motín fracasa.")
+            await modificar_recurso(bot, game, "moral", -1)
+        else:
+            ant = game.playerlist.get(st.almirante_uid)
+            if ant and "Almirante" in ant.titulos:
+                ant.titulos.remove("Almirante")
+            st.almirante_uid = objetivo.uid
+            if "Almirante" not in objetivo.titulos:
+                objetivo.titulos.append("Almirante")
+            await bot.send_message(game.cid, f"🎲 Tirada {r}: *{objetivo.name}* se vuelve Almirante.", parse_mode=ParseMode.MARKDOWN)
+    elif ef == "mugshots":
+        cartas = ", ".join(objetivo.loyalty_cards) if objetivo.loyalty_cards else "ninguna"
+        await bot.send_message(st.presidente_uid or ADMIN[0],
+                               f"🔎 Lealtad de {objetivo.name}: {cartas}")
+        await bot.send_message(game.cid, f"🔎 El Presidente revisa la ficha de *{objetivo.name}*.", parse_mode=ParseMode.MARKDOWN)
+        r = _d8()
+        if r <= 3:
+            await bot.send_message(game.cid, f"🎲 Tirada {r}: -1 Moral.")
+            await modificar_recurso(bot, game, "moral", -1)
+
     st.quorum_discard.append(carta)
     await save(bot, game.cid)
     await _chequear_fin(bot, game)
@@ -1220,6 +1282,12 @@ async def aplicar_efectos(bot, game, efectos):
             await bot.send_message(game.cid, f"⏫ Preparación de salto: {st.jump_prep}/{st.jump_prep_max}")
         elif tipo == "destruir_civil":
             await _destruir_civil(bot, game)
+        elif tipo == "roll":
+            r = _d8()
+            lo, hi = ef.get("rango", [6, 8])
+            ok = lo <= r <= hi
+            await bot.send_message(game.cid, f"🎲 Tirada: *{r}* ({'éxito' if ok else 'fallo'} en {lo}-{hi})", parse_mode=ParseMode.MARKDOWN)
+            await aplicar_efectos(bot, game, ef["exito"] if ok else ef.get("fracaso", []))
         elif tipo == "mensaje":
             await bot.send_message(game.cid, ef["texto"])
 

--- a/MainController.py
+++ b/MainController.py
@@ -840,6 +840,7 @@ def main(stop_event):
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgBrig\*(-?[0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_brig))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgFree\*(-?[0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_free))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgQuorum\*([0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_quorum))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgQTarget\*[a-z]*\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_qtarget))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgEleccion\*([0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_eleccion))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgCrisisOpt\*([a-z]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_crisis_opt))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgCrisisVoto\*([0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_crisis_voto))


### PR DESCRIPTION
## Resumen

Décima capa de **Battlestar Galactica**: el mazo de Quórum oficial del juego base (hoja `Quorum Cards`, Module=B).

## Qué incluye

- **Discurso Inspirador** / **Racionamiento de Comida**: tirada 1d8 (6-8) → +1 recurso.
- **Autorización de Fuerza Brutal**: destruye 3 Raiders; 1d8 (1-2) → −1 Población.
- **Cartas con objetivo:** Orden de Arresto (al Calabozo), Indulto Presidencial (saca del Calabozo), Fomentar Motín (1-2 −1 Moral; 3-8 el objetivo se vuelve Almirante), Difundir Fichas Cylon (mirar lealtad + 1-3 −1 Moral).
- **Cartas de asignación** (Aceptar Profecía, Especialista de Misión, Árbitro, Vicepresidente): el Presidente roba cartas de Política; permanecen en juego (efecto continuo descrito en el texto).
- Nuevo efecto `roll` (tirada d8 condicional) + estado `quorum_pendiente` y selección de objetivo (`bsgQTarget`).

## Verificación

Test unitario de cada categoría (roll, fuerza bruta, arresto, indulto, motín→almirante, asignar VP con robo+keep) y smoke de 30 partidas con Quórum activo, sin excepciones.

## Pendiente

Skill cards con efecto especial y efectos de crisis no modelados (descartes/tiradas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMgYi6AeG1HSRBrLcJ2iTQ)_