### PR TITLE
BSG: cartas de habilidad de acción jugables (/jugar) y pasivas de personaje

### DIFF
--- a/BattlestarGalactica/Boardgamebox/State.py
+++ b/BattlestarGalactica/Boardgamebox/State.py
@@ -51,6 +51,9 @@ class State(BaseState):
         # --- Paso "Recibir Habilidades" en curso (elección de color) ---
         self.skill_draw = None            # dict: {uid, restantes, pool:[colores]}
 
+        # --- Carta de habilidad de acción en curso (multi-paso) ---
+        self.play_pending = None          # dict: {tipo, uid, ...} para Consolidate/Scout
+
         # --- Naves: modelo posicional por áreas del espacio ---
         self.areas = [Space.nueva_area() for _ in range(Space.N_AREAS)]
         self.vipers_reserva = 8

--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -33,6 +33,7 @@ async def command_call(bot, game):
             game.cid,
             f"🚀 *BSG en curso* — turno de *{st.active_player.name}*.\n"
             "Mover: `/mover` · Acción: `/accion` · Crisis: `/crisis` · Tablero: `/estado` · Mapa: `/mapa`\n"
+            "Mano: `/mano` · Jugar carta: `/jugar` · Aportar a chequeo: `/aportar`\n"
             "Habilidad: `/habilidad` · Presidente: `/quorum` · Cylons: `/revelar`\n"
             "Presidente/Almirante: `/encarcelar` · `/liberar`",
             parse_mode=ParseMode.MARKDOWN,
@@ -172,6 +173,127 @@ async def command_mano(update: Update, context: CallbackContext):
     lineas = [f"{i+1}. {Skills.EMOJI_COLOR[c['color']]} {c['color']} {c['valor']} — _{c.get('nombre','')}_"
               for i, c in enumerate(player.skill_hand)]
     await bot.send_message(uid, "🃏 *Tu mano:*\n" + "\n".join(lineas), parse_mode=ParseMode.MARKDOWN)
