### PR TITLE
BSG: combate espacial posicional completo (Vipers tripulados, Heavy Raiders, daño por ubicaciones, iconos de activación)

### DIFF
--- a/BattlestarGalactica/Boardgamebox/Board.py
+++ b/BattlestarGalactica/Boardgamebox/Board.py
@@ -27,11 +27,25 @@ def naves_de_area(area):
         piezas.append(f"🛸{extra}")
     if area["raiders"]:
         piezas.append(f"👾×{area['raiders']}")
+    if area.get("heavy_raiders"):
+        piezas.append(f"🚁×{area['heavy_raiders']}")
     if area["vipers"]:
         piezas.append(f"✈️×{area['vipers']}")
     if area["civiles"]:
         piezas.append(f"🛰️×{len(area['civiles'])}")
     return piezas
+
+
+def track_abordaje(st):
+    """Representa el track de la Partida de Abordaje: una barra de casillas con
+    los centuriones que avanzan hacia el puente (casilla final = abordaje)."""
+    n = st.boarding_breach
+    casillas = ["▫️"] * n
+    for pos in st.boarding_party:
+        idx = max(0, min(pos, n) - 1)
+        casillas[idx] = "🔺"
+    barra = "".join(casillas)
+    return f"{barra} ({st.total_centuriones()} a bordo)"
 
 
 class Board(BaseBoard):
@@ -53,10 +67,11 @@ class Board(BaseBoard):
         board += "*Naves:*\n"
         board += (f"✈️ Vipers (espacio/reserva/dañados): "
                   f"{st.total_vipers_espacio()}/{st.vipers_reserva}/{st.vipers_danados}\n")
-        board += f"👾 Raiders: {st.total_raiders()}   🛸 Basestars: {st.total_basestars()}\n"
+        board += (f"👾 Raiders: {st.total_raiders()}   🚁 Heavy Raiders: {st.total_heavy_raiders()}   "
+                  f"🛸 Basestars: {st.total_basestars()}\n")
         board += f"🛰️ Naves civiles: {st.total_civiles()}\n"
-        board += (f"🛡️ Daño Galactica: {st.galactica_danos}/{st.galactica_danos_max}   "
-                  f"🔺 Centuriones: {st.centuriones}/{st.centuriones_max}\n\n")
+        board += f"🛡️ Daño Galactica: {st.galactica_danos}/{st.galactica_danos_max}\n"
+        board += f"🔺 Abordaje: {track_abordaje(st)}\n\n"
 
         pres = game.playerlist.get(st.presidente_uid)
         alm = game.playerlist.get(st.almirante_uid)
@@ -108,8 +123,8 @@ class Board(BaseBoard):
             cuerpo += f"  {meta['emoji']} {meta['nombre']}{tubo}: {'  '.join(piezas) if piezas else '—'}\n"
         cuerpo += (f"  🅿️ Reserva vipers: {st.vipers_reserva}   "
                    f"🛠️ dañados: {st.vipers_danados}\n")
-        cuerpo += (f"  🛡️ Daño Galactica: {st.galactica_danos}/{st.galactica_danos_max}   "
-                   f"🔺 Abordaje: {st.centuriones}/{st.centuriones_max}\n\n")
+        cuerpo += f"  🛡️ Daño Galactica: {st.galactica_danos}/{st.galactica_danos_max}\n"
+        cuerpo += f"  🔺 Abordaje: {track_abordaje(st)}\n\n"
         cuerpo += "──────────── GALÁCTICA ────────────\n" + _bloque(_GALACTICA) + "\n\n"
         cuerpo += "─────────── COLONIAL ONE ──────────\n" + _bloque(_COLONIAL) + "\n\n"
         cuerpo += "──────── LOCALIZACIONES CYLON ──────\n" + _bloque(_CYLON)

--- a/BattlestarGalactica/Boardgamebox/Board.py
+++ b/BattlestarGalactica/Boardgamebox/Board.py
@@ -73,8 +73,9 @@ class Board(BaseBoard):
         board += f"🧭 Distancia: {st.distancia}/{st.objetivo_distancia}   "
         board += f"⏫ Prep. salto: {st.jump_prep}/{st.jump_prep_max}\n\n"
         board += "*Naves:*\n"
-        board += (f"✈️ Vipers (espacio/reserva/dañados): "
-                  f"{st.total_vipers_espacio()}/{st.vipers_reserva}/{st.vipers_danados}\n")
+        tripulados = sum(1 for p in game.playerlist.values() if getattr(p, "viper_area", None) is not None)
+        board += (f"✈️ Vipers (espacio/tripulados/reserva/dañados): "
+                  f"{st.total_vipers_espacio()}/{tripulados}/{st.vipers_reserva}/{st.vipers_danados}\n")
         board += (f"👾 Raiders: {st.total_raiders()}   🚁 Heavy Raiders: {st.total_heavy_raiders()}   "
                   f"🛸 Basestars: {st.total_basestars()}\n")
         board += f"🛰️ Naves civiles: {st.total_civiles()}\n"
@@ -124,10 +125,19 @@ class Board(BaseBoard):
                 lineas.append(f"  {icono} {nombre}{averia}: {quienes}")
             return "\n".join(lineas)
 
+        # Vipers tripulados por área (ficha de piloto = nombre del jugador).
+        pilotos_area = {}
+        for p in game.playerlist.values():
+            ar = getattr(p, "viper_area", None)
+            if ar is not None:
+                pilotos_area.setdefault(ar, []).append(p.name)
+
         cuerpo = "═════════════ ESPACIO ═════════════\n"
         for meta in Space.AREAS:
             area = st.areas[meta["id"]]
             piezas = naves_de_area(area)
