### PR TITLE
BSG: súper crisis completa (mano del Cylon, juego en Caprica e intercambio)

### DIFF
--- a/BattlestarGalactica/Boardgamebox/Player.py
+++ b/BattlestarGalactica/Boardgamebox/Player.py
@@ -13,6 +13,7 @@ class Player(BasePlayer):
         self.revealed = False          # si ya se reveló como Cylon
         self.skill_hand = []           # lista de cartas {color, valor}
         self.quorum_hand = []          # cartas de Quórum (Presidente)
+        self.super_crisis = None       # Súper Crisis en mano (Cylon revelado): se juega en Caprica
         self.en_calabozo = False
         self.habilidad_usada = False   # habilidad de "una vez por juego"
         self.viper_area = None         # índice de área si pilota un Viper (None = en una ubicación)

--- a/BattlestarGalactica/Boardgamebox/State.py
+++ b/BattlestarGalactica/Boardgamebox/State.py
@@ -46,6 +46,7 @@ class State(BaseState):
         self.crisis_discard = []
         self.crisis_actual = None         # dict de la crisis en curso
         self.super_crisis_deck = []       # mazo de súper crisis (Cylons revelados)
+        self.super_crisis_discard = []    # súper crisis ya jugadas o descartadas
         self.quorum_deck = []             # mazo de Quórum (Presidente)
         self.quorum_discard = []
         self.quorum_pendiente = None      # carta de Quórum esperando elección de objetivo

--- a/BattlestarGalactica/Constants/Crisis.py
+++ b/BattlestarGalactica/Constants/Crisis.py
@@ -720,8 +720,13 @@ CRISIS_DECK = [
 ]
 
 