+
+
+async def command_jugar(update: Update, context: CallbackContext):
+    """Juega una carta de habilidad de ACCIÓN por su efecto (en tu turno)."""
+    bot = context.bot
+    uid = update.message.from_user.id
+    cid = update.message.chat_id
+    # Localizar la partida (también funciona desde el privado).
+    game = get_game(cid)
+    if not (_validar(game) and uid in getattr(game, "playerlist", {})):
+        game = None
+        for g in GamesController.games.values():
+            if getattr(g, "tipo", None) == "BattlestarGalactica" and uid in getattr(g, "playerlist", {}):
+                game = g
+                break
+    if not game or not game.board:
+        await bot.send_message(uid, "No estás en una partida activa de BSG.")
+        return
+    st = game.board.state
+    player = game.playerlist[uid]
+    if st.fase_actual != "En Juego" or not st.active_player or st.active_player.uid != uid:
+        await bot.send_message(uid, "Solo puedes jugar cartas de acción en tu turno.")
+        return
+    if player.revealed:
+        await bot.send_message(uid, "Un Cylon revelado no usa cartas de habilidad humanas.")
+        return
+    jugables = [(i, c) for i, c in enumerate(player.skill_hand)
+                if c.get("nombre") in BSGController.CARTAS_ACCION]
+    if not jugables:
+        await bot.send_message(uid, "No tienes cartas de *acción* jugables ahora. "
+                                    "(Declare Emergency / Scientific Research se aportan a un chequeo con `/aportar`.)",
+                               parse_mode=ParseMode.MARKDOWN)
+        return
+    btns = [[InlineKeyboardButton(f"{Skills.EMOJI_COLOR[c['color']]} {c.get('nombre')} ({c['valor']})",
+                                  callback_data=f"{game.cid}*bsgJugar*card_{i + 1}*{uid}")]
+            for i, c in jugables]
+    await bot.send_message(uid, "🃏 *Jugar carta de acción:*",
+                           reply_markup=InlineKeyboardMarkup(btns), parse_mode=ParseMode.MARKDOWN)
+
+
+async def callback_bsg_jugar(update: Update, context: CallbackContext):
+    bot = context.bot
+    callback = update.callback_query
+    presser = callback.from_user.id
+    try:
+        regex = re.search(r"(-?[0-9]*)\*bsgJugar\*([A-Za-z]+_[0-9A-Za-z]+)\*(-?[0-9]*)", callback.data)
+        cid = int(regex.group(1))
+        token = regex.group(2)
+        target = int(regex.group(3))
+        game = get_game(cid)
+        if not _validar(game):
+            await callback.answer("Partida no encontrada.")
+            return
+        st = game.board.state
+        if presser != target:
+            await callback.answer("No es tu carta.")
+            return
+        player = game.playerlist.get(presser)
+        if not player:
+            await callback.answer("No estás en la partida.")
+            return
+
+        if token.startswith("card_"):
+            idx = int(token[5:])
+            if idx < 1 or idx > len(player.skill_hand):
+                await callback.answer("Carta inválida.")
+                return
+            nombre = player.skill_hand[idx - 1].get("nombre")
+            if nombre not in BSGController.CARTAS_ACCION:
+                await callback.answer("Esa carta no es de acción.")
+                return
+            await callback.answer("Carta jugada.")
+            if nombre == "Consolidate Power":
+                player.skill_hand.pop(idx - 1)
+                st.play_pending = {"tipo": "consolidate", "uid": presser, "restantes": 2}
+                await BSGController.save(bot, cid)
+                btns = [[InlineKeyboardButton(f"{Skills.EMOJI_COLOR[c]} {c}",
+                                              callback_data=f"{cid}*bsgJugar*cp_{c}*{presser}")]
+                        for c in Skills.COLORES]
+                await bot.send_message(presser, "🟢 *Consolidación de Poder* — elige el tipo (robarás 2):",
+                                       reply_markup=InlineKeyboardMarkup(btns), parse_mode=ParseMode.MARKDOWN)
+            elif nombre == "Launch Scout":
+                player.skill_hand.pop(idx - 1)
+                st.play_pending = {"tipo": "scout", "uid": presser}
+                await BSGController.save(bot, cid)
+                top = st.crisis_deck[-1] if st.crisis_deck else None
+                txt = (f"🔭 Próxima Crisis: *{top['titulo']}*\n_{top['texto'][:180]}_"
+                       if top else "El mazo de Crisis está vacío.")
+                btns = [[InlineKeyboardButton("⬆️ Mantener arriba", callback_data=f"{cid}*bsgJugar*ls_keep*{presser}"),
+                         InlineKeyboardButton("⬇️ Enviar al fondo", callback_data=f"{cid}*bsgJugar*ls_bottom*{presser}")]]
+                await bot.send_message(presser, txt, reply_markup=InlineKeyboardMarkup(btns), parse_mode=ParseMode.MARKDOWN)
+            elif nombre == "Repair":
+                ok = await BSGController.carta_repair(bot, game, player)
+                if ok:
+                    player.skill_hand.pop(idx - 1)
+                await BSGController.save(bot, cid)
+            elif nombre == "Maximum Firepower":
+                ok = await BSGController.carta_max_firepower(bot, game, player)
+                if ok:
+                    player.skill_hand.pop(idx - 1)
+                await BSGController.save(bot, cid)
+        elif token.startswith("cp_"):
+            await callback.answer()
+            await BSGController.carta_consolidate_color(bot, game, presser, token[3:])
+            pp = st.play_pending
+            if pp and pp.get("tipo") == "consolidate":
+                btns = [[InlineKeyboardButton(f"{Skills.EMOJI_COLOR[c]} {c}",
+                                              callback_data=f"{cid}*bsgJugar*cp_{c}*{presser}")]
+                        for c in Skills.COLORES]
+                await bot.send_message(presser, f"Elige el tipo de la siguiente carta ({pp['restantes']} restante):",
+                                       reply_markup=InlineKeyboardMarkup(btns))
+        elif token in ("ls_keep", "ls_bottom"):
+            await callback.answer()
+            await BSGController.carta_scout_resolve(bot, game, presser, token == "ls_keep")
+    except Exception as e:
+        logger.error(f"callback_bsg_jugar error: {e}")
+        try:
+            await callback.answer("Error.")
+        except Exception:
+            pass
+        await bot.send_message(ADMIN[0], f"BSG jugar error: {e}")
 
 
 async def command_estado(update: Update, context: CallbackContext):

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -13,9 +13,13 @@ Implementado en esta capa:
 - Combate espacial posicional: Vipers tripulados, Heavy Raiders, abordaje.
 - Daño a Galactica por ubicaciones e iconos de activación Cylon por crisis.
 