+            for nombre_p in pilotos_area.get(meta["id"], []):
+                piezas.append(f"🧑‍🚀{nombre_p}")
             tubo = " (tubo)" if meta["launch"] else ""
             cuerpo += f"  {meta['emoji']} {meta['nombre']}{tubo}: {'  '.join(piezas) if piezas else '—'}\n"
         cuerpo += (f"  🅿️ Reserva vipers: {st.vipers_reserva}   "

--- a/BattlestarGalactica/Boardgamebox/Board.py
+++ b/BattlestarGalactica/Boardgamebox/Board.py
@@ -36,6 +36,14 @@ def naves_de_area(area):
     return piezas
 
 
+def sistemas_averiados(st):
+    """Sufijo con los sistemas de Galactica averiados (para el resumen)."""
+    if not st.galactica_damage:
+        return ""
+    nombres = [Locations.UBICACIONES[k]["nombre"].split(" (")[0] for k in st.galactica_damage]
+    return "  ⚠️ avería: " + ", ".join(nombres)
+
+
 def track_abordaje(st):
     """Representa el track de la Partida de Abordaje: una barra de casillas con
     los centuriones que avanzan hacia el puente (casilla final = abordaje)."""
@@ -70,7 +78,7 @@ class Board(BaseBoard):
         board += (f"👾 Raiders: {st.total_raiders()}   🚁 Heavy Raiders: {st.total_heavy_raiders()}   "
                   f"🛸 Basestars: {st.total_basestars()}\n")
         board += f"🛰️ Naves civiles: {st.total_civiles()}\n"
-        board += f"🛡️ Daño Galactica: {st.galactica_danos}/{st.galactica_danos_max}\n"
+        board += f"🛡️ Daño Galactica: {st.total_danos_galactica()}/{st.galactica_danos_max}{sistemas_averiados(st)}\n"
         board += f"🔺 Abordaje: {track_abordaje(st)}\n\n"
 
         pres = game.playerlist.get(st.presidente_uid)
@@ -111,8 +119,9 @@ class Board(BaseBoard):
                     continue
                 nombre = info["nombre"].split(" (")[0]
                 icono = ICONO_UBICACION.get(key, "•")
+                averia = " 💥" if key in st.galactica_damage else ""
                 quienes = ", ".join(ocupantes.get(key, [])) or "—"
-                lineas.append(f"  {icono} {nombre}: {quienes}")
+                lineas.append(f"  {icono} {nombre}{averia}: {quienes}")
             return "\n".join(lineas)
 
         cuerpo = "═════════════ ESPACIO ═════════════\n"
@@ -123,7 +132,7 @@ class Board(BaseBoard):
             cuerpo += f"  {meta['emoji']} {meta['nombre']}{tubo}: {'  '.join(piezas) if piezas else '—'}\n"
         cuerpo += (f"  🅿️ Reserva vipers: {st.vipers_reserva}   "
                    f"🛠️ dañados: {st.vipers_danados}\n")
-        cuerpo += f"  🛡️ Daño Galactica: {st.galactica_danos}/{st.galactica_danos_max}\n"
+        cuerpo += f"  🛡️ Daño Galactica: {st.total_danos_galactica()}/{st.galactica_danos_max}\n"
         cuerpo += f"  🔺 Abordaje: {track_abordaje(st)}\n\n"
         cuerpo += "──────────── GALÁCTICA ────────────\n" + _bloque(_GALACTICA) + "\n\n"
         cuerpo += "─────────── COLONIAL ONE ──────────\n" + _bloque(_COLONIAL) + "\n\n"

--- a/BattlestarGalactica/Boardgamebox/Player.py
+++ b/BattlestarGalactica/Boardgamebox/Player.py
@@ -15,3 +15,4 @@ class Player(BasePlayer):
         self.quorum_hand = []          # cartas de Quórum (Presidente)
         self.en_calabozo = False
         self.habilidad_usada = False   # habilidad de "una vez por juego"
+        self.viper_area = None         # índice de área si pilota un Viper (None = en una ubicación)

--- a/BattlestarGalactica/Boardgamebox/State.py
+++ b/BattlestarGalactica/Boardgamebox/State.py
@@ -64,9 +64,13 @@ class State(BaseState):
         self.galactica_danos = 0
         self.galactica_danos_max = 6
 
-        # --- Abordaje / centuriones en Galactica ---
-        self.centuriones = 0              # avance del abordaje
-        self.centuriones_max = 4          # al llegar, Galactica es tomada (Cylons ganan)
+        # --- Partida de Abordaje (centuriones dentro de Galactica) ---
+        # Cada centurión es una posición entera 1..boarding_breach en el track;
+        # al alcanzar la casilla final (boarding_breach) toman Galactica (derrota
+        # humana). Los Heavy Raiders aterrizan y desembarcan centuriones en la
+        # primera casilla; el Almirante puede atacarlos desde la Armería.
+        self.boarding_party = []          # posiciones de los centuriones a bordo
+        self.boarding_breach = 4          # casilla final = Galactica abordada
 
         # --- Cylons revelados ---
         self.cylons_revelados = []        # uids
@@ -85,5 +89,11 @@ class State(BaseState):
     def total_vipers_espacio(self):
         return sum(a["vipers"] for a in self.areas)
 
+    def total_heavy_raiders(self):
+        return sum(a.get("heavy_raiders", 0) for a in self.areas)
+
     def total_civiles(self):
         return sum(len(a["civiles"]) for a in self.areas)
+
+    def total_centuriones(self):
+        return len(self.boarding_party)

--- a/BattlestarGalactica/Boardgamebox/State.py
+++ b/BattlestarGalactica/Boardgamebox/State.py
@@ -60,8 +60,11 @@ class State(BaseState):
         # --- Naves civiles aún no desplegadas (con carga oculta) ---
         self.civiles_pile = []
 
-        # --- Daño a Galactica (6 tokens = destruida → derrota humana) ---
-        self.galactica_danos = 0
+        # --- Daño a Galactica por ubicaciones (tokens de avería) ---
+        # Cada token avería una ubicación de Galactica (deshabilita su acción
+        # hasta repararla). Cuando las 6 ubicaciones quedan averiadas, Galactica
+        # es destruida (derrota humana).
+        self.galactica_damage = []        # claves de ubicaciones averiadas
         self.galactica_danos_max = 6
 
         # --- Partida de Abordaje (centuriones dentro de Galactica) ---
@@ -97,3 +100,9 @@ class State(BaseState):
 
     def total_centuriones(self):
         return len(self.boarding_party)
+
+    def total_danos_galactica(self):
+        return len(self.galactica_damage)
+
+    def ubicacion_averiada(self, key):
+        return key in self.galactica_damage

--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -219,6 +219,15 @@ async def command_accion(update: Update, context: CallbackContext):
         await bot.send_message(cid, "Estás en el calabozo y no puedes realizar acciones.")
         return
 
+    # Pilotando un Viper tripulado: acciones de piloto en lugar de las de ubicación.
+    if getattr(player, "viper_area", None) is not None:
+        btns = [[InlineKeyboardButton(BSGController.ETIQUETA_ACCION[a],
+                                      callback_data=f"{cid}*bsgAccion*{a}*{uid}")]
+                for a in BSGController.ACCIONES_PILOTO]
+        await bot.send_message(cid, f"✈️ Pilotas un Viper en *{Space.nombre(player.viper_area)}* — elige tu acción:",
+                               reply_markup=InlineKeyboardMarkup(btns), parse_mode=ParseMode.MARKDOWN)
+        return
+
     ubic = Locations.UBICACIONES.get(player.ubicacion, {}).get("nombre", "—")
 
     # Cylon revelado: acciones de sabotaje según su ubicación Cylon
@@ -270,6 +279,23 @@ async def callback_bsg_accion(update: Update, context: CallbackContext):
         st = game.board.state
         if not st.active_player or st.active_player.uid != presser or presser != target:
             await callback.answer("No es tu acción.")
+            return
+
+        # Acción de piloto que requiere elegir un área adyacente → vecinos
+        if accion in BSGController.ACCIONES_PILOTO_AREA:
+            await callback.answer()
+            i = getattr(game.playerlist[presser], "viper_area", None)
+            if i is None:
+                await bot.send_message(cid, "No estás pilotando un Viper.")
+                return
+            btns = [[InlineKeyboardButton(Space.nombre(n),
+                                          callback_data=f"{cid}*bsgArea*{accion}_{n}*{presser}")]
+                    for n in Space.vecinos(i)]
+            try:
+                await bot.edit_message_text("¿A qué área adyacente vuelas?", cid, callback.message.message_id,
+                                            reply_markup=InlineKeyboardMarkup(btns))
+            except Exception:
+                await bot.send_message(cid, "¿A qué área adyacente vuelas?", reply_markup=InlineKeyboardMarkup(btns))
             return
 
         # Acciones que requieren elegir un ÁREA del espacio → mostrar botonera de áreas
@@ -351,9 +377,9 @@ async def callback_bsg_area(update: Update, context: CallbackContext):
         if not st.active_player or st.active_player.uid != presser or presser != target:
             await callback.answer("No es tu acción.")
             return
-        await callback.answer("Disparo realizado.")
+        await callback.answer("Área seleccionada.")
         try:
-            await bot.edit_message_text(f"Atacas {Space.nombre(area_idx)}.", cid, callback.message.message_id)
+            await bot.edit_message_text(f"{Space.nombre(area_idx)} seleccionada.", cid, callback.message.message_id)
         except Exception:
             pass
         await BSGController.ejecutar_accion_ubicacion(bot, game, presser, accion, objetivo=area_idx)
@@ -421,6 +447,10 @@ async def command_mover(update: Update, context: CallbackContext):
         await bot.send_message(cid, "Primero elige tus cartas de habilidad (revisa tu privado).")
         return
     player = game.playerlist[uid]
+    if getattr(player, "viper_area", None) is not None:
+        await bot.send_message(cid, "✈️ Estás pilotando un Viper: usa `/accion` para volar a otra área o aterrizar.",
+                               parse_mode=ParseMode.MARKDOWN)
+        return
     es_cylon_revelado = player.revealed
     btns = []
     for key, info in Locations.UBICACIONES.items():

--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -235,6 +235,12 @@ async def command_accion(update: Update, context: CallbackContext):
                                reply_markup=InlineKeyboardMarkup(btns), parse_mode=ParseMode.MARKDOWN)
         return
 
