### PR TITLE
SecretoCodigo: permitir pistas con espacios en /hint

### DIFF
--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -47,14 +47,14 @@ async def command_hint(update: Update, context: CallbackContext):
         await bot.send_message(uid, "Uso: /hint PALABRA NUMERO  (ej: /hint ANIMAL 3)")
         return
 
-    word = args[0]
+    word = " ".join(args[:-1])
     if word.lstrip('-').isdigit():
         await bot.send_message(uid, "La pista debe ser una palabra, no un número. Uso: `/hint PALABRA NUMERO`", parse_mode=ParseMode.MARKDOWN)
         return
     try:
-        number = int(args[1])
+        number = int(args[-1])
     except ValueError:
-        await bot.send_message(uid, "El segundo argumento debe ser un número entero.")
+        await bot.send_message(uid, "El último argumento debe ser un número entero.")
         return
 
     if not (-1 <= number <= 9):

--- a/SecretoCodigo/Controller.py
+++ b/SecretoCodigo/Controller.py
@@ -305,9 +305,6 @@ async def process_hint_duo(bot, game, uid, word: str, number: int):
     if not dador or dador.uid != uid:
         await bot.send_message(uid, "No eres quien debe dar la pista ahora.")
         return
-    if " " in word:
-        await bot.send_message(uid, "La pista debe ser una sola palabra sin espacios.")
-        return
     if len(word) > 30:
         await bot.send_message(uid, "Ni los alemanes se animan a escribir una palabra tan larga, intenta de nuevo por favor... (Max 30 caracteres)")
         return
@@ -460,9 +457,6 @@ async def process_hint(bot, game, spymaster_uid, word: str, number: int):
         return
     if not spymaster or spymaster.uid != spymaster_uid:
         await bot.send_message(spymaster_uid, "No eres el espía activo.")
-        return
-    if " " in word:
-        await bot.send_message(spymaster_uid, "La pista debe ser una sola palabra sin espacios.")
         return
     if len(word) > 30:
         await bot.send_message(spymaster_uid, f"La pista es demasiado larga ({len(word)} caracteres). Máximo 30.")


### PR DESCRIPTION
## Summary
- `/hint` y la selección de pista por callback rechazaban cualquier pista con espacios ("La pista debe ser una sola palabra sin espacios").
- Ahora el último argumento sigue siendo el número de intentos; todo lo que viene antes se une como la pista, permitiendo frases con espacios.

## Test plan
- [ ] `/hint PERRO GATO 3` en privado debería aceptar "PERRO GATO" como pista con 3 intentos
- [ ] Verificar que `/history` y los mensajes de turno muestren la pista completa con espacios


---
_Generated by [Claude Code](https://claude.ai/code/session_01M7aPEd7LX15JwyN1FrK525)_