+- Cartas de habilidad de acción jugables (Consolidate Power, Repair, Maximum
+  Firepower, Launch Scout) y habilidades 1/juego de cada personaje.
+
 Pendiente para capas siguientes (claramente acotado):
 - Acciones de ubicación completas, Quórum, súper crisis.
-- Habilidades específicas de cada personaje y cartas de habilidad con efecto.
+- Cartas de habilidad reactivas (Strategic Planning, Evasive Maneuvers,
+  Executive Order) y resto de habilidades pasivas de personaje.
 - Roster completo de cartas de crisis con sus efectos de éxito/fracaso.
 """
 
@@ -238,10 +242,18 @@ def _robar_skills(st, player, cantidad=3):
 LIMITE_MANO = 10
 
 
+def _limite_mano(player):
+    """Límite de mano de cartas de habilidad (Tyrol 'Imprudente' tiene 8)."""
+    if getattr(player, "personaje", None) == "tyrol":
+        return 8
+    return LIMITE_MANO
+
+
 async def _descartar_hasta_limite(bot, game, player):
     """Al final del turno, descarta hasta el límite de 10 cartas de habilidad.
     El motor descarta automáticamente las de menor fuerza (las menos útiles)."""
-    sobran = len(player.skill_hand) - LIMITE_MANO
+    limite = _limite_mano(player)
+    sobran = len(player.skill_hand) - limite
     if sobran <= 0:
         return
     st = game.board.state
@@ -252,7 +264,7 @@ async def _descartar_hasta_limite(bot, game, player):
         st.skill_discards.setdefault(c["color"], []).append(c)
     await bot.send_message(
         player.uid,
-        f"🗑️ Tenías más de {LIMITE_MANO} cartas; se descartaron {sobran} "
+        f"🗑️ Tenías más de {limite} cartas; se descartaron {sobran} "
         f"(las de menor fuerza).",
     )
     await _dm_mano(bot, player)
@@ -1788,6 +1800,101 @@ async def abrir_chequeo(bot, game, crisis):
     await save(bot, game.cid)
 
 
+# ===================== CARTAS DE HABILIDAD (ACCIÓN) =====================
+# Cartas que se pueden JUGAR como acción por su efecto (las demás se aportan a
+# chequeos por su valor o se juegan en momentos concretos —próxima capa—).
+CARTAS_ACCION = {"Consolidate Power", "Repair", "Maximum Firepower", "Launch Scout"}
+
+# Cuándo se usan las cartas que no son acción autónoma (mensaje informativo).
+CUANDO_SE_JUEGAN = {
+    "Declare Emergency": "se aporta a un chequeo (reduce su dificultad en 2).",
+    "Scientific Research": "se aporta a un chequeo (Ingeniería cuenta en positivo).",
+    "Strategic Planning": "se juega antes de una tirada de dado (próxima capa).",
+    "Evasive Maneuvers": "se juega al ser atacado un Viper (próxima capa).",
+    "Executive Order": "concede una acción a otro jugador (próxima capa).",
+}
+
+
+async def carta_repair(bot, game, player):
+    """Reparación: en Hangar/pilotando arregla hasta 2 Vipers; si no, repara una
+    ubicación averiada de Galactica. Devuelve True si tuvo efecto."""
+    st = game.board.state
+    if player.ubicacion == "hangar" or getattr(player, "viper_area", None) is not None:
+        rep = min(2, st.vipers_danados)
+        if rep:
+            st.vipers_danados -= rep
+            st.vipers_reserva += rep
+            await bot.send_message(game.cid, f"🔧 {player.name} usa *Reparación*: arregla {rep} Viper(s) dañado(s).", parse_mode=ParseMode.MARKDOWN)
+            return True
+    loc = player.ubicacion
+    if loc in st.galactica_damage:
+        await _reparar_galactica(bot, game, player, loc)
+        return True
+    if st.galactica_damage:
+        await _reparar_galactica(bot, game, player)
+        return True
+    await bot.send_message(player.uid, "🔧 No hay nada que reparar (ni Vipers dañados ni sistemas averiados).")
+    return False
+
+
+async def carta_max_firepower(bot, game, player):
+    """Potencia de Fuego Máxima: pilotando, ataca hasta 4 veces en tu área."""
+    st = game.board.state
+    if getattr(player, "viper_area", None) is None:
+        await bot.send_message(player.uid, "Debes estar pilotando un Viper para usar Potencia de Fuego Máxima.")
+        return False
+    await bot.send_message(game.cid, f"🔫 {player.name} desata *Potencia de Fuego Máxima* (hasta 4 ataques).", parse_mode=ParseMode.MARKDOWN)
+    for _ in range(4):
+        i = player.viper_area
+        a = st.areas[i]
+        if a["raiders"] <= 0 and a.get("heavy_raiders", 0) <= 0 and not a["basestars"]:
+            break
+        await _pilot_atacar(bot, game, player)
+        if st.ganador:
+            break
+    return True
+
+
+async def carta_consolidate_color(bot, game, uid, color):
+    """Consolidación de Poder: roba 1 carta del color elegido (de 2 en total)."""
+    st = game.board.state
+    pp = st.play_pending
+    if not pp or pp.get("tipo") != "consolidate" or pp.get("uid") != uid:
+        return
+    player = game.playerlist[uid]
+    carta = _robar_carta_color(st, color)
+    if carta:
+        player.skill_hand.append(carta)
+        await bot.send_message(
+            uid,
+            f"➕ *Consolidación de Poder*: robaste {Skills.EMOJI_COLOR[carta['color']]} {color} {carta['valor']}.",
+            parse_mode=ParseMode.MARKDOWN,
+        )
+    else:
+        await bot.send_message(uid, f"(No quedan cartas de {color}.)")
+    pp["restantes"] -= 1
+    if pp["restantes"] <= 0:
+        st.play_pending = None
+        await _dm_mano(bot, player)
+    await save(bot, game.cid)
+
+
+async def carta_scout_resolve(bot, game, uid, mantener):
+    """Explorar: mantiene la próxima Crisis arriba o la manda al fondo del mazo."""
+    st = game.board.state
+    pp = st.play_pending
+    if not pp or pp.get("tipo") != "scout" or pp.get("uid") != uid:
+        return
+    st.play_pending = None
+    if st.crisis_deck and not mantener:
+        c = st.crisis_deck.pop()         # cima
+        st.crisis_deck.insert(0, c)      # al fondo
+        await bot.send_message(game.cid, "🔭 *Lanzar Sonda*: la próxima Crisis se envía al fondo del mazo.", parse_mode=ParseMode.MARKDOWN)
+    else:
+        await bot.send_message(game.cid, "🔭 *Lanzar Sonda*: la próxima Crisis se mantiene arriba.", parse_mode=ParseMode.MARKDOWN)
+    await save(bot, game.cid)
+
+
 async def aportar_carta(bot, game, uid, indice):
     st = game.board.state
     if not st.skill_check:
@@ -1828,6 +1935,9 @@ async def resolver_chequeo(bot, game):
     nombres = [c.get("nombre") for c in todas]
     scientific = "Scientific Research" in nombres   # Ingeniería cuenta en positivo
     declare_emergency = nombres.count("Declare Emergency")
+    # Adama 'Líder Inspirador': las cartas de fuerza 1 cuentan en positivo.
+    adama_activo = any(getattr(p, "personaje", None) == "adama" and not p.revealed
+                       for p in game.playerlist.values())
     # 2 cartas de destino
     destino = _robar_destino(st, 2)
     for c in destino:
@@ -1836,6 +1946,8 @@ async def resolver_chequeo(bot, game):
     random.shuffle(todas)  # ocultar quién aportó qué
     for c in todas:
         if scientific and c["color"] == Skills.INGENIERIA:
+            signo = 1
+        elif adama_activo and c["valor"] == 1:
             signo = 1
         else:
             signo = Skills.signo_para_check(c["color"], colores)
@@ -1857,6 +1969,8 @@ async def resolver_chequeo(bot, game):
         notas.append("Declare Emergency −2 dif.")
     if scientific:
         notas.append("Scientific Research: Ingeniería positiva")
+    if adama_activo:
+        notas.append("Adama: fuerza 1 positiva")
 
     exito = total >= dificultad
     extra = (" (" + "; ".join(notas) + ")") if notas else ""

--- a/MainController.py
+++ b/MainController.py
@@ -828,6 +828,7 @@ def main(stop_event):
 	app.add_handler(CommandHandler("mover", BSGCommands.command_mover))
 	app.add_handler(CommandHandler("crisis", BSGCommands.command_crisis))
 	app.add_handler(CommandHandler("aportar", BSGCommands.command_aportar))
+	app.add_handler(CommandHandler("jugar", BSGCommands.command_jugar))
 	app.add_handler(CommandHandler("resolver", BSGCommands.command_resolver))
 	app.add_handler(CommandHandler("revelar", BSGCommands.command_revelar))
 	app.add_handler(CommandHandler("habilidad", BSGCommands.command_habilidad))
@@ -848,6 +849,7 @@ def main(stop_event):
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgCrisisVoto\*([0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_crisis_voto))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgTarget\*([a-z0-9_]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_target))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgArea\*([a-z_]+)_([0-9]+)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_area))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgJugar\*([A-Za-z]+_[0-9A-Za-z]+)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_jugar))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*chooseendBSG\*(.*)\*([0-9]*)", callback=BSGController.callback_finish_game_buttons_bsg))
 
 	app.add_handler(CommandHandler("status", command_status))


### PR DESCRIPTION
## Resumen

Suma a Battlestar Galactica la capacidad de **jugar** cartas de habilidad por su efecto (hasta ahora solo se podían aportar boca abajo a un chequeo), más las primeras habilidades **pasivas** de personaje.

### 🃏 Cartas de habilidad de acción jugables (nuevo `/jugar`)
- Nuevo comando `/jugar` + callback `bsgJugar` para el jugador activo.
- **Consolidate Power**: roba 2 cartas de los tipos que elijas.
- **Repair**: en Hangar/pilotando arregla hasta 2 Vipers dañados; si no, repara una ubicación averiada de Galactica (sinergia con el daño por ubicaciones).
- **Maximum Firepower**: pilotando, ataca hasta 4 veces en tu área.
- **Launch Scout**: mira la próxima Crisis y mantenla arriba o mándala al fondo.
- Las cartas reactivas/de chequeo (Declare Emergency, Scientific Research, Strategic Planning, Evasive Maneuvers, Executive Order) informan cuándo se usan.

### 🎭 Habilidades pasivas de personaje
- **Adama "Líder Inspirador"**: las cartas de fuerza 1 cuentan en positivo en los chequeos mientras esté en juego y sin revelar.
- **Tyrol "Imprudente"**: límite de mano de 8 cartas (en vez de 10).

## Verificación
- Compilan todos los módulos tocados (Controller, Commands, State, MainController).
- Validados los tokens del callback `bsgJugar` contra el regex y el mapeo nombre→carta.

## Pendiente para capas siguientes
- Cartas reactivas (Strategic Planning, Evasive Maneuvers, Executive Order) y resto de pasivas de personaje.
- Acciones de ubicación completas, Quórum y súper crisis.
- Efectos de éxito/fracaso del roster completo de crisis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_