### PR TITLE
BSG: la mano inicial también deja elegir los slots de elección (Apolo)

### DIFF
--- a/BattlestarGalactica/Boardgamebox/Player.py
+++ b/BattlestarGalactica/Boardgamebox/Player.py
@@ -12,6 +12,7 @@ class Player(BasePlayer):
         self.is_cylon = False          # revelado o no, refleja si tiene carta cylon
         self.revealed = False          # si ya se reveló como Cylon
         self.skill_hand = []           # lista de cartas {color, valor}
+        self.skill_choices_pendientes = []  # slots de elección del reparto inicial por decidir
         self.quorum_hand = []          # cartas de Quórum (Presidente)
         self.super_crisis = None       # Súper Crisis en mano (Cylon revelado): se juega en Caprica
         self.en_calabozo = False

--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -132,6 +132,43 @@ async def callback_bsg_draw(update: Update, context: CallbackContext):
         await bot.send_message(ADMIN[0], f"BSG draw error: {e}")
 
 
+async def callback_bsg_setup(update: Update, context: CallbackContext):
+    """Elección del color de un slot de la mano inicial (reparto de setup)."""
+    bot = context.bot
+    callback = update.callback_query
+    presser = callback.from_user.id
+    try:
+        regex = re.search(r"(-?[0-9]*)\*bsgSetup\*([A-Za-z]*)\*(-?[0-9]*)", callback.data)
+        cid = int(regex.group(1))
+        color = regex.group(2)
+        target = int(regex.group(3))
+        game = get_game(cid)
+        if not _validar(game):
+            await callback.answer("Partida no encontrada.")
+            return
+        if presser != target:
+            await callback.answer("No es tu mano.")
+            return
+        player = game.playerlist.get(presser)
+        if not player or not player.skill_choices_pendientes \
+                or color not in player.skill_choices_pendientes[0]:
+            await callback.answer("Color no disponible.")
+            return
+        await callback.answer(f"Robaste {color}.")
+        try:
+            await bot.edit_message_reply_markup(presser, callback.message.message_id, reply_markup=None)
+        except Exception:
+            pass
+        await BSGController.resolver_setup_choice(bot, game, presser, color)
+    except Exception as e:
+        logger.error(f"callback_bsg_setup error: {e}")
+        try:
+            await callback.answer("Error.")
+        except Exception:
+            pass
+        await bot.send_message(ADMIN[0], f"BSG setup error: {e}")
+
+
 def _esperando_robo(st, uid):
     """True si el jugador activo aún debe elegir sus cartas de Recibir Habilidades."""
     return bool(st.skill_draw and st.active_player and st.active_player.uid == uid

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -195,15 +195,18 @@ async def finalizar_setup(bot, game):
 
     # --- Mano inicial de habilidades (regla del juego base) ---
     # Todos los jugadores EXCEPTO el primero roban su set completo de habilidades
-    # al empezar (los slots de elección se resuelven al azar en este reparto de
-    # setup). El primer jugador robará su mano en su primer turno (su ventaja es
-    # jugar primero).
+    # al empezar. Los slots fijos se reparten solos; los de elección (p. ej. Apolo,
+    # Liderazgo/Política) los decide el propio jugador por privado. El primer
+    # jugador robará su mano en su primer turno (su ventaja es jugar primero).
     primer_jugador = game.player_sequence[0]
     for player in game.player_sequence:
         if player.uid == primer_jugador.uid:
             continue
-        _robar_skills(st, player)
-        await _dm_mano(bot, player)
+        player.skill_choices_pendientes = _repartir_set_fijo(st, player)
+        if player.skill_choices_pendientes:
+            await _prompt_setup_choice(bot, game, player)
+        else:
+            await _dm_mano(bot, player)
 
     st.fase_actual = "En Juego"
     st.player_counter = 0
@@ -252,19 +255,19 @@ def _slots_personaje(skill_set):
     return [list(s) if isinstance(s, (list, tuple)) else [s] for s in skill_set]
 
 
-def _robar_skills(st, player, cantidad=None):
-    """Reparte la mano de habilidades del set del personaje (un slot = una carta).
-    Los slots fijos dan su color; los de elección se resuelven al azar (reparto
-    automático de setup). Si se pasa 'cantidad', limita el número de cartas."""
+def _repartir_set_fijo(st, player):
+    """Reparte a la mano los slots FIJOS del set del personaje y devuelve la lista
+    de slots de ELECCIÓN pendientes (para que el jugador los decida por privado)."""
     pj = Characters.PERSONAJES[player.personaje]
-    slots = _slots_personaje(pj["skill_set"])
-    if cantidad is not None:
-        slots = slots[:cantidad]
-    for opciones in slots:
-        color = random.choice(opciones)
-        carta = _robar_carta_color(st, color)
-        if carta:
-            player.skill_hand.append(carta)
+    pendientes = []
+    for opciones in _slots_personaje(pj["skill_set"]):
+        if len(opciones) == 1:
+            carta = _robar_carta_color(st, opciones[0])
+            if carta:
+                player.skill_hand.append(carta)
+        else:
+            pendientes.append(list(opciones))
+    return pendientes
 
 
 LIMITE_MANO = 10
@@ -419,6 +422,43 @@ async def _entregar_carta_skill(bot, game, player, color):
         )
     else:
         await bot.send_message(player.uid, f"(No quedan cartas de {color}.)")