+    if st.ubicacion_averiada(player.ubicacion):
+        await bot.send_message(cid, f"🛠️ *{ubic}* está averiada: su acción no está disponible hasta repararla "
+                                    f"(usa el Laboratorio de Investigación). Puedes `/mover` o `/crisis`.",
+                               parse_mode=ParseMode.MARKDOWN)
+        return
+
     acciones = BSGController.ACCIONES_UBICACION.get(player.ubicacion, [])
     if not acciones:
         await bot.send_message(cid, f"📍 {ubic}: no hay acción disponible aquí. Usa `/crisis`.",

--- a/BattlestarGalactica/Constants/Crisis.py
+++ b/BattlestarGalactica/Constants/Crisis.py
@@ -749,6 +749,12 @@ SUPER_CRISIS_DECK = [
         "efectos": [{"tipo": "centuriones", "delta": 2}],
     },
     {
+        "id": "oleada_heavy_raiders",
+        "titulo": "Oleada de Heavy Raiders",
+        "texto": "Heavy Raiders se lanzan hacia el hangar de Galactica.",
+        "efectos": [{"tipo": "heavy_raiders", "cantidad": 2}],
+    },
+    {
         "id": "refuerzos_cylon",
         "titulo": "Refuerzos Cylon",
         "texto": "Una Basestar llega con refuerzos.",

--- a/BattlestarGalactica/Constants/Locations.py
+++ b/BattlestarGalactica/Constants/Locations.py
@@ -123,6 +123,11 @@ UBICACIONES = {
 
 AREAS_ESPACIO = ["espacio_1", "espacio_2", "espacio_3", "espacio_4", "espacio_5", "espacio_6"]
 
+# Ubicaciones de Galactica que pueden recibir un token de avería. Al dañarse,
+# su acción queda deshabilitada hasta repararla; con las 6 averiadas, Galactica
+# es destruida.
+GALACTICA_DAMAGEABLE = ["command", "weapons", "ftl", "hangar", "armory", "admiral_quarters"]
+
 
 def ubicaciones_humanas():
     return {k: v for k, v in UBICACIONES.items() if not v.get("es_cylon")}

--- a/BattlestarGalactica/Constants/Space.py
+++ b/BattlestarGalactica/Constants/Space.py
@@ -10,6 +10,7 @@ Cada área es un dict:
     {
       "vipers":   int,            # Vipers (sin tripular) en el área
       "raiders":  int,            # Raiders Cylon
+      "heavy_raiders": int,       # Heavy Raiders (transportan centuriones al hangar)
       "basestars": [int, ...],    # una entrada por Basestar = tokens de daño
       "civiles":  [carga, ...],   # naves civiles (carga oculta) en el área
     }
@@ -32,7 +33,7 @@ AREA_POPA = 3           # naves civiles iniciales
 
 
 def nueva_area():
-    return {"vipers": 0, "raiders": 0, "basestars": [], "civiles": []}
+    return {"vipers": 0, "raiders": 0, "heavy_raiders": 0, "basestars": [], "civiles": []}
 
 
 def distancia(i, j):

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -834,22 +834,135 @@ async def mover_jugador(bot, game, uid, destino):
     await save(bot, game.cid)
 
 
-async def activar_naves_cylon(bot, game):
-    """Activación de naves Cylon de una crisis: se activan los Raiders y los Heavy
-    Raiders (programas posicionales), avanzan los centuriones del abordaje y, por
-    último, las Basestars atacan a Galactica."""
+# Iconos de activación Cylon que puede llevar una carta de crisis.
+ICONOS_CYLON = {
+    "raiders": "Activar Raiders",
+    "heavy_raiders": "Activar Heavy Raiders",
+    "centuriones": "Activar Centuriones",
+    "basestars": "Activar Basestars",
+    "launch_raiders": "Lanzar Raiders",
+    "launch_heavy": "Lanzar Heavy Raiders",
+}
+
+
+def _iconos_desde_texto(texto):
+    """Deriva los iconos de activación Cylon a partir del texto de la crisis
+    (las cartas del set indican qué naves se activan/lanzan al pie de la carta)."""
+    t = (texto or "").lower()
+    iconos = []
+    if ("activate heavy raider" in t) or ("activar heavy raider" in t):
+        iconos.append("heavy_raiders")
+    if ("activate raiders" in t) or ("activar raiders" in t) or ("activa raiders" in t):
+        iconos.append("raiders")
+    if ("activate basestars" in t) or ("activar basestars" in t):
+        iconos.append("basestars")
+    if ("activate centurion" in t) or ("activar centurion" in t):
+        iconos.append("centuriones")
+    if ("launch raiders" in t) or ("lanzar raiders" in t):
+        iconos.append("launch_raiders")
+    if ("launch" in t and "heavy raider" in t):
+        iconos.append("launch_heavy")
+    # Quitar duplicados conservando el orden de aparición.
+    vistos, salida = set(), []
+    for i in iconos:
+        if i not in vistos:
+            vistos.add(i)
+            salida.append(i)
+    return salida
+
+
+# Distribución de iconos de activación que aproxima la del juego base (la mayoría
+# de las cartas activan Raiders; algunas Basestars o lanzan refuerzos; pocas
+# activan Heavy Raiders o Centuriones). Las cartas físicas llevan estos iconos al
+# pie; como no están en los datos, se asignan de forma estable por carta.
+_PERFIL_ICONOS = [
+    ["raiders"], ["raiders"], ["raiders"], ["raiders"],
+    ["basestars"], ["basestars"],
+    ["launch_raiders"], ["launch_raiders"],
+    ["raiders", "basestars"],
+    ["heavy_raiders"],
+    ["launch_heavy"],
+    ["centuriones"],
+]
+
+
+def _hash_estable(s):
+    """Hash determinista (estable entre ejecuciones, a diferencia de hash())."""
+    h = 0
+    for ch in s or "":
+        h = (h * 31 + ord(ch)) & 0xFFFFFFFF
+    return h
+
+
+def _activaciones_para_crisis(crisis):
+    """Iconos de activación Cylon de una crisis: si el texto los nombra de forma
+    explícita se usan esos; si no, se asigna un perfil estable según la carta."""
+    ic = _iconos_desde_texto(crisis.get("texto", ""))
+    if ic:
+        return ic
+    clave = crisis.get("id") or crisis.get("titulo") or crisis.get("texto") or ""
+    return list(_PERFIL_ICONOS[_hash_estable(clave) % len(_PERFIL_ICONOS)])
+
+
+async def _lanzar_raiders_por_basestar(bot, game):
+    """Lanzar Raiders: cada Basestar suelta 2 Raiders en su propia área."""
     st = game.board.state
-    await bot.send_message(game.cid, "🤖 *Se activan las naves Cylon…*", parse_mode=ParseMode.MARKDOWN)
-    await _activar_raiders(bot, game)
-    if st.ganador or await _chequear_fin(bot, game):
+    total = 0
+    for a in st.areas:
+        for _ in a["basestars"]:
+            a["raiders"] += 2
+            total += 2
+    if total:
+        await bot.send_message(game.cid, f"🛸 Las Basestars lanzan {total} Raiders (total: {st.total_raiders()}).")
+    else:
+        await bot.send_message(game.cid, "🛸 No hay Basestars para lanzar Raiders.")
+
+
+async def _lanzar_heavy_por_basestar(bot, game):
+    """Lanzar Heavy Raiders: cada Basestar suelta 1 Heavy Raider en su área."""
+    st = game.board.state
+    total = 0
+    for i, a in enumerate(st.areas):
+        for _ in a["basestars"]:
+            a["heavy_raiders"] = a.get("heavy_raiders", 0) + 1
+            total += 1
+    if total:
+        await bot.send_message(game.cid, f"🚁 Las Basestars lanzan {total} Heavy Raider(s) (total: {st.total_heavy_raiders()}).")
+    else:
+        await bot.send_message(game.cid, "🚁 No hay Basestars para lanzar Heavy Raiders.")
+
+
+async def activar_naves_cylon(bot, game, iconos):
+    """Resuelve la activación Cylon de una crisis según sus iconos. Primero se
+    activan las naves existentes (Raiders → Heavy Raiders → Centuriones →
+    Basestars) y al final se lanzan refuerzos (Raiders / Heavy Raiders), para que
+    las naves recién traídas no actúen en la misma activación."""
+    st = game.board.state
+    if not iconos:
         return
-    await _activar_heavy_raiders(bot, game)
-    if st.ganador or await _chequear_fin(bot, game):
-        return
-    await _activar_centuriones(bot, game)
-    if st.ganador or await _chequear_fin(bot, game):
-        return
-    await _activar_basestars(bot, game)
+    desc = ", ".join(ICONOS_CYLON.get(i, i) for i in iconos)
+    await bot.send_message(game.cid, f"🤖 *Activación Cylon:* {desc}.", parse_mode=ParseMode.MARKDOWN)
+
+    if "raiders" in iconos:
+        await _activar_raiders(bot, game)
+        if st.ganador or await _chequear_fin(bot, game):
+            return
+    if "heavy_raiders" in iconos:
+        await _activar_heavy_raiders(bot, game)
+        if st.ganador or await _chequear_fin(bot, game):
+            return
+    if "centuriones" in iconos:
+        await _activar_centuriones(bot, game)
+        if st.ganador or await _chequear_fin(bot, game):
+            return
+    if "basestars" in iconos:
+        await _activar_basestars(bot, game)
+        if st.ganador or await _chequear_fin(bot, game):
+            return
+    if "launch_raiders" in iconos:
+        await _lanzar_raiders_por_basestar(bot, game)
+    if "launch_heavy" in iconos:
+        await _lanzar_heavy_por_basestar(bot, game)
     await _chequear_fin(bot, game)
 
 
@@ -1639,9 +1752,14 @@ async def cerrar_crisis(bot, game, crisis):
     st.crisis_discard.append(crisis)
     st.crisis_actual = None
 
-    # Activación de naves Cylon si la crisis lo indica
-    if crisis.get("activar_cylons"):
-        await activar_naves_cylon(bot, game)
+    # Activación de naves Cylon según los iconos de la crisis. Las cartas nuevas
+    # pueden traer la lista explícita en "activaciones"; las heredadas marcan
+    # "activar_cylons" y derivamos los iconos del texto de la carta.
+    iconos = crisis.get("activaciones")
+    if iconos is None and crisis.get("activar_cylons"):
+        iconos = _activaciones_para_crisis(crisis)
+    if iconos:
+        await activar_naves_cylon(bot, game, iconos)
         if await _chequear_fin(bot, game):
             return
 
@@ -1717,6 +1835,8 @@ async def aplicar_efectos(bot, game, efectos):
         elif tipo == "jump_prep":
             st.jump_prep = max(0, min(st.jump_prep_max, st.jump_prep + ef["delta"]))
             await bot.send_message(game.cid, f"⏫ Preparación de salto: {st.jump_prep}/{st.jump_prep_max}")
+        elif tipo == "activar":
+            await activar_naves_cylon(bot, game, ef.get("iconos", []))
         elif tipo == "destruir_civil":
             await _destruir_civil(bot, game)
         elif tipo == "roll":

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -504,12 +504,38 @@ async def _danar_basestar(bot, game, area_idx, cantidad=1):
 
 
 async def _danar_galactica(bot, game, fuente="ataque"):
-    """Galactica recibe 1 token de daño; con 6 es destruida (derrota humana)."""
+    """Galactica recibe un token de avería en una ubicación al azar (deshabilita
+    su acción). Con las 6 ubicaciones averiadas, Galactica es destruida."""
     st = game.board.state
-    st.galactica_danos += 1
+    disponibles = [k for k in Locations.GALACTICA_DAMAGEABLE if k not in st.galactica_damage]
+    if not disponibles:
+        await bot.send_message(game.cid, f"🛡️💥 Galactica recibe daño ({fuente}): ya no quedan sistemas operativos.")
+        return
+    loc = random.choice(disponibles)
+    st.galactica_damage.append(loc)
+    nombre = Locations.UBICACIONES[loc]["nombre"].split(" (")[0]
     await bot.send_message(
         game.cid,
-        f"🛡️💥 *Galactica recibe daño* ({fuente}): {st.galactica_danos}/{st.galactica_danos_max}.",
+        f"🛡️💥 *Galactica recibe daño* ({fuente}): se avería *{nombre}* "
+        f"({st.total_danos_galactica()}/{st.galactica_danos_max}).",
+        parse_mode=ParseMode.MARKDOWN,
+    )
+
+
+async def _reparar_galactica(bot, game, player, loc=None):
+    """Repara una ubicación averiada de Galactica (equipo de control de daños)."""
+    st = game.board.state
+    if not st.galactica_damage:
+        await bot.send_message(game.cid, "🔧 No hay sistemas averiados que reparar.")
+        return
+    if loc is None or loc not in st.galactica_damage:
+        loc = st.galactica_damage[0]
+    st.galactica_damage.remove(loc)
+    nombre = Locations.UBICACIONES[loc]["nombre"].split(" (")[0]
+    await bot.send_message(
+        game.cid,
+        f"🔧 {player.name} repara *{nombre}* "
+        f"({st.total_danos_galactica()}/{st.galactica_danos_max} averiadas).",
         parse_mode=ParseMode.MARKDOWN,
     )
 
@@ -521,7 +547,7 @@ ACCIONES_UBICACION = {
     "command": ["activate_vipers"],
     "communications": ["peek_civiles"],
     "admiral_quarters": ["brig_check"],
-    "research": ["draw_eng", "draw_tac"],
+    "research": ["draw_eng", "draw_tac", "repair"],
     "hangar": ["launch"],
     "armory": ["armory_attack"],
     "sickbay": [],
@@ -546,6 +572,7 @@ ETIQUETA_ACCION = {
     "brig_check": "🚔 Enviar a alguien al Calabozo (chequeo)",
     "draw_eng": "🟡 Robar 1 carta de Ingeniería",
     "draw_tac": "🔴 Robar 1 carta de Táctica",
+    "repair": "🔧 Reparar un sistema de Galactica",
     "launch": "✈️ Lanzarte en un Viper",
     "armory_attack": "🪖 Atacar a un centurión",
     "draw_politics": "🟢 Robar 2 cartas de Política",
@@ -558,6 +585,13 @@ async def ejecutar_accion_ubicacion(bot, game, uid, accion, objetivo=None):
     """Resuelve la acción de ubicación elegida por el jugador activo."""
     st = game.board.state
     player = game.playerlist[uid]
+
+    # Una ubicación averiada no permite usar su acción hasta repararla.
+    if st.ubicacion_averiada(player.ubicacion):
+        nombre = Locations.UBICACIONES[player.ubicacion]["nombre"].split(" (")[0]
+        await bot.send_message(game.cid, f"🛠️ *{nombre}* está averiada: hay que repararla antes de usar su acción.",
+                               parse_mode=ParseMode.MARKDOWN)
+        return
 
     if accion == "jump":
         # FTL Control: saltar si el track no está en zona roja (proxy: prep >= 2)
@@ -584,6 +618,8 @@ async def ejecutar_accion_ubicacion(bot, game, uid, accion, objetivo=None):
         await _robar_color(bot, game, player, Skills.INGENIERIA)
     elif accion == "draw_tac":
         await _robar_color(bot, game, player, Skills.TACTICA)
+    elif accion == "repair":
+        await _reparar_galactica(bot, game, player)
     elif accion == "launch":
         await _lanzar_viper(bot, game)
         await bot.send_message(game.cid, f"✈️ {player.name} se lanza en un Viper.")
@@ -1933,9 +1969,9 @@ async def _chequear_fin(bot, game):
     if any(p >= st.boarding_breach for p in st.boarding_party):
         await terminar(bot, game, "Cylons", "Los centuriones llegaron al puente: Galactica fue abordada.")
         return True
-    # Derrota: Galactica destruida (6 tokens de daño)
-    if st.galactica_danos >= st.galactica_danos_max:
-        await terminar(bot, game, "Cylons", "Galactica fue destruida.")
+    # Derrota: Galactica destruida (6 ubicaciones averiadas)
+    if st.total_danos_galactica() >= st.galactica_danos_max:
+        await terminar(bot, game, "Cylons", "Todos los sistemas de Galactica fueron destruidos.")
         return True
     # Victoria humana
     if st.distancia >= st.objetivo_distancia:

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -10,12 +10,13 @@ Implementado en esta capa:
 - Chequeos de habilidad con mazo de Destino.
 - Fase del Agente Durmiente (distancia 4).
 - Salto FTL, condiciones de victoria/derrota.
+- Combate espacial posicional: Vipers tripulados, Heavy Raiders, abordaje.
+- Daño a Galactica por ubicaciones e iconos de activación Cylon por crisis.
 
 Pendiente para capas siguientes (claramente acotado):
-- Vipers tripulados con fichas de piloto; daño a Galactica por ubicaciones.
 - Acciones de ubicación completas, Quórum, súper crisis.
 - Habilidades específicas de cada personaje y cartas de habilidad con efecto.
-- Roster completo de cartas de crisis.
+- Roster completo de cartas de crisis con sus efectos de éxito/fracaso.
 """
 
 import logging as log
@@ -563,6 +564,12 @@ ACCIONES_CON_OBJETIVO = {"brig_check": "brig", "president_check": "president"}
 # Acciones que requieren elegir un ÁREA del espacio (Control de Armas) → tipo de nave
 ACCIONES_CON_AREA = {"shoot_raider": "raiders", "shoot_basestar": "basestars"}
 
+# Acciones disponibles mientras se pilota un Viper tripulado.
+ACCIONES_PILOTO = ["pilot_attack", "pilot_move", "pilot_land"]
+
+# Acción de piloto que requiere elegir un área adyacente.
+ACCIONES_PILOTO_AREA = {"pilot_move"}
+
 ETIQUETA_ACCION = {
     "jump": "🌌 Saltar la flota (FTL)",
     "shoot_raider": "🔫 Disparar a un Raider",
@@ -578,6 +585,9 @@ ETIQUETA_ACCION = {
     "draw_politics": "🟢 Robar 2 cartas de Política",
     "draw_quorum": "🏛️ Robar una carta de Quórum",
     "president_check": "🏛️ Dar la Presidencia (chequeo)",
+    "pilot_attack": "🔫 Atacar Cylon en tu área",
+    "pilot_move": "✈️ Volar a un área adyacente",
+    "pilot_land": "🛬 Aterrizar en Galactica",
 }
 
 
@@ -621,8 +631,13 @@ async def ejecutar_accion_ubicacion(bot, game, uid, accion, objetivo=None):
     elif accion == "repair":
         await _reparar_galactica(bot, game, player)
     elif accion == "launch":
-        await _lanzar_viper(bot, game)
-        await bot.send_message(game.cid, f"✈️ {player.name} se lanza en un Viper.")
+        await _lanzar_piloto(bot, game, player)
+    elif accion == "pilot_attack":
+        await _pilot_atacar(bot, game, player)
+    elif accion == "pilot_move":
+        await _pilot_mover(bot, game, player, objetivo)
+    elif accion == "pilot_land":
+        await _pilot_aterrizar(bot, game, player)
     elif accion == "armory_attack":
         if not st.boarding_party:
             await bot.send_message(game.cid, "No hay centuriones a bordo de Galactica.")
@@ -785,6 +800,82 @@ async def _lanzar_viper(bot, game, area_idx=None):
     st.areas[area_idx]["vipers"] += 1
     await bot.send_message(game.cid, f"✈️ Viper lanzado en {Space.nombre(area_idx)} (en vuelo: {st.total_vipers_espacio()}).")
     return True
+
+
+# ---- Vipers tripulados (fichas de piloto) ----
+
+def _pilotos_en_area(game, i):
+    """Jugadores que pilotan un Viper en el área i."""
+    return [p for p in game.playerlist.values() if getattr(p, "viper_area", None) == i]
+
+
+def total_vipers_tripulados(game):
+    return sum(1 for p in game.playerlist.values() if getattr(p, "viper_area", None) is not None)
+
+
+async def _lanzar_piloto(bot, game, player):
+    """El jugador despega en un Viper tripulado desde un tubo de lanzamiento."""
+    st = game.board.state
+    if getattr(player, "viper_area", None) is not None:
+        await bot.send_message(game.cid, "Ya estás pilotando un Viper.")
+        return False
+    if st.vipers_reserva <= 0:
+        await bot.send_message(game.cid, "No quedan Vipers en la reserva.")
+        return False
+    # Despega por el tubo con menos presencia Cylon.
+    area = min(Space.LAUNCH_AREAS,
+               key=lambda k: st.areas[k]["raiders"] + st.areas[k].get("heavy_raiders", 0) + len(st.areas[k]["basestars"]))
+    st.vipers_reserva -= 1
+    player.viper_area = area
+    player.ubicacion = None
+    await bot.send_message(game.cid, f"✈️ {player.name} despega en un Viper desde {Space.nombre(area)}.")
+    return True
+
+
+async def _pilot_atacar(bot, game, player):
+    """El Viper tripulado ataca una nave Cylon de su área (Raider 3+, Heavy 4+, Basestar 6+)."""
+    st = game.board.state
+    i = player.viper_area
+    area = st.areas[i]
+    r = _d8()
+    if area["raiders"] > 0:
+        if r >= 3:
+            area["raiders"] -= 1
+            await bot.send_message(game.cid, f"✈️🔫 Tirada {r}: {player.name} derriba un Raider en {Space.nombre(i)} (quedan {area['raiders']}).")
+        else:
+            await bot.send_message(game.cid, f"✈️ Tirada {r}: {player.name} falla contra el Raider.")
+    elif area.get("heavy_raiders", 0) > 0:
+        if r >= 4:
+            area["heavy_raiders"] -= 1
+            await bot.send_message(game.cid, f"✈️🔫 Tirada {r}: {player.name} derriba un Heavy Raider en {Space.nombre(i)}.")
+        else:
+            await bot.send_message(game.cid, f"✈️ Tirada {r}: {player.name} falla contra el Heavy Raider.")
+    elif area["basestars"]:
+        if r >= 6:
+            await _danar_basestar(bot, game, i)
+        else:
+            await bot.send_message(game.cid, f"✈️ Tirada {r}: {player.name} no logra dañar la Basestar.")
+    else:
+        await bot.send_message(game.cid, "No hay naves Cylon en tu área para atacar.")
+
+
+async def _pilot_mover(bot, game, player, destino):
+    """El Viper tripulado vuela a un área adyacente del anillo."""
+    i = player.viper_area
+    if destino is None or destino not in Space.vecinos(i):
+        await bot.send_message(game.cid, "Solo puedes volar a un área adyacente.")
+        return
+    player.viper_area = destino
+    await bot.send_message(game.cid, f"✈️ {player.name} vuela de {Space.nombre(i)} a {Space.nombre(destino)}.")
+
+
+async def _pilot_aterrizar(bot, game, player):
+    """El Viper tripulado aterriza: vuelve a la reserva y el piloto al Hangar."""
+    st = game.board.state
+    st.vipers_reserva += 1
+    player.viper_area = None
+    player.ubicacion = "hangar"
+    await bot.send_message(game.cid, f"🛬 {player.name} aterriza en la Cubierta de Hangar.")
 
 
 async def _activar_vipers_comando(bot, game):
@@ -1034,7 +1125,25 @@ async def _activar_un_raider(bot, game, i):
     area = st.areas[i]
     if area["raiders"] <= 0:
         return
-    # 1. Atacar un Viper en el área (5-7 dañado, 8 destruido)
+    # 1. Atacar un Viper tripulado del área (objetivo prioritario: 8 destruido
+    #    → piloto a Enfermería; 5-7 dañado → piloto al Hangar).
+    pilotos = _pilotos_en_area(game, i)
+    if pilotos:
+        piloto = random.choice(pilotos)
+        r = _d8()
+        if r == 8:
+            piloto.viper_area = None
+            piloto.ubicacion = "sickbay"
+            await bot.send_message(game.cid, f"👾 Tirada {r}: ¡el Viper de {piloto.name} es destruido en {Space.nombre(i)}! Va a Enfermería.")
+        elif r >= 5:
+            piloto.viper_area = None
+            piloto.ubicacion = "hangar"
+            st.vipers_danados += 1
+            await bot.send_message(game.cid, f"👾 Tirada {r}: el Viper de {piloto.name} queda dañado; aterriza en el Hangar.")
+        else:
+            await bot.send_message(game.cid, f"👾 Tirada {r}: el Raider falla contra el Viper de {piloto.name} en {Space.nombre(i)}.")
+        return
+    # 2. Atacar un Viper sin tripular en el área (5-7 dañado, 8 destruido)
     if area["vipers"] > 0:
         r = _d8()
         if r == 8:
@@ -1047,11 +1156,11 @@ async def _activar_un_raider(bot, game, i):
         else:
             await bot.send_message(game.cid, f"👾 Tirada {r}: el Raider falla contra el Viper en {Space.nombre(i)}.")
         return
-    # 2. Destruir una nave civil en el área (sin tirada)
+    # 3. Destruir una nave civil en el área (sin tirada)
     if area["civiles"]:
         await _destruir_civil(bot, game, i)
         return
-    # 3. Moverse hacia la nave civil más cercana (desempate horario)
+    # 4. Moverse hacia la nave civil más cercana (desempate horario)
     objetivos = _areas_con(st, "civiles")
     if objetivos:
         destino = _paso_hacia(i, objetivos)
@@ -1060,7 +1169,7 @@ async def _activar_un_raider(bot, game, i):
             st.areas[destino]["raiders"] += 1   # no se reactiva este turno
             await bot.send_message(game.cid, f"👾 Un Raider avanza de {Space.nombre(i)} a {Space.nombre(destino)}.")
             return
-    # 4. Sin naves civiles: atacar Galactica (daña con 8)
+    # 5. Sin naves civiles: atacar Galactica (daña con 8)
     r = _d8()
     if r == 8:
         await _danar_galactica(bot, game, "Raider")
@@ -1225,6 +1334,10 @@ async def revelar_cylon(bot, game, uid):
     if uid == st.almirante_uid:
         st.almirante_uid = None
         player.titulos = [t for t in player.titulos if t != "Almirante"]
+    # Si estaba pilotando, abandona el Viper (vuelve a la reserva).
+    if getattr(player, "viper_area", None) is not None:
+        player.viper_area = None
+        st.vipers_reserva += 1
     # Se traslada al lado Cylon
     player.ubicacion = "cylon_fleet"
     player.skill_hand = []
@@ -1917,6 +2030,12 @@ async def ejecutar_salto(bot, game, auto=False):
         a["basestars"] = []
     st.vipers_reserva += st.vipers_danados
     st.vipers_danados = 0
+    # Los Vipers tripulados regresan al Hangar con la flota.
+    for p in game.playerlist.values():
+        if getattr(p, "viper_area", None) is not None:
+            p.viper_area = None
+            p.ubicacion = "hangar"
+            st.vipers_reserva += 1
 
     etiqueta = "AUTOMÁTICO" if auto else "FTL"
     await bot.send_message(

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -12,7 +12,7 @@ Implementado en esta capa:
 - Salto FTL, condiciones de victoria/derrota.
 
 Pendiente para capas siguientes (claramente acotado):
-- Combate espacial detallado (vipers/raiders/basestars), abordaje.
+- Vipers tripulados con fichas de piloto; daño a Galactica por ubicaciones.
 - Acciones de ubicación completas, Quórum, súper crisis.
 - Habilidades específicas de cada personaje y cartas de habilidad con efecto.
 - Roster completo de cartas de crisis.
@@ -471,10 +471,13 @@ def _d8():
 
 def _areas_con(st, tipo):
     """Índices de áreas que contienen al menos una nave del tipo dado
-    ('raiders', 'basestars', 'vipers', 'civiles')."""
+    ('raiders', 'heavy_raiders', 'basestars', 'vipers', 'civiles')."""
     res = []
     for i, a in enumerate(st.areas):
-        cant = a[tipo] if tipo in ("raiders", "vipers") else len(a[tipo])
+        if tipo in ("raiders", "vipers", "heavy_raiders"):
+            cant = a.get(tipo, 0)
+        else:
+            cant = len(a.get(tipo, []))
         if cant > 0:
             res.append(i)
     return res
@@ -585,15 +588,15 @@ async def ejecutar_accion_ubicacion(bot, game, uid, accion, objetivo=None):
         await _lanzar_viper(bot, game)
         await bot.send_message(game.cid, f"✈️ {player.name} se lanza en un Viper.")
     elif accion == "armory_attack":
-        if st.centuriones <= 0:
-            await bot.send_message(game.cid, "No hay centuriones en el track de abordaje.")
+        if not st.boarding_party:
+            await bot.send_message(game.cid, "No hay centuriones a bordo de Galactica.")
         else:
             r = _d8()
             if r >= 7:
-                st.centuriones -= 1
-                await bot.send_message(game.cid, f"🪖 Tirada {r}: ¡centurión destruido! ({st.centuriones}/{st.centuriones_max})")
+                _destruir_centurion_avanzado(st)
+                await bot.send_message(game.cid, f"🪖 Tirada {r}: ¡centurión destruido! (a bordo: {st.total_centuriones()})")
             else:
-                await bot.send_message(game.cid, f"🪖 Tirada {r}: el centurión resiste.")
+                await bot.send_message(game.cid, f"🪖 Tirada {r}: el centurión resiste el fuego.")
     elif accion == "draw_politics":
         await _robar_color(bot, game, player, Skills.POLITICA)
         await _robar_color(bot, game, player, Skills.POLITICA)
@@ -832,11 +835,18 @@ async def mover_jugador(bot, game, uid, destino):
 
 
 async def activar_naves_cylon(bot, game):
-    """Activación de naves Cylon de una crisis: se activan los Raiders (programa
-    posicional) y luego las Basestars atacan a Galactica."""
+    """Activación de naves Cylon de una crisis: se activan los Raiders y los Heavy
+    Raiders (programas posicionales), avanzan los centuriones del abordaje y, por
+    último, las Basestars atacan a Galactica."""
     st = game.board.state
     await bot.send_message(game.cid, "🤖 *Se activan las naves Cylon…*", parse_mode=ParseMode.MARKDOWN)
     await _activar_raiders(bot, game)
+    if st.ganador or await _chequear_fin(bot, game):
+        return
+    await _activar_heavy_raiders(bot, game)
+    if st.ganador or await _chequear_fin(bot, game):
+        return
+    await _activar_centuriones(bot, game)
     if st.ganador or await _chequear_fin(bot, game):
         return
     await _activar_basestars(bot, game)
@@ -925,6 +935,87 @@ async def _activar_basestars(bot, game):
                 await bot.send_message(game.cid, f"🛸 Tirada {r}: la Basestar falla contra Galactica.")
 
 
+# ---- Heavy Raiders y Partida de Abordaje (centuriones) ----
+
+def _colocar_centurion(st, cantidad=1):
+    """Coloca 'cantidad' centuriones en la primera casilla del track de abordaje."""
+    for _ in range(cantidad):
+        st.boarding_party.append(1)
+
+
+async def _lanzar_heavy_raider(bot, game, cantidad=1, area_idx=None):
+    """Hace aparecer Heavy Raiders en un área (por defecto, la Proa)."""
+    st = game.board.state
+    if area_idx is None:
+        area_idx = Space.AREA_PROA
+    st.areas[area_idx]["heavy_raiders"] = st.areas[area_idx].get("heavy_raiders", 0) + cantidad
+    await bot.send_message(
+        game.cid,
+        f"🚁 Aparece(n) {cantidad} Heavy Raider(s) en {Space.nombre(area_idx)} "
+        f"(total: {st.total_heavy_raiders()}).",
+    )
+
+
+async def _activar_heavy_raiders(bot, game):
+    """Programa de los Heavy Raiders: el que está en un área con tubo de
+    lanzamiento accede al hangar, aterriza y desembarca un centurión en el track
+    de abordaje (y se retira); el resto avanza un área hacia el tubo más cercano."""
+    st = game.board.state
+    if st.total_heavy_raiders() == 0:
+        return
+    # 1. Aterrizajes desde las áreas con acceso al hangar (tubos de lanzamiento)
+    for i in Space.LAUNCH_AREAS:
+        while st.areas[i].get("heavy_raiders", 0) > 0:
+            st.areas[i]["heavy_raiders"] -= 1
+            _colocar_centurion(st, 1)
+            await bot.send_message(
+                game.cid,
+                f"🚁 Un Heavy Raider aterriza desde {Space.nombre(i)}: desembarca un "
+                f"centurión en Galactica (a bordo: {st.total_centuriones()}).",
+            )
+            if await _chequear_fin(bot, game):
+                return
+    # 2. El resto avanza un área hacia el tubo de lanzamiento más cercano
+    for i in range(Space.N_AREAS):
+        if i in Space.LAUNCH_AREAS:
+            continue
+        cant = st.areas[i].get("heavy_raiders", 0)
+        if cant <= 0:
+            continue
+        destino = _paso_hacia(i, Space.LAUNCH_AREAS)
+        if destino is not None and destino != i:
+            st.areas[i]["heavy_raiders"] = 0
+            st.areas[destino]["heavy_raiders"] = st.areas[destino].get("heavy_raiders", 0) + cant
+            await bot.send_message(
+                game.cid,
+                f"🚁 {cant} Heavy Raider(s) avanzan de {Space.nombre(i)} a {Space.nombre(destino)}.",
+            )
+
+
+async def _activar_centuriones(bot, game):
+    """Programa de la Partida de Abordaje: cada centurión avanza una casilla hacia
+    el puente. Al alcanzar la casilla final, los Cylons toman Galactica."""
+    st = game.board.state
+    if not st.boarding_party:
+        return
+    st.boarding_party = sorted((p + 1 for p in st.boarding_party), reverse=True)
+    cercano = min(st.boarding_party[0], st.boarding_breach)
+    await bot.send_message(
+        game.cid,
+        f"🔺 Los centuriones avanzan por los pasillos de Galactica: {st.total_centuriones()} "
+        f"a bordo (el más cercano al puente en la casilla {cercano}/{st.boarding_breach}).",
+    )
+
+
+def _destruir_centurion_avanzado(st):
+    """Elimina el centurión más cercano al puente (el de mayor posición). True si lo hizo."""
+    if not st.boarding_party:
+        return False
+    k = max(range(len(st.boarding_party)), key=lambda j: st.boarding_party[j])
+    st.boarding_party.pop(k)
+    return True
+
+
 async def _destruir_civil(bot, game, area_idx=None):
     """Destruye una nave civil (de un área concreta o, si no, de un área al azar)."""
     st = game.board.state
@@ -948,7 +1039,7 @@ async def _destruir_civil(bot, game, area_idx=None):
 
 # Acciones disponibles para un Cylon revelado, según su ubicación Cylon.
 ACCIONES_CYLON = {
-    "cylon_fleet": ["launch_raiders", "launch_basestar"],
+    "cylon_fleet": ["launch_raiders", "launch_heavy", "launch_basestar"],
     "caprica": ["sabotage", "board"],
     "resurrection_ship": ["launch_raiders", "sabotage"],
     "human_fleet": ["sabotage", "board"],
@@ -956,9 +1047,10 @@ ACCIONES_CYLON = {
 
 ETIQUETA_ACCION_CYLON = {
     "launch_raiders": "👾 Lanzar 2 Raiders",
+    "launch_heavy": "🚁 Lanzar un Heavy Raider",
     "launch_basestar": "🛸 Traer una Basestar",
     "sabotage": "🔧💥 Sabotear un recurso (-1)",
-    "board": "🔺 Avanzar abordaje (+1)",
+    "board": "🔺 Desembarcar un centurión",
 }
 
 
@@ -1017,6 +1109,8 @@ async def ejecutar_accion_cylon(bot, game, uid, accion):
         area_idx = objetivos[0] if objetivos else Space.AREA_PROA
         st.areas[area_idx]["raiders"] += 2
         await bot.send_message(game.cid, f"👾 El Cylon lanza 2 Raiders en {Space.nombre(area_idx)} (total: {st.total_raiders()}).")
+    elif accion == "launch_heavy":
+        await _lanzar_heavy_raider(bot, game, 1)
     elif accion == "launch_basestar":
         st.areas[Space.AREA_PROA]["basestars"].append(0)
         await bot.send_message(game.cid, f"🛸 El Cylon trae una Basestar a {Space.nombre(Space.AREA_PROA)} (total: {st.total_basestars()}).")
@@ -1028,8 +1122,8 @@ async def ejecutar_accion_cylon(bot, game, uid, accion):
         objetivo = min(candidatos, key=candidatos.get) if candidatos else "moral"
         await modificar_recurso(bot, game, objetivo, -1)
     elif accion == "board":
-        st.centuriones = min(st.centuriones_max, st.centuriones + 1)
-        await bot.send_message(game.cid, f"🔺 Abordaje Cylon: {st.centuriones}/{st.centuriones_max}")
+        _colocar_centurion(st, 1)
+        await bot.send_message(game.cid, f"🔺 El Cylon introduce un centurión en Galactica (a bordo: {st.total_centuriones()}).")
     else:
         await bot.send_message(game.cid, "Acción Cylon no disponible.")
     await save(bot, game.cid)
@@ -1600,8 +1694,26 @@ async def aplicar_efectos(bot, game, efectos):
                 st.areas[Space.AREA_PROA]["basestars"].append(0)
             await bot.send_message(game.cid, f"🛸 Aparece(n) {ef['cantidad']} Basestar(s) en {Space.nombre(Space.AREA_PROA)} (total: {st.total_basestars()}).")
         elif tipo == "centuriones":
-            st.centuriones = max(0, st.centuriones + ef["delta"])
-            await bot.send_message(game.cid, f"🔺 Centuriones: {st.centuriones}/{st.centuriones_max}")
+            delta = ef["delta"]
+            if delta >= 0:
+                _colocar_centurion(st, delta)
+                await bot.send_message(game.cid, f"🔺 Se colocan {delta} centurión/es en el track de abordaje (a bordo: {st.total_centuriones()}).")
+            else:
+                for _ in range(-delta):
+                    if not _destruir_centurion_avanzado(st):
+                        break
+                await bot.send_message(game.cid, f"🔺 Se eliminan centuriones (a bordo: {st.total_centuriones()}).")
+        elif tipo == "heavy_raiders":
+            cant = ef["cantidad"]
+            if cant >= 0:
+                await _lanzar_heavy_raider(bot, game, cant)
+            else:
+                restantes = -cant
+                for a in st.areas:
+                    while restantes > 0 and a.get("heavy_raiders", 0) > 0:
+                        a["heavy_raiders"] -= 1
+                        restantes -= 1
+                await bot.send_message(game.cid, f"🚁 Se destruyen Heavy Raiders (total: {st.total_heavy_raiders()}).")
         elif tipo == "jump_prep":
             st.jump_prep = max(0, min(st.jump_prep_max, st.jump_prep + ef["delta"]))
             await bot.send_message(game.cid, f"⏫ Preparación de salto: {st.jump_prep}/{st.jump_prep_max}")
@@ -1645,6 +1757,7 @@ async def ejecutar_salto(bot, game, auto=False):
         st.vipers_reserva += a["vipers"]
         a["vipers"] = 0
         a["raiders"] = 0
+        a["heavy_raiders"] = 0
         a["basestars"] = []
     st.vipers_reserva += st.vipers_danados
     st.vipers_danados = 0
@@ -1696,9 +1809,9 @@ async def _chequear_fin(bot, game):
         if getattr(st, recurso) <= 0:
             await terminar(bot, game, "Cylons", f"El recurso *{nombre}* llegó a 0.")
             return True
-    # Derrota: Galactica tomada por los centuriones
-    if st.centuriones >= st.centuriones_max:
-        await terminar(bot, game, "Cylons", "Los centuriones tomaron Galactica.")
+    # Derrota: los centuriones llegan al puente (casilla final del track)
+    if any(p >= st.boarding_breach for p in st.boarding_party):
+        await terminar(bot, game, "Cylons", "Los centuriones llegaron al puente: Galactica fue abordada.")
         return True
     # Derrota: Galactica destruida (6 tokens de daño)
     if st.galactica_danos >= st.galactica_danos_max:


### PR DESCRIPTION
Completa el combate espacial de Battlestar Galactica con un modelo posicional fiel al reglamento, reemplazando las aproximaciones simplificadas previas.

## Capas incluidas

### 🔺 Heavy Raiders y Partida de Abordaje posicional
- Heavy Raiders como nave posicional: aparecen (Proa), avanzan hacia el tubo de lanzamiento más cercano y, al llegar, aterrizan y desembarcan un centurión.
- Track de abordaje real (posiciones 1–4): los centuriones avanzan al activarse y, al llegar al puente, los Cylons toman Galactica.
- La Armería destruye al centurión más cercano al puente (7-8 en 1d8).
- Reemplaza el contador simplificado de abordaje (0–4).

### ✈️ Vipers tripulados con fichas de piloto
- `Player.viper_area` marca dónde pilota cada jugador.
- "Lanzarte en un Viper" convierte al jugador en piloto en el espacio.
- Menú de piloto: atacar nave Cylon del área (Raider 3+, Heavy 4+, Basestar 6+), volar a un área adyacente, o aterrizar.
- Los Raiders atacan primero a los Vipers tripulados (8 destruye → Enfermería; 5-7 daña → Hangar).
- Al saltar (FTL) o al revelarse como Cylon, el piloto deja el Viper.

### 🛡️ Daño a Galactica por ubicaciones
- Cada daño avería una de las 6 ubicaciones (Comando, Armas, FTL, Hangar, Armería, Camarote del Almirante), deshabilitando su acción.
- Con las 6 averiadas, Galactica es destruida.
- Nueva acción "Reparar un sistema" en el Laboratorio de Investigación.

### 🤖 Iconos de activación Cylon por crisis
- Reemplaza el booleano que activaba todo por `activar_naves_cylon(iconos)`: activar Raiders / Heavy Raiders / Centuriones / Basestars y lanzar Raiders / Heavy Raiders.
- Nuevo efecto de crisis `{"tipo": "activar", "iconos": [...]}`.
- Las crisis heredadas derivan iconos del texto o reciben un perfil estable por carta que aproxima la distribución del juego base.

## Nota sobre fidelidad
Los iconos exactos de activación de cada carta de crisis no están en los datos del repo (en el juego físico son gráficos al pie de cada carta). Se asigna un perfil determinista por carta que reproduce la distinción y distribución del reglamento, pero no coincide carta por carta con las físicas. Si se dispone de esa data, puede cargarse en un campo `activaciones` explícito.

## Verificación
- Todos los módulos compilan.
- Validada la lógica pura accesible: movimiento de Heavy Raiders por el anillo, track de abordaje y condición de abordaje, daño/reparación por ubicación, distribución de iconos, y render de tablero/mapa con pilotos y sistemas averiados.
- El flujo completo con el bot (telegram/PIL) no es ejecutable en el entorno de CI local, pero las piezas de lógica y render pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_