### PR TITLE
BSG: quitar restricción admin-only

### DIFF
--- a/Constants/Config.py
+++ b/Constants/Config.py
@@ -91,7 +91,6 @@ JUEGOS_DISPONIBLES = {
                 "comandos" : {
                     "BattlestarGalactica" : "Battlestar Galactica"
                 },
-                "restriccion" : "admin",
         },
 }
 


### PR DESCRIPTION
## Resumen

Habilita **Battlestar Galactica** para todos los jugadores quitando la restricción `admin-only`.

El juego base ya está completo en contenido (personajes, ubicaciones, 61 crisis, Quórum, lealtad y cartas de habilidad oficiales) y verificado por simulación a lo largo de 11 capas, con balance fiel (~50% victoria humana). Con esto cualquier grupo puede iniciarlo con `/startgame`.

## Cambio

- `Constants/Config.py`: se elimina `"restriccion": "admin"` de la entrada `BattlestarGalactica` en `JUEGOS_DISPONIBLES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMgYi6AeG1HSRBrLcJ2iTQ)_