+
+
+async def _prompt_setup_choice(bot, game, player):
+    """Pide por privado al jugador el color del siguiente slot de elección de su
+    mano inicial (reparto de setup)."""
+    if not player.skill_choices_pendientes:
+        await _dm_mano(bot, player)
+        return
+    opciones = player.skill_choices_pendientes[0]
+    btns = [[InlineKeyboardButton(
+                f"{Skills.EMOJI_COLOR[c]} {c}",
+                callback_data=f"{game.cid}*bsgSetup*{c}*{player.uid}")]
+            for c in opciones]
+    await bot.send_message(
+        player.uid,
+        f"🃏 *Mano inicial* — te quedan *{len(player.skill_choices_pendientes)}* carta(s) a elegir.\n"
+        f"Elige el tipo de esta carta ({' / '.join(opciones)}):",
+        reply_markup=InlineKeyboardMarkup(btns),
+        parse_mode=ParseMode.MARKDOWN,
+    )
+
+
+async def resolver_setup_choice(bot, game, uid, color):
+    """Resuelve un slot de elección del reparto inicial con el color elegido."""
+    player = game.playerlist.get(uid)
+    if not player or not player.skill_choices_pendientes:
+        return
+    if color not in player.skill_choices_pendientes[0]:
+        return
+    player.skill_choices_pendientes.pop(0)
+    await _entregar_carta_skill(bot, game, player, color)
+    if player.skill_choices_pendientes:
+        await save(bot, game.cid)
+        await _prompt_setup_choice(bot, game, player)
+    else:
+        await _dm_mano(bot, player)
+        await save(bot, game.cid)
 
 
 async def _prompt_color_skill(bot, game):

--- a/MainController.py
+++ b/MainController.py
@@ -837,6 +837,7 @@ def main(stop_event):
 	app.add_handler(CommandHandler("liberar", BSGCommands.command_liberar))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgPick\*([a-z_]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_pick))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgDraw\*([A-Za-z]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_draw))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgSetup\*([A-Za-z]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_setup))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgAccion\*([a-z0-9_]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_accion))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgMover\*([a-z_]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_mover))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgCylon\*([a-z0-9_]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_cylon))


### PR DESCRIPTION
Corrige que con **Lee "Apollo" Adama** la mano inicial repartía sus 2 cartas de elección (Liderazgo/Política) **al azar** en vez de dejar elegir al jugador.

## Causa
El flujo interactivo de elección solo corría en el paso "Recibir Habilidades" del **turno**. En el **reparto de setup** (jugadores que no son el primero), `_robar_skills` resolvía los slots de elección con `random.choice` → el motor decidía por vos.

## Solución
El reparto inicial ahora reparte solo los slots **fijos** y te ofrece, por privado, **elegir el color de cada slot de elección** — pudiendo armar **1+1, 2 de un tipo o 2 del otro**, igual que en el turno.

- `Player.skill_choices_pendientes`: cola de slots de elección por decidir.
- `Controller`:
  - `_repartir_set_fijo` reparte los fijos y devuelve los de elección pendientes.
  - `_prompt_setup_choice` / `resolver_setup_choice`: flujo interactivo de la mano inicial.
- `Commands.callback_bsg_setup` + handler `bsgSetup` registrado en `MainController`.

El primer jugador (que no recibe mano de setup) ya elegía bien en su 1er turno; no cambia.

## Verificación
- `py_compile` OK.
- Regex `bsgSetup` y el flujo de slots validados (Apolo: fijos 1 Táctica + 2 Pilotaje; luego 2 elecciones Liderazgo/Política → permite 2 Liderazgo o 2 Política).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_