-# Mazo de SÚPER CRISIS: efectos potentes que dispara un Cylon al revelarse.
-# (Set inicial; el juego base tiene varias más.)  # VERIFICAR / COMPLETAR
+# Mazo de SÚPER CRISIS (hoja "Super Crisis Cards", Module=B).
+# Cuando un jugador Cylon se revela, roba 1 carta de Súper Crisis a su mano y la
+# juega más tarde desde la ubicación Caprica (o la intercambia en la Nave de
+# Resurrección). Cada carta lista efectos inmediatos resueltos por
+# Controller.aplicar_efectos (raiders/recurso/centuriones/heavy_raiders/basestar/
+# activar/mensaje). Los textos reflejan el espíritu de las cartas oficiales,
+# adaptados al motor posicional de naves de este módulo.
 SUPER_CRISIS_DECK = [
     {
         "id": "asalto_masivo",
@@ -760,5 +765,32 @@ SUPER_CRISIS_DECK = [
         "texto": "Una Basestar llega con refuerzos.",
         "efectos": [{"tipo": "basestar", "cantidad": 1},
                     {"tipo": "raiders", "cantidad": 2}],
+    },
+    {
+        "id": "ofensiva_total",
+        "titulo": "Ofensiva Total",
+        "texto": "Las Basestars activan a sus Raiders y lanzan una nueva oleada.",
+        "efectos": [{"tipo": "activar", "iconos": ["raiders", "launch_raiders"]},
+                    {"tipo": "mensaje", "texto": "¡La flota Cylon arrecia el ataque!"}],
+    },
+    {
+        "id": "asalto_nuclear",
+        "titulo": "Asalto Nuclear",
+        "texto": "Una ojiva Cylon alcanza la flota: caos y bajas civiles.",
+        "efectos": [{"tipo": "recurso", "recurso": "poblacion", "delta": -1},
+                    {"tipo": "destruir_civil"}],
+    },
+    {
+        "id": "hambruna_inducida",
+        "titulo": "Hambruna Inducida",
+        "texto": "El sabotaje a los suministros agota las reservas.",
+        "efectos": [{"tipo": "recurso", "recurso": "comida", "delta": -2}],
+    },
+    {
+        "id": "enjambre_raiders",
+        "titulo": "Enjambre de Raiders",
+        "texto": "Raiders y Heavy Raiders saturan el espacio alrededor de Galactica.",
+        "efectos": [{"tipo": "raiders", "cantidad": 2},
+                    {"tipo": "heavy_raiders", "cantidad": 1}],
     },
 ]

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -30,8 +30,11 @@ Implementado en esta capa:
   Especialista de Misión (elige destino en el próximo salto), Árbitro (±3 en el
   Camarote del Almirante) y Vicepresidente (único candidato a la Presidencia).
 
+- Súper crisis: al revelarse, el Cylon roba una Súper Crisis a su mano; la juega
+  desde Caprica (resuelve sus efectos) o la intercambia en la Nave de
+  Resurrección. Mazo y descarte propios.
+
 Pendiente para capas siguientes (claramente acotado):
-- Súper crisis (mazo y resolución).
 - Roster completo de cartas de crisis con sus efectos de éxito/fracaso.
 """
 
@@ -1477,8 +1480,8 @@ async def _destruir_civil(bot, game, area_idx=None):
 # Acciones disponibles para un Cylon revelado, según su ubicación Cylon.
 ACCIONES_CYLON = {
     "cylon_fleet": ["launch_raiders", "launch_heavy", "launch_basestar"],
-    "caprica": ["sabotage", "board"],
-    "resurrection_ship": ["launch_raiders", "sabotage"],
+    "caprica": ["play_super_crisis", "sabotage", "board"],
+    "resurrection_ship": ["swap_super_crisis", "launch_raiders", "sabotage"],
     "human_fleet": ["sabotage", "board"],
 }
 
@@ -1488,6 +1491,8 @@ ETIQUETA_ACCION_CYLON = {
     "launch_basestar": "🛸 Traer una Basestar",
     "sabotage": "🔧💥 Sabotear un recurso (-1)",
     "board": "🔺 Desembarcar un centurión",
+    "play_super_crisis": "☠️ Jugar tu Súper Crisis",
+    "swap_super_crisis": "♻️ Descartar y robar otra Súper Crisis",
 }
 
 
@@ -1527,15 +1532,19 @@ async def revelar_cylon(bot, game, uid):
         parse_mode=ParseMode.MARKDOWN,
     )
 
-    # Desata una súper crisis
+    # Roba una Súper Crisis a su mano (la jugará desde Caprica)
     if st.super_crisis_deck:
-        sc = st.super_crisis_deck.pop()
+        player.super_crisis = st.super_crisis_deck.pop()
+        await bot.send_message(game.cid, "☠️ El Cylon roba una *Súper Crisis*…", parse_mode=ParseMode.MARKDOWN)
         await bot.send_message(
-            game.cid,
-            f"☠️ *SÚPER CRISIS: {sc['titulo']}*\n_{sc['texto']}_",
+            uid,
+            f"☠️ *SÚPER CRISIS robada: {player.super_crisis['titulo']}*\n_{player.super_crisis['texto']}_\n\n"
+            f"Muévete a *Caprica* y usa `/accion` para *jugarla*. En la *Nave de Resurrección* "
+            f"puedes descartarla y robar otra.",
             parse_mode=ParseMode.MARKDOWN,
         )
-        await aplicar_efectos(bot, game, sc.get("efectos", []))
+    else:
+        await bot.send_message(game.cid, "☠️ No quedan Súper Crisis en el mazo.")
 
     await save(bot, game.cid)
     if await _chequear_fin(bot, game):
@@ -1545,6 +1554,41 @@ async def revelar_cylon(bot, game, uid):
 async def ejecutar_accion_cylon(bot, game, uid, accion):
     """Acción de un Cylon revelado en su turno."""
     st = game.board.state
+    player = game.playerlist.get(uid)
+    if accion == "play_super_crisis":
+        # Caprica: resolver la Súper Crisis que el Cylon tiene en mano.
+        if not player or not player.super_crisis:
+            await bot.send_message(uid, "No tienes ninguna Súper Crisis en mano.")
+            return
+        sc = player.super_crisis
+        player.super_crisis = None
+        st.super_crisis_discard.append(sc)
+        await bot.send_message(
+            game.cid,
+            f"☠️ *SÚPER CRISIS: {sc['titulo']}*\n_{sc['texto']}_",
+            parse_mode=ParseMode.MARKDOWN,
+        )
+        await aplicar_efectos(bot, game, sc.get("efectos", []))
+        await save(bot, game.cid)
+        await _chequear_fin(bot, game)
+        return
+    if accion == "swap_super_crisis":
+        # Nave de Resurrección: descartar la Súper Crisis actual y robar otra.
+        if player and player.super_crisis:
+            st.super_crisis_discard.append(player.super_crisis)
+            player.super_crisis = None
+        if st.super_crisis_deck:
+            player.super_crisis = st.super_crisis_deck.pop()
+            await bot.send_message(game.cid, "♻️ El Cylon descarta su Súper Crisis y roba otra.")
+            await bot.send_message(
+                uid,
+                f"☠️ *Nueva Súper Crisis: {player.super_crisis['titulo']}*\n_{player.super_crisis['texto']}_",
+                parse_mode=ParseMode.MARKDOWN,
+            )
+        else:
+            await bot.send_message(game.cid, "♻️ El Cylon descarta su Súper Crisis, pero el mazo está vacío.")
+        await save(bot, game.cid)
+        return
     if accion == "launch_raiders":
         objetivos = _areas_con(st, "basestars")
         area_idx = objetivos[0] if objetivos else Space.AREA_PROA


### PR DESCRIPTION
Implementa el sistema de **Súper Crisis** de Battlestar Galactica de forma fiel al juego base.

## Mecánica
Antes, al revelarse un Cylon se aplicaba una súper crisis al instante. Ahora:
- **Al revelarse**, el jugador Cylon **roba** una carta de Súper Crisis a su mano (privado).
- **Caprica**: nueva acción Cylon `play_super_crisis` → resuelve los efectos de la carta en mano y la descarta.
- **Nave de Resurrección**: nueva acción `swap_super_crisis` → descarta la Súper Crisis actual y roba otra.

## Cambios
- `Player.super_crisis`: carta de Súper Crisis en mano del Cylon.
- `State.super_crisis_discard`: pila de descarte propia del mazo de Súper Crisis.
- `ACCIONES_CYLON` / `ETIQUETA_ACCION_CYLON`: añadidas `play_super_crisis` (Caprica) y `swap_super_crisis` (Resurrección).
- `revelar_cylon`: roba a la mano del Cylon en vez de aplicar el efecto inmediatamente.
- `ejecutar_accion_cylon`: resuelve jugar e intercambiar la Súper Crisis (con guardas de mano vacía / mazo vacío).
- `SUPER_CRISIS_DECK`: ampliado de 6 a **10 cartas** con docstring; corregidos los iconos de la activación (`raiders`/`launch_raiders`) para que la carta *Ofensiva Total* surta efecto real.

## Verificación
- `py_compile` OK en los 5 ficheros.
- Estructura del mazo validada: ids únicos, todos los `tipo` de efecto soportados por `aplicar_efectos`, iconos de `activar` válidos.
- Regex de `bsgCylon` verificada para las nuevas acciones.

## Notas de adaptación
- Los textos de las Súper Crisis reflejan el espíritu de las cartas oficiales, adaptados al motor posicional de naves de este módulo.
- La acción de Caprica "robar 2 Crisis y resolver 1" no se modela aquí; Caprica conserva sus acciones de sabotaje/abordaje junto a la de jugar la Súper Crisis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_