### PR TITLE
SecretoCodigo: mostrar número original de pista (-1/0) en historial y mensajes

### DIFF
--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -4,6 +4,7 @@ import urllib.parse
 
 import psycopg
 import SecretoCodigo.Controller as SecretoCodigoController
+from SecretoCodigo.Controller import format_numero_pista
 from Utils import get_game, save, player_call, simple_choose_buttons
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
@@ -423,7 +424,7 @@ async def command_history(update: Update, context: CallbackContext):
         dador = entrada["dador"]
         pista = entrada["pista"]
         numero = entrada["numero"]
-        numero_str = "∞" if numero in (0, -1) else str(numero)
+        numero_str = format_numero_pista(numero)
 
         if game.modo == "Cooperativo":
             lines.append(f"👤 *{dador}* (Jugador {turno}) — *{pista}* ({numero_str})")
@@ -477,7 +478,7 @@ async def command_call(bot, game):
             )
         elif "Adivinar" in fase:
             intentos_display = "∞" if st.intentos_restantes >= 999 else st.intentos_restantes
-            numero_display = "∞" if st.numero_pista in (0, -1) else st.numero_pista
+            numero_display = format_numero_pista(st.numero_pista)
             await bot.send_photo(
                 game.cid,
                 photo=game.board.render_duo_board_image(game),
@@ -520,7 +521,7 @@ async def command_call(bot, game):
         numero = game.board.state.numero_pista
         intentos = game.board.state.intentos_restantes
         intentos_display = "∞" if intentos >= 999 else intentos
-        numero_display = "∞" if numero in (0, -1) else numero
+        numero_display = format_numero_pista(numero)
         await bot.send_photo(
             game.cid,
             photo=game.board.render_board_image(game),

--- a/SecretoCodigo/Controller.py
+++ b/SecretoCodigo/Controller.py
@@ -30,6 +30,11 @@ def _hist(st):
     return st.historial
 
 
+def format_numero_pista(numero: int) -> str:
+    """Muestra el número de pista original (-1 o 0) junto con el símbolo de infinito."""
+    return f"{numero} (∞)" if numero in (0, -1) else str(numero)
+
+
 async def init_game(bot, game):
     try:
         log.info('SecretoCodigo init_game called')
@@ -325,7 +330,7 @@ async def process_hint_duo(bot, game, uid, word: str, number: int):
         game.cid,
         photo=game.board.render_duo_board_image(game),
         caption=(
-            f"💬 Pista de *{dador.name}*: *{word.upper()}* — {'∞' if infinito else number}\n"
+            f"💬 Pista de *{dador.name}*: *{word.upper()}* — {format_numero_pista(number)}\n"
             f"{player_call(receptor)}, usa `/pick NUMERO` o `/pickb` (botonera) para adivinar (en el grupo). "
             f"Hasta *{intentos_str}* intentos o `/endturn` para pasar."
         ),
@@ -483,7 +488,7 @@ async def process_hint(bot, game, spymaster_uid, word: str, number: int):
         if not game.is_spymaster(p.uid)
     )
     caption_pista = (
-        f"💬 Pista del espía *{team}*: *{word.upper()}* — {'∞' if infinito else number}\n"
+        f"💬 Pista del espía *{team}*: *{word.upper()}* — {format_numero_pista(number)}\n"
         f"{field_mentions} usen `/pick NUMERO` o `/pickb` (botonera) para elegir una carta.\n"
         f"Hasta *{intentos_str}* intentos o `/endturn` para pasar."
     )
@@ -680,7 +685,7 @@ async def myturn_message(game, uid) -> str:
         if "Pista" in fase and dador and dador.uid == uid:
             return f"Partida {group}: es tu turno de dar pista. Usa `/hint PALABRA NUMERO`"
         if "Adivinar" in fase and receptor and receptor.uid == uid:
-            return f"Partida {group}: debes adivinar. Pista: *{st.pista_actual}* — {st.numero_pista}. Usa `/pick NUMERO`"
+            return f"Partida {group}: debes adivinar. Pista: *{st.pista_actual}* — {format_numero_pista(st.numero_pista)}. Usa `/pick NUMERO`"
         return None
 
     sm_r = game.board.state.spymaster_rojo
@@ -695,5 +700,5 @@ async def myturn_message(game, uid) -> str:
         if game.is_field_operative(uid, team):
             pista = game.board.state.pista_actual
             numero = game.board.state.numero_pista
-            return f"Partida {group}: equipo {team} debe adivinar. Pista: *{pista}* — {numero}. Usa `/pick NUMERO`"
+            return f"Partida {group}: equipo {team} debe adivinar. Pista: *{pista}* — {format_numero_pista(numero)}. Usa `/pick NUMERO`"
     return None


### PR DESCRIPTION
## Summary
- Una pista de `-1` o `0` ya habilitaba intentos infinitos, pero el historial y los mensajes de turno mostraban siempre `∞`, sin distinguir si el dador usó `-1` o `0`.
- Se agrega `format_numero_pista()` y se usa en todos los lugares donde se muestra el número de pista (`/history`, mensajes de pista, recordatorios de turno) para mostrar el valor original junto al símbolo de infinito, ej. `-1 (∞)` o `0 (∞)`.

## Test plan
- [x] Revisión de código y verificación de sintaxis
- [ ] Probar en un grupo real: dar una pista con `-1`, luego otra con `0`, y confirmar que `/history` y los mensajes de turno muestran el valor correcto en cada caso


---
_Generated by [Claude Code](https://claude.ai/code/session_01M7aPEd7LX15JwyN1FrK525)_