### PR TITLE
BSG: escalón intermedio en los chequeos de crisis (Pass / N+ / Fail)

### DIFF
--- a/BattlestarGalactica/Constants/Crisis.py
+++ b/BattlestarGalactica/Constants/Crisis.py
@@ -4,7 +4,9 @@ Mazo de Crisis del JUEGO BASE (61 cartas oficiales, hoja 'crisis' game=B).
 Cada carta: colores/dificultad del chequeo, icono de salto (jump), activación
 de naves Cylon, decisor (activo/presidente/almirante) y el texto oficial.
 - tipo 'chequeo': Pass/Fail; si tiene 'alternativa', el decisor elige entre
-  intentar el chequeo o tomar la alternativa garantizada (opción 'OR').
+  intentar el chequeo o tomar la alternativa garantizada (opción 'OR'). Las
+  cartas con escalón intermedio ("Pass / N+ / Fail") llevan 'intermedio':
+  {"umbral": N, "efectos": [...]} — se aplica si total>=N pero <dificultad.
 - tipo 'eleccion': el decisor elige entre dos opciones directas.
 - tipo 'evento': efecto inmediato.
 
@@ -15,12 +17,14 @@ ubicación, p. ej. {"tipo":"sickbay","quien":"ubicacion:command"}), descartar
 (descarte forzado: quien/cantidad/modo), civiles (colocar naves civiles tras
 Galactica), danar_galactica, titulo (transferir Presidente/Almirante),
 vipers_recall (devolver todos los Vipers sin daños a la reserva), recrisis
-(robar y resolver otra Crisis tras la activación Cylon) y nuke_token (el
-Almirante descarta/recibe Ojivas Nucleares: delta).
+(robar y resolver otra Crisis tras la activación Cylon), nuke_token (el
+Almirante descarta/recibe Ojivas Nucleares: delta) y danar_vipers
+(cantidad/donde: 'reserva' o 'espacio').
 El objetivo de sickbay/brig admite además 'nave:<Nave>' (todos los de esa nave).
 Los efectos que requieren que un jugador ELIJA un objetivo usan elegir_objetivo
