### PR TITLE
BSG: mecánica de Ojivas Nucleares del Almirante

### DIFF
--- a/BattlestarGalactica/Boardgamebox/Board.py
+++ b/BattlestarGalactica/Boardgamebox/Board.py
@@ -85,7 +85,7 @@ class Board(BaseBoard):
         pres = game.playerlist.get(st.presidente_uid)
         alm = game.playerlist.get(st.almirante_uid)
         board += f"🏛️ Presidente: {pres.name if pres else '—'}\n"
-        board += f"🎖️ Almirante: {alm.name if alm else '—'}\n\n"
+        board += f"🎖️ Almirante: {alm.name if alm else '—'}   ☢️ Ojivas: {st.nukes}\n\n"
 
         board += "*Jugadores:*\n"
         for player in game.player_sequence:

--- a/BattlestarGalactica/Boardgamebox/State.py
+++ b/BattlestarGalactica/Boardgamebox/State.py
@@ -76,7 +76,7 @@ class State(BaseState):
         self.areas = [Space.nueva_area() for _ in range(Space.N_AREAS)]
         self.vipers_reserva = 8
         self.vipers_danados = 0           # Vipers dañados (fuera de combate hasta reparar)
-        self.nuke_usado = False           # ataque nuclear del Almirante (1 por juego)
+        self.nukes = 2                    # Ojivas Nucleares del Almirante (2 al inicio)
 
         # --- Naves civiles aún no desplegadas (con carga oculta) ---
         self.civiles_pile = []

--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -505,7 +505,10 @@ async def command_accion(update: Update, context: CallbackContext):
                                parse_mode=ParseMode.MARKDOWN)
         return
 
-    acciones = BSGController.ACCIONES_UBICACION.get(player.ubicacion, [])
+    acciones = list(BSGController.ACCIONES_UBICACION.get(player.ubicacion, []))
+    # La Ojiva Nuclear solo se ofrece al Almirante y si quedan Ojivas.
+    if "launch_nuke" in acciones and (uid != st.almirante_uid or st.nukes <= 0):
+        acciones.remove("launch_nuke")
     if not acciones:
         await bot.send_message(cid, f"📍 {ubic}: no hay acción disponible aquí. Usa `/crisis`.",
                                parse_mode=ParseMode.MARKDOWN)
@@ -559,7 +562,12 @@ async def callback_bsg_accion(update: Update, context: CallbackContext):
             tipo = BSGController.ACCIONES_CON_AREA[accion]
             btns = []
             for i, a in enumerate(st.areas):
