### PR TITLE
BSG: Recibir Habilidades de Cylon + límite de mano de 10

### DIFF
--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -379,6 +379,13 @@ async def command_crisis(update: Update, context: CallbackContext):
     if st.active_player and st.active_player.uid != uid and uid not in ADMIN:
         await bot.send_message(cid, "Solo el jugador activo (o un admin) revela la crisis.")
         return
+    # Los jugadores Cylon revelados no roban crisis: con esto terminan su turno.
+    if st.active_player and st.active_player.revealed:
+        await bot.send_message(
+            cid, f"🤖 {st.active_player.name} termina su turno (los Cylon no roban crisis)."
+        )
+        await BSGController.avanzar_turno(bot, game)
+        return
     await BSGController.robar_crisis(bot, game)
 
 
@@ -572,7 +579,7 @@ async def callback_bsg_cylon(update: Update, context: CallbackContext):
             pass
         await BSGController.ejecutar_accion_cylon(bot, game, presser, accion)
         if not st.ganador:
-            await bot.send_message(cid, "Ahora se revela la *Crisis*. Usa `/crisis`.", parse_mode=ParseMode.MARKDOWN)
+            await bot.send_message(cid, "Usa `/crisis` para *terminar tu turno*.", parse_mode=ParseMode.MARKDOWN)
     except Exception as e:
         logger.error(f"callback_bsg_cylon error: {e}")
         try:

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -234,6 +234,39 @@ def _robar_skills(st, player, cantidad=3):
             player.skill_hand.append(carta)
 
 
+def _robar_skills_cylon(st, player, cantidad=2):
+    """Un Cylon revelado roba 'cantidad' cartas de habilidad de CUALQUIER tipo
+    (regla del paso Recibir Habilidades para jugadores Cylon)."""
+    for _ in range(cantidad):
+        color = random.choice(Skills.COLORES)
+        carta = _robar_carta_color(st, color)
+        if carta:
+            player.skill_hand.append(carta)
+
+
+LIMITE_MANO = 10
+
+
+async def _descartar_hasta_limite(bot, game, player):
+    """Al final del turno, descarta hasta el límite de 10 cartas de habilidad.
+    El motor descarta automáticamente las de menor fuerza (las menos útiles)."""
+    sobran = len(player.skill_hand) - LIMITE_MANO
+    if sobran <= 0:
+        return
+    st = game.board.state
+    # Ordenar por fuerza ascendente y descartar las más débiles.
+    player.skill_hand.sort(key=lambda c: c.get("valor", 0))
+    descartadas = [player.skill_hand.pop(0) for _ in range(sobran)]
+    for c in descartadas:
+        st.skill_discards.setdefault(c["color"], []).append(c)
+    await bot.send_message(
+        player.uid,
+        f"🗑️ Tenías más de {LIMITE_MANO} cartas; se descartaron {sobran} "
+        f"(las de menor fuerza).",
+    )
+    await _dm_mano(bot, player)
+
+
 def _robar_carta_color(st, color):
     if not st.skill_decks.get(color):
         # Rebarajar descartes de ese color
@@ -281,11 +314,28 @@ async def iniciar_turno(bot, game):
         return
     player = st.active_player
 
+    ubic = Locations.UBICACIONES.get(player.ubicacion, {}).get("nombre", "—")
+
+    if player.revealed:
+        # Jugador Cylon: roba 2 cartas de cualquier tipo y NO roba crisis.
+        _robar_skills_cylon(st, player)
+        await _dm_mano(bot, player)
+        await bot.send_message(
+            game.cid,
+            f"🤖 *Turno del Cylon {player.name}* (robó 2 cartas de habilidad).\n"
+            f"📍 Estás en: *{ubic}*\n\n"
+            f"`/mover` y `/accion` para sabotear · luego `/crisis` para *terminar tu turno* "
+            f"(los Cylon no roban crisis).\n"
+            f"Consulta `/mapa` para ver la flota.",
+            parse_mode=ParseMode.MARKDOWN,
+        )
+        await save(bot, game.cid)
+        return
+
     # Recibir habilidades
     _robar_skills(st, player)
     await _dm_mano(bot, player)
 
-    ubic = Locations.UBICACIONES.get(player.ubicacion, {}).get("nombre", "—")
     await bot.send_message(
         game.cid,
         f"🎬 *Turno de {player.name}* (recibió cartas de habilidad).\n"
@@ -302,6 +352,9 @@ async def avanzar_turno(bot, game):
     st = game.board.state
     if st.ganador:
         return
+    # Fin del turno del jugador activo: descartar hasta el límite de mano.
+    if st.active_player:
+        await _descartar_hasta_limite(bot, game, st.active_player)
     seq = game.player_sequence
     st.player_counter = (st.player_counter + 1) % len(seq)
     st.active_player = seq[st.player_counter]


### PR DESCRIPTION
## Resumen

Mejoras de fidelidad al reglamento del juego base en el bucle de turno de Battlestar Galactica, a partir de las secciones **Game turn**, **Cylon Players** y los **Rule reminders**.

## Cambios

- **Recibir Habilidades de un Cylon revelado:** ahora roba **2 cartas de cualquier tipo** (regla "*Cylon players draw two Skill cards of any type*"). Antes robaba del set de habilidades de su personaje humano, lo que además contradice "*Cylon players are not allowed to use old human character sheet*".
- **Los Cylon revelados no roban crisis:** `/crisis` ahora **termina su turno** ("*Cylon players always skip this step*"). Se actualizan los mensajes del turno y de la acción Cylon.
- **Límite de mano (10 cartas):** al final de cada turno el jugador descarta hasta 10 cartas ("*All players must discard down to 10 Skill cards at the end of each turn*"). El motor descarta automáticamente las de menor fuerza y avisa por privado.

## Verificación
- `py_compile` OK.
- Lógica de descarte verificada (mantiene las 10 cartas de mayor fuerza).

## Nota de alcance
El número exacto de cartas por color que roba cada **personaje humano** en su turno (según su hoja) sigue como aproximación (3 cartas repartidas en su set), porque el roster no incluye esos conteos por tipo. El combate espacial sigue siendo abstracto. Ambos quedarían para una capa posterior si se desea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_