-(quien=decisor, accion=brig/sickbay/loyalty_peek, candidatos=todos/otros o lista
-de roles, opcional=True si "puede" elegir): pausan la crisis y abren una botonera.
+(quien=decisor, accion=brig/sickbay/loyalty_peek/presidencia, candidatos=
+todos/otros o lista de roles, opcional=True si "puede" elegir): pausan la
+crisis y abren una botonera.
 """
 
 CRISIS_DECK = [
@@ -201,7 +205,8 @@ CRISIS_DECK = [
         "colores": ["Politica", "Liderazgo"],
         "dificultad": 8,
         "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
-        "fracaso": [{"tipo": "recurso", "recurso": "moral", "delta": -1}],
+        "intermedio": {"umbral": 5, "efectos": [{"tipo": "recurso", "recurso": "moral", "delta": -1}]},
+        "fracaso": [{"tipo": "recurso", "recurso": "moral", "delta": -1}, {"tipo": "descartar", "quien": "presidente", "cantidad": 4}],
         "jump": 1,
         "activar_cylons": True,
     },
@@ -260,7 +265,8 @@ CRISIS_DECK = [
         "colores": ["Tactica", "Pilotaje", "Ingenieria"],
         "dificultad": 10,
         "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
-        "fracaso": [{"tipo": "recurso", "recurso": "poblacion", "delta": -1}],
+        "intermedio": {"umbral": 7, "efectos": [{"tipo": "recurso", "recurso": "poblacion", "delta": -1}]},
+        "fracaso": [{"tipo": "recurso", "recurso": "poblacion", "delta": -1}, {"tipo": "danar_vipers", "cantidad": 2, "donde": "reserva"}],
         "jump": 1,
         "activar_cylons": True,
     },
@@ -322,6 +328,7 @@ CRISIS_DECK = [
         "colores": ["Politica", "Liderazgo"],
         "dificultad": 9,
         "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
+        "intermedio": {"umbral": 7, "efectos": [{"tipo": "descartar", "quien": "activo", "cantidad": 2}]},
         "fracaso": [{"tipo": "recurso", "recurso": "moral", "delta": -1}, {"tipo": "descartar", "quien": "activo", "cantidad": 2}],
         "jump": 1,
         "activar_cylons": True,
@@ -346,6 +353,7 @@ CRISIS_DECK = [
         "colores": ["Politica", "Liderazgo"],
         "dificultad": 13,
         "exito": [{"tipo": "elegir_objetivo", "quien": "presidente", "accion": "loyalty_peek", "candidatos": ["activo"]}],
+        "intermedio": {"umbral": 9, "efectos": [{"tipo": "mensaje", "texto": "Sin efecto."}]},
         "fracaso": [{"tipo": "recurso", "recurso": "moral", "delta": -1}],
         "jump": 1,
         "activar_cylons": True,
@@ -395,7 +403,8 @@ CRISIS_DECK = [
         "colores": ["Politica", "Liderazgo", "Tactica"],
         "dificultad": 11,
         "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
-        "fracaso": [{"tipo": "recurso", "recurso": "poblacion", "delta": -1}],
+        "intermedio": {"umbral": 6, "efectos": [{"tipo": "recurso", "recurso": "poblacion", "delta": -1}]},
+        "fracaso": [{"tipo": "recurso", "recurso": "poblacion", "delta": -1}, {"tipo": "elegir_objetivo", "quien": "presidente", "accion": "presidencia", "candidatos": "otros"}],
         "jump": 1,
         "activar_cylons": True,
     },
@@ -452,6 +461,7 @@ CRISIS_DECK = [
         "colores": ["Politica", "Liderazgo", "Tactica"],
         "dificultad": 12,
         "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
+        "intermedio": {"umbral": 9, "efectos": [{"tipo": "recurso", "recurso": "comida", "delta": -1}]},
         "fracaso": [{"tipo": "recurso", "recurso": "comida", "delta": -1}, {"tipo": "recurso", "recurso": "combustible", "delta": -1}],
         "jump": 1,
         "activar_cylons": True,
@@ -554,6 +564,7 @@ CRISIS_DECK = [
         "colores": ["Politica", "Liderazgo"],
         "dificultad": 12,
         "exito": [{"tipo": "elegir_objetivo", "quien": "activo", "accion": "loyalty_peek", "candidatos": "otros"}],
+        "intermedio": {"umbral": 6, "efectos": [{"tipo": "mensaje", "texto": "Sin efecto."}]},
         "fracaso": [{"tipo": "recurso", "recurso": "moral", "delta": -1}],
         "jump": 1,
         "activar_cylons": True,
@@ -566,6 +577,7 @@ CRISIS_DECK = [
         "colores": ["Politica", "Liderazgo", "Pilotaje"],
         "dificultad": 11,
         "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
+        "intermedio": {"umbral": 8, "efectos": [{"tipo": "recurso", "recurso": "poblacion", "delta": -1}]},
         "fracaso": [{"tipo": "recurso", "recurso": "moral", "delta": -1}, {"tipo": "recurso", "recurso": "poblacion", "delta": -1}],
         "jump": 1,
         "activar_cylons": True,
@@ -642,7 +654,7 @@ CRISIS_DECK = [
         "colores": ["Tactica", "Pilotaje", "Ingenieria"],
         "dificultad": 11,
         "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
-        "fracaso": [{"tipo": "sickbay", "quien": "ubicacion:weapons"}],
+        "fracaso": [{"tipo": "danar_vipers", "cantidad": 2, "donde": "espacio"}, {"tipo": "sickbay", "quien": "ubicacion:weapons"}],
         "jump": 0,
         "activar_cylons": True,
     },
@@ -654,6 +666,7 @@ CRISIS_DECK = [
         "colores": ["Politica", "Liderazgo"],
         "dificultad": 10,
         "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
+        "intermedio": {"umbral": 6, "efectos": [{"tipo": "recurso", "recurso": "moral", "delta": -1}]},
         "fracaso": [{"tipo": "recurso", "recurso": "moral", "delta": -1}, {"tipo": "elegir_objetivo", "quien": "activo", "accion": "sickbay"}],
         "jump": 1,
         "activar_cylons": True,
@@ -678,6 +691,7 @@ CRISIS_DECK = [
         "colores": ["Liderazgo", "Tactica"],
         "dificultad": 18,
         "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
+        "intermedio": {"umbral": 14, "efectos": [{"tipo": "centuriones", "delta": 1}]},
         "fracaso": [{"tipo": "danar_galactica"}, {"tipo": "centuriones", "delta": 2}],
         "jump": 0,
         "activar_cylons": False,

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -10,7 +10,8 @@ Implementado en esta capa:
 - Recibir Habilidades fiel al set del personaje: se roba el set completo cada
   turno; los slots fijos se reparten solos y los de elección (p. ej. Apolo,
   Liderazgo/Política) los decide el jugador.
-- Chequeos de habilidad con mazo de Destino.
+- Chequeos de habilidad con mazo de Destino, con escalón intermedio opcional
+  ("Pass / N+ / Fail") cuando la carta define 'intermedio'.
 - Fase del Agente Durmiente (distancia 4).
 - Salto FTL, condiciones de victoria/derrota.
 - Combate espacial posicional: Vipers tripulados, Heavy Raiders, abordaje.
@@ -2406,11 +2407,21 @@ async def resolver_chequeo(bot, game):
         notas.append("Adama: fuerza 1 positiva")
 
     exito = total >= dificultad
+    # Escalón intermedio (cartas "Pass / N+ / Fail"): por encima del umbral
+    # parcial pero sin alcanzar la dificultad (Pass) se aplica un efecto medio.
+    crisis = st.crisis_actual
+    intermedio = crisis.get("intermedio") if crisis else None
+    if exito:
+        resultado_txt = "✅ ÉXITO"
+    elif intermedio and total >= intermedio["umbral"]:
+        resultado_txt = f"🟨 PARCIAL ({intermedio['umbral']}+)"
+    else:
+        resultado_txt = "❌ FRACASO"
     extra = (" (" + "; ".join(notas) + ")") if notas else ""
     await bot.send_message(
         game.cid,
         f"🎲 Resultado del chequeo: *{total}* vs dificultad *{dificultad}*{extra} → "
-        f"{'✅ ÉXITO' if exito else '❌ FRACASO'}\n"
+        f"{resultado_txt}\n"
         f"Cartas: {' '.join(detalle) if detalle else '(ninguna)'}",
         parse_mode=ParseMode.MARKDOWN,
     )
@@ -2420,9 +2431,13 @@ async def resolver_chequeo(bot, game):
         await _resolver_chequeo_ubicacion(bot, game, sc, total, exito)
         return
 
-    crisis = st.crisis_actual
     st.skill_check = None
-    efectos = crisis["exito"] if exito else crisis["fracaso"]
+    if exito:
+        efectos = crisis["exito"]
+    elif intermedio and total >= intermedio["umbral"]:
+        efectos = intermedio["efectos"]
+    else:
+        efectos = crisis["fracaso"]
     if await aplicar_efectos(bot, game, efectos):
         await cerrar_crisis(bot, game, crisis)
 
@@ -2583,6 +2598,28 @@ async def _descartar_skills(bot, game, player, cantidad, modo="azar"):
     await bot.send_message(player.uid, f"🗑️ Descartaste {n} carta(s) de habilidad (te quedan {len(player.skill_hand)}).")
 
 
+async def _danar_vipers(bot, game, cantidad, donde="reserva"):
+    """Daña Vipers (pasan a 'dañados', fuera de combate hasta repararlos).
+    donde: 'reserva' (de la reserva) | 'espacio' (desplegados en las áreas)."""
+    st = game.board.state
+    danados = 0
+    if donde == "reserva":
+        n = min(cantidad, st.vipers_reserva)
+        st.vipers_reserva -= n
+        st.vipers_danados += n
+        danados = n
+    else:  # 'espacio'
+        restantes = cantidad
+        for a in st.areas:
+            while restantes > 0 and a["vipers"] > 0:
+                a["vipers"] -= 1
+                st.vipers_danados += 1
+                restantes -= 1
+                danados += 1
+    lugar = "la reserva" if donde == "reserva" else "el espacio"
+    await bot.send_message(game.cid, f"✈️💥 Se dañan {danados} Viper(s) en {lugar} (dañados: {st.vipers_danados}).")
+
+
 async def _recall_vipers(bot, game):
     """Devuelve a la reserva todos los Vipers SIN daños del tablero: los de las
     áreas del espacio y los que estén tripulados (vuelven al Hangar). Los Vipers
@@ -2645,6 +2682,7 @@ _ETIQUETA_ACCION_OBJETIVO = {
     "brig": ("enviar al Calabozo", "🔒"),
     "sickbay": ("enviar a la Enfermería", "🏥"),
     "loyalty_peek": ("inspeccionar una carta de lealtad", "🔍"),
+    "presidencia": ("ceder la Presidencia", "🏛️"),
 }
 
 
@@ -2725,6 +2763,15 @@ async def _aplicar_accion_objetivo(bot, game, chooser, target, accion):
         await _enviar_sickbay(bot, game, target)
     elif accion == "loyalty_peek":
         await _inspeccionar_lealtad(bot, game, chooser, target)
+    elif accion == "presidencia":
+        st = game.board.state
+        anterior = game.playerlist.get(st.presidente_uid)
+        if anterior and anterior.uid != target.uid:
+            anterior.titulos = [t for t in anterior.titulos if t != "Presidente"]
+        st.presidente_uid = target.uid
+        if "Presidente" not in target.titulos:
+            target.titulos.append("Presidente")
+        await bot.send_message(game.cid, f"🏛️ *{target.name}* recibe el título de Presidente.", parse_mode=ParseMode.MARKDOWN)
 
 
 async def resolver_eleccion_objetivo(bot, game, target_token):
@@ -2831,6 +2878,8 @@ async def aplicar_efectos(bot, game, efectos):
                 await bot.send_message(game.cid, f"☢️ El Almirante {verbo} {abs(delta)} Ojiva(s) Nuclear(es) (quedan {st.nukes}).")
         elif tipo == "vipers_recall":
             await _recall_vipers(bot, game)
+        elif tipo == "danar_vipers":
+            await _danar_vipers(bot, game, ef.get("cantidad", 1), ef.get("donde", "reserva"))
         elif tipo == "recrisis":
             st.recrisis_pendiente = True
             await bot.send_message(game.cid, "🔁 Tras el paso de activación Cylon se robará y resolverá una *nueva Crisis*.", parse_mode=ParseMode.MARKDOWN)


### PR DESCRIPTION
## Resumen

Las cartas de crisis con **tres niveles de resultado** ("Pass / N+ / Fail") ignoraban el escalón intermedio: el chequeo era binario y solo aplicaba el efecto de Pass o el de Fail. Ahora se respeta el nivel parcial.

## Mecánica

En `resolver_chequeo`, con `total` = resultado del chequeo:
- `total >= dificultad` → **✅ Pass** (efectos de `exito`)
- `umbral <= total < dificultad` → **🟨 Parcial** (efectos de `intermedio`)
- `total < umbral` → **❌ Fail** (efectos de `fracaso`)

El mensaje de resultado refleja los tres niveles. Las cartas con escalón intermedio llevan `"intermedio": {"umbral": N, "efectos": [...]}`.

## Cartas conectadas (10)

Elections Loom · Hangar Accident · Loss of a Friend · Mandatory Testing · Prisoner Revolt · Resistance · Terrorist Investigations · The Olympic Carrier · Witch Hunt · Cylon Intruders

De paso se **completan efectos de Fail que faltaban** en algunas de esas cartas:
- *Elections Loom*: el Presidente descarta 4 cartas (faltaba).
- *Prisoner Revolt*: el Presidente cede la Presidencia a otro jugador (interactivo).

## Efectos nuevos

- **`danar_vipers`** (`cantidad`/`donde` = `reserva` o `espacio`): usado por *Hangar Accident* y *Weapon Malfunction*, que antes ignoraban el daño a Vipers.
- **`elegir_objetivo` acción `presidencia`**: el decisor cede la Presidencia al personaje elegido.

## Validación

- `py_compile` OK.
- Validación AST: las 10 cartas con `intermedio` tienen `umbral < dificultad`; todos los `tipo` de efecto soportados (incluidos `danar_vipers` y la acción `presidencia`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_