-                cant = a["raiders"] if tipo == "raiders" else len(a["basestars"])
+                if tipo == "raiders":
+                    cant = a["raiders"]
+                elif tipo == "basestars":
+                    cant = len(a["basestars"])
+                else:  # "cualquiera": cualquier nave Cylon (Ojiva Nuclear)
+                    cant = a["raiders"] + a.get("heavy_raiders", 0) + len(a["basestars"])
                 if cant > 0:
                     btns.append([InlineKeyboardButton(
                         f"{Space.nombre(i)} ({cant})",

--- a/BattlestarGalactica/Constants/Crisis.py
+++ b/BattlestarGalactica/Constants/Crisis.py
@@ -14,8 +14,9 @@ mensaje, prophecy y, además: sickbay/brig (enviar a un rol o a todos los de una
 ubicación, p. ej. {"tipo":"sickbay","quien":"ubicacion:command"}), descartar
 (descarte forzado: quien/cantidad/modo), civiles (colocar naves civiles tras
 Galactica), danar_galactica, titulo (transferir Presidente/Almirante),
-vipers_recall (devolver todos los Vipers sin daños a la reserva) y recrisis
-(robar y resolver otra Crisis tras la activación Cylon).
+vipers_recall (devolver todos los Vipers sin daños a la reserva), recrisis
+(robar y resolver otra Crisis tras la activación Cylon) y nuke_token (el
+Almirante descarta/recibe Ojivas Nucleares: delta).
 El objetivo de sickbay/brig admite además 'nave:<Nave>' (todos los de esa nave).
 Los efectos que requieren que un jugador ELIJA un objetivo usan elegir_objetivo
 (quien=decisor, accion=brig/sickbay/loyalty_peek, candidatos=todos/otros o lista
@@ -80,7 +81,7 @@ CRISIS_DECK = [
         "texto": "Admiral Chooses: Discard 1 Nuke Token. If you do not have any Nuke tokens, you may not choose this option. OR -1 Morale, and the Admiral discards 2 Skill Cards.",
         "tipo": "eleccion",
         "decisor": "almirante",
-        "opciones": [{"label": "A) Discard 1 Nuke Token. If you do not have any Nuke to…", "efectos": [{"tipo": "mensaje", "texto": "El Almirante descarta 1 token de Ojiva Nuclear (mecánica pendiente; control manual)."}]}, {"label": "B) -1 Morale, and the Admiral discards 2 Skill Cards", "efectos": [{"tipo": "recurso", "recurso": "moral", "delta": -1}, {"tipo": "descartar", "quien": "almirante", "cantidad": 2}]}],
+        "opciones": [{"label": "A) Descartar 1 Ojiva Nuclear (si tienes)", "efectos": [{"tipo": "nuke_token", "delta": -1}]}, {"label": "B) -1 Morale, and the Admiral discards 2 Skill Cards", "efectos": [{"tipo": "recurso", "recurso": "moral", "delta": -1}, {"tipo": "descartar", "quien": "almirante", "cantidad": 2}]}],
         "jump": 0,
         "activar_cylons": True,
     },

--- a/BattlestarGalactica/Constants/Locations.py
+++ b/BattlestarGalactica/Constants/Locations.py
@@ -29,7 +29,7 @@ UBICACIONES = {
     "weapons": {
         "nombre": "Control de Armas (Galactica)",
         "nave": GALACTICA,
-        "accion": "Atacar 1 nave Cylon con Galactica.",
+        "accion": "Atacar 1 nave Cylon con Galactica. El Almirante puede lanzar una Ojiva Nuclear (limpia un área).",
     },
     "command": {
         "nombre": "Comando (Galactica)",

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -15,6 +15,8 @@ Implementado en esta capa:
 - Salto FTL, condiciones de victoria/derrota.
 - Combate espacial posicional: Vipers tripulados, Heavy Raiders, abordaje.
 - Daño a Galactica por ubicaciones e iconos de activación Cylon por crisis.
+- Ojivas Nucleares: el Almirante tiene 2 al inicio; desde Control de Armas
+  lanza una sobre un área y destruye TODAS sus naves Cylon (consume 1 Ojiva).
 
 - Cartas de habilidad jugables con /jugar: de acción (Consolidate Power,
   Repair, Maximum Firepower, Launch Scout, Executive Order) y reactivas que se
@@ -686,7 +688,7 @@ async def _reparar_galactica(bot, game, player, loc=None):
 # Acciones disponibles por ubicación (clave -> lista de acciones), según el set oficial.
 ACCIONES_UBICACION = {
     "ftl": ["jump"],
-    "weapons": ["shoot_raider", "shoot_basestar"],
+    "weapons": ["shoot_raider", "shoot_basestar", "launch_nuke"],
     "command": ["activate_vipers"],
     "communications": ["peek_civiles"],
     "admiral_quarters": ["brig_check"],
@@ -704,7 +706,9 @@ ACCIONES_UBICACION = {
 ACCIONES_CON_OBJETIVO = {"brig_check": "brig", "president_check": "president"}
 
 # Acciones que requieren elegir un ÁREA del espacio (Control de Armas) → tipo de nave
-ACCIONES_CON_AREA = {"shoot_raider": "raiders", "shoot_basestar": "basestars"}
+# ("cualquiera" = áreas con cualquier nave Cylon, p. ej. la Ojiva Nuclear).
+ACCIONES_CON_AREA = {"shoot_raider": "raiders", "shoot_basestar": "basestars",
+                     "launch_nuke": "cualquiera"}
 
 # Acciones disponibles mientras se pilota un Viper tripulado.
 ACCIONES_PILOTO = ["pilot_attack", "pilot_move", "pilot_land"]
@@ -716,6 +720,7 @@ ETIQUETA_ACCION = {
     "jump": "🌌 Saltar la flota (FTL)",
     "shoot_raider": "🔫 Disparar a un Raider",
     "shoot_basestar": "💥 Disparar a una Basestar",
+    "launch_nuke": "☢️ Lanzar Ojiva Nuclear (Almirante)",
     "activate_vipers": "✈️ Activar Vipers (atacan Raiders)",
     "peek_civiles": "🔭 Inspeccionar naves civiles",
     "brig_check": "🚔 Enviar a alguien al Calabozo (chequeo)",
@@ -755,6 +760,11 @@ async def ejecutar_accion_ubicacion(bot, game, uid, accion, objetivo=None):
         await _disparar(bot, game, "raider", objetivo)
     elif accion == "shoot_basestar":
         await _disparar(bot, game, "basestar", objetivo)
+    elif accion == "launch_nuke":
+        if uid != st.almirante_uid and uid not in ADMIN:
+            await bot.send_message(game.cid, "☢️ Solo el Almirante puede lanzar Ojivas Nucleares.")
+            return
+        await _nuke(bot, game, objetivo)
     elif accion == "activate_vipers":
         # Comando: hasta 2 activaciones de Vipers sin tripular (atacar o mover).
         await _activar_vipers_comando(bot, game)
@@ -1172,34 +1182,48 @@ async def _activar_un_viper(bot, game):
             return
 
 
+def _areas_con_cylons(st):
+    """Áreas del espacio que contienen alguna nave Cylon (Raiders, Heavy Raiders
+    o Basestars)."""
+    return [i for i, a in enumerate(st.areas)
+            if a["raiders"] > 0 or a.get("heavy_raiders", 0) > 0 or a["basestars"]]
+
+
 async def _nuke(bot, game, area_idx=None):
-    """Ataque nuclear del Almirante (1 por juego) sobre una Basestar."""
+    """Lanza una Ojiva Nuclear del Almirante sobre un área del espacio: destruye
+    TODAS las naves Cylon de esa área (Raiders, Heavy Raiders y Basestars).
+    Consume 1 Ojiva (hay 2 al inicio de la partida)."""
     st = game.board.state
-    if st.nuke_usado:
-        await bot.send_message(game.cid, "El ataque nuclear ya fue utilizado.")
+    if st.nukes <= 0:
+        await bot.send_message(game.cid, "☢️ No quedan Ojivas Nucleares.")
         return
-    objetivos = _areas_con(st, "basestars")
+    objetivos = _areas_con_cylons(st)
     if not objetivos:
-        await bot.send_message(game.cid, "No hay Basestars para atacar.")
+        await bot.send_message(game.cid, "No hay naves Cylon en el espacio a las que disparar.")
         return
     if area_idx is None or area_idx not in objetivos:
         area_idx = objetivos[0]
-    st.nuke_usado = True
+    st.nukes -= 1
     area = st.areas[area_idx]
-    r = _tirar_ataque(st)
-    await bot.send_message(game.cid, f"☢️ *¡ATAQUE NUCLEAR!* Tirada {r} sobre {Space.nombre(area_idx)}.", parse_mode=ParseMode.MARKDOWN)
-    if r <= 2:
-        await _danar_basestar(bot, game, area_idx, cantidad=2)
-    else:
-        if area["basestars"]:
-            k = max(range(len(area["basestars"])), key=lambda j: area["basestars"][j])
-            area["basestars"].pop(k)
-            await bot.send_message(game.cid, "🛸💀 ¡Basestar destruida por el ataque nuclear!")
-        if r >= 7:
-            destr = min(3, area["raiders"])
-            area["raiders"] -= destr
-            if destr:
-                await bot.send_message(game.cid, f"💥 La explosión destruye {destr} Raider(s) en {Space.nombre(area_idx)}.")
+    nb, nr, nh = len(area["basestars"]), area["raiders"], area.get("heavy_raiders", 0)
+    area["basestars"] = []
+    area["raiders"] = 0
+    area["heavy_raiders"] = 0
+    partes = []
+    if nb:
+        partes.append(f"{nb} Basestar(s)")
+    if nr:
+        partes.append(f"{nr} Raider(s)")
+    if nh:
+        partes.append(f"{nh} Heavy Raider(s)")
+    destruidas = ", ".join(partes) if partes else "el área (sin naves)"
+    await bot.send_message(
+        game.cid,
+        f"☢️ *¡OJIVA NUCLEAR sobre {Space.nombre(area_idx)}!* Se destruye(n) {destruidas}. "
+        f"Ojivas restantes: {st.nukes}.",
+        parse_mode=ParseMode.MARKDOWN,
+    )
+    await _chequear_fin(bot, game)
 
 
 async def mover_jugador(bot, game, uid, destino):
@@ -2797,6 +2821,14 @@ async def aplicar_efectos(bot, game, efectos):
         elif tipo == "civiles":
             n = _colocar_civiles(st, ef.get("cantidad", 1))
             await bot.send_message(game.cid, f"🛰️ Aparece(n) {n} nave(s) civil(es) tras Galactica (total: {st.total_civiles()}).")
+        elif tipo == "nuke_token":
+            delta = ef.get("delta", -1)
+            if delta < 0 and st.nukes <= 0:
+                await bot.send_message(game.cid, "☢️ El Almirante no tiene Ojivas Nucleares que descartar.")
+            else:
+                st.nukes = max(0, st.nukes + delta)
+                verbo = "descarta" if delta < 0 else "recibe"
+                await bot.send_message(game.cid, f"☢️ El Almirante {verbo} {abs(delta)} Ojiva(s) Nuclear(es) (quedan {st.nukes}).")
         elif tipo == "vipers_recall":
             await _recall_vipers(bot, game)
         elif tipo == "recrisis":


### PR DESCRIPTION
## Resumen

Implementa la **mecánica de Ojivas Nucleares** del Almirante, completa e integrada. Antes existía una función `_nuke` de un solo uso (booleano) que **nunca llegaba a invocarse** (código muerto).

## Cambios

- **Estado**: `nuke_usado` (booleano, 1 por juego) → **`nukes`** (contador, **2 al inicio**, regla oficial).
- **Acción "☢️ Lanzar Ojiva Nuclear"** en Control de Armas:
  - Solo se ofrece **al Almirante** y **si quedan Ojivas**.
  - Elige un **área del espacio** (con cualquier nave Cylon) y **destruye TODAS las naves de esa área** (Raiders, Heavy Raiders y Basestars), consumiendo 1 Ojiva.
  - Reutiliza la selección de área existente (`ACCIONES_CON_AREA` con tipo nuevo `"cualquiera"`).
- **Tablero**: muestra las Ojivas restantes junto al Almirante (`☢️ Ojivas: N`).
- **Efecto de crisis `nuke_token`** (`delta`): el Almirante descarta/recibe Ojivas. Conecta la **opción A de "Build Cylon Detector"** (Descartar 1 Ojiva), que estaba diferida; si no tiene Ojivas, lo informa.

## Resultado

Con esto, **el mazo de Crisis queda sin efectos pendientes (0 placeholders `(según texto)`)**.

## Validación

- `py_compile` OK en todos los módulos BSG.
- Sin referencias colgantes a `nuke_usado`.
- Validación AST: todos los `tipo` de efecto de ambos mazos están soportados (incluido `nuke_token`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_