### PR TITLE
BSG: bloqueo persistente de ubicaciones (Bomb on Colonial One)

### DIFF
--- a/BattlestarGalactica/Boardgamebox/Board.py
+++ b/BattlestarGalactica/Boardgamebox/Board.py
@@ -85,7 +85,13 @@ class Board(BaseBoard):
         pres = game.playerlist.get(st.presidente_uid)
         alm = game.playerlist.get(st.almirante_uid)
         board += f"🏛️ Presidente: {pres.name if pres else '—'}\n"
-        board += f"🎖️ Almirante: {alm.name if alm else '—'}   ☢️ Ojivas: {st.nukes}\n\n"
+        board += f"🎖️ Almirante: {alm.name if alm else '—'}   ☢️ Ojivas: {st.nukes}\n"
+        bloqueadas = getattr(st, "ubicaciones_bloqueadas", None)
+        if bloqueadas:
+            nombres = ", ".join(Locations.UBICACIONES[k]["nombre"].split(" (")[0]
+                                for k in bloqueadas if k in Locations.UBICACIONES)
+            board += f"🚫 Bloqueadas: {nombres}\n"
+        board += "\n"
 
         board += "*Jugadores:*\n"
         for player in game.player_sequence:

--- a/BattlestarGalactica/Boardgamebox/State.py
+++ b/BattlestarGalactica/Boardgamebox/State.py
@@ -81,6 +81,10 @@ class State(BaseState):
         # --- Naves civiles aún no desplegadas (con carga oculta) ---
         self.civiles_pile = []
 
+        # --- Ubicaciones bloqueadas el resto de la partida (claves de ubicación) ---
+        # p. ej. Colonial One tras "Bomb on Colonial One": nadie puede moverse allí.
+        self.ubicaciones_bloqueadas = []
+
         # --- Daño a Galactica por ubicaciones (tokens de avería) ---
         # Cada token avería una ubicación de Galactica (deshabilita su acción
         # hasta repararla). Cuando las 6 ubicaciones quedan averiadas, Galactica

--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -726,6 +726,8 @@ async def command_mover(update: Update, context: CallbackContext):
             continue
         if key == player.ubicacion:
             continue
+        if key in getattr(st, "ubicaciones_bloqueadas", []):
+            continue
         btns.append([InlineKeyboardButton(info["nombre"], callback_data=f"{cid}*bsgMover*{key}*{uid}")])
     await bot.send_message(cid, "📍 ¿A dónde quieres moverte?",
                            reply_markup=InlineKeyboardMarkup(btns))

--- a/BattlestarGalactica/Constants/Crisis.py
+++ b/BattlestarGalactica/Constants/Crisis.py
@@ -18,8 +18,9 @@ ubicación, p. ej. {"tipo":"sickbay","quien":"ubicacion:command"}), descartar
 Galactica), danar_galactica, titulo (transferir Presidente/Almirante),
 vipers_recall (devolver todos los Vipers sin daños a la reserva), recrisis
 (robar y resolver otra Crisis tras la activación Cylon), nuke_token (el
-Almirante descarta/recibe Ojivas Nucleares: delta) y danar_vipers
-(cantidad/donde: 'reserva' o 'espacio').
+Almirante descarta/recibe Ojivas Nucleares: delta), danar_vipers
+(cantidad/donde: 'reserva' o 'espacio') y bloquear (nave o ubicacion:
+nadie puede moverse allí el resto de la partida).
 El objetivo de sickbay/brig admite además 'nave:<Nave>' (todos los de esa nave).
 Los efectos que requieren que un jugador ELIJA un objetivo usan elegir_objetivo
 (quien=decisor, accion=brig/sickbay/loyalty_peek/presidencia, candidatos=
@@ -679,7 +680,7 @@ CRISIS_DECK = [
         "colores": ["Tactica", "Pilotaje", "Ingenieria"],
         "dificultad": 15,
         "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
-        "fracaso": [{"tipo": "recurso", "recurso": "moral", "delta": -2}, {"tipo": "sickbay", "quien": "nave:Colonial One"}, {"tipo": "mensaje", "texto": "🚫 Nadie puede moverse a Colonial One el resto de la partida (control manual)."}],
+        "fracaso": [{"tipo": "recurso", "recurso": "moral", "delta": -2}, {"tipo": "sickbay", "quien": "nave:Colonial One"}, {"tipo": "bloquear", "nave": "Colonial One"}],
         "jump": 0,
         "activar_cylons": False,
     },

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -1233,6 +1233,11 @@ async def mover_jugador(bot, game, uid, destino):
     if destino not in Locations.UBICACIONES:
         await bot.send_message(game.cid, "Ubicación inválida.")
         return
+    if destino in getattr(st, "ubicaciones_bloqueadas", []):
+        nombre = Locations.UBICACIONES[destino]["nombre"].split(" (")[0]
+        await bot.send_message(game.cid, f"🚫 *{nombre}* está bloqueada el resto de la partida: no puedes entrar.",
+                               parse_mode=ParseMode.MARKDOWN)
+        return
     player.ubicacion = destino
     await bot.send_message(
         game.cid,
@@ -2620,6 +2625,25 @@ async def _danar_vipers(bot, game, cantidad, donde="reserva"):
     await bot.send_message(game.cid, f"✈️💥 Se dañan {danados} Viper(s) en {lugar} (dañados: {st.vipers_danados}).")
 
 
+async def _bloquear_ubicaciones(bot, game, nave=None, ubicacion=None):
+    """Bloquea ubicaciones el resto de la partida (nadie podrá moverse a ellas).
+    Se puede bloquear una nave entera (todas sus ubicaciones) o una sola."""
+    st = game.board.state
+    if not hasattr(st, "ubicaciones_bloqueadas") or st.ubicaciones_bloqueadas is None:
+        st.ubicaciones_bloqueadas = []
+    if nave:
+        keys = [k for k, v in Locations.UBICACIONES.items() if v.get("nave") == nave]
+    elif ubicacion:
+        keys = [ubicacion]
+    else:
+        keys = []
+    nuevas = [k for k in keys if k in Locations.UBICACIONES and k not in st.ubicaciones_bloqueadas]
+    st.ubicaciones_bloqueadas.extend(nuevas)
+    if nuevas:
+        nombres = ", ".join(Locations.UBICACIONES[k]["nombre"].split(" (")[0] for k in nuevas)
+        await bot.send_message(game.cid, f"🚫 Bloqueado el resto de la partida (no se puede entrar): {nombres}.")
+
+
 async def _recall_vipers(bot, game):
     """Devuelve a la reserva todos los Vipers SIN daños del tablero: los de las
     áreas del espacio y los que estén tripulados (vuelven al Hangar). Los Vipers
@@ -2880,6 +2904,8 @@ async def aplicar_efectos(bot, game, efectos):
             await _recall_vipers(bot, game)
         elif tipo == "danar_vipers":
             await _danar_vipers(bot, game, ef.get("cantidad", 1), ef.get("donde", "reserva"))
+        elif tipo == "bloquear":
+            await _bloquear_ubicaciones(bot, game, ef.get("nave"), ef.get("ubicacion"))
         elif tipo == "recrisis":
             st.recrisis_pendiente = True
             await bot.send_message(game.cid, "🔁 Tras el paso de activación Cylon se robará y resolverá una *nueva Crisis*.", parse_mode=ParseMode.MARKDOWN)


### PR DESCRIPTION
## Resumen

Implementa el **bloqueo persistente de ubicaciones** el resto de la partida, que hasta ahora quedaba como nota de control manual en *Bomb on Colonial One* ("Characters may not move to Colonial One for the rest of the game").

## Cambios

- **Estado**: nuevo `ubicaciones_bloqueadas` (lista de claves de ubicación).
- **Efecto de crisis `bloquear`**:
  - `nave=<Nave>` → bloquea **todas** las ubicaciones de esa nave.
  - `ubicacion=<clave>` → bloquea una sola.
  - *Bomb on Colonial One* lo usa para bloquear las 3 ubicaciones de Colonial One (`press_room`, `president_office`, `administration`).
- **Movimiento**:
  - `command_mover` oculta del listado las ubicaciones bloqueadas.
  - `mover_jugador` rechaza el destino bloqueado con aviso.
- **Tablero**: muestra `🚫 Bloqueadas: …` cuando las hay.
- Accesos defensivos con `getattr` para partidas guardadas antes del cambio (sin el atributo).

## Coherencia

Al fallar la crisis, todos los personajes de Colonial One son enviados a Enfermería (efecto ya existente) y a partir de ahí nadie puede regresar — comportamiento consistente con la regla oficial.

## Validación

- `py_compile` OK en los 5 módulos.
- Comprobado que `nave:"Colonial One"` resuelve las 3 ubicaciones y que el efecto `bloquear` queda enlazado en el `fracaso` de la carta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_