### PR TITLE
BSG: eliminar 2 filas espurias del mazo de Crisis (cartas de ubicación)

### DIFF
--- a/BattlestarGalactica/Constants/Crisis.py
+++ b/BattlestarGalactica/Constants/Crisis.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-Mazo de Crisis del JUEGO BASE (61 cartas oficiales, hoja 'crisis' game=B).
+Mazo de Crisis del JUEGO BASE (59 cartas, hoja 'crisis' game=B).
+Nota: la hoja de origen incluía 2 filas espurias ("Admirals Quarters" y
+"Brig") que en realidad son acciones de ubicación de Galactica —ya
+modeladas en Locations.UBICACIONES—, no cartas de Crisis; se excluyen.
 Cada carta: colores/dificultad del chequeo, icono de salto (jump), activación
 de naves Cylon, decisor (activo/presidente/almirante) y el texto oficial.
 - tipo 'chequeo': Pass/Fail; si tiene 'alternativa', el decisor elige entre
@@ -718,30 +721,6 @@ CRISIS_DECK = [
         "dificultad": 15,
         "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
         "fracaso": [{"tipo": "recurso", "recurso": "combustible", "delta": -1}, {"tipo": "recurso", "recurso": "comida", "delta": -1}, {"tipo": "recurso", "recurso": "poblacion", "delta": -1}],
-        "jump": 0,
-        "activar_cylons": False,
-    },
-    {
-        "titulo": "Admirals Quarters",
-        "texto": "Action: Choose a character, then pass this skill check to send him to the \"Brig\"",
-        "tipo": "chequeo",
-        "decisor": "activo",
-        "colores": ["Liderazgo", "Tactica"],
-        "dificultad": 7,
-        "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
-        "fracaso": [{"tipo": "mensaje", "texto": "Sin efecto adicional."}],
-        "jump": 0,
-        "activar_cylons": False,
-    },
-    {
-        "titulo": "Brig",
-        "texto": "Action: Pass this skill check to move to any location",
-        "tipo": "chequeo",
-        "decisor": "activo",
-        "colores": ["Politica", "Tactica"],
-        "dificultad": 7,
-        "exito": [{"tipo": "mensaje", "texto": "Sin efecto."}],
-        "fracaso": [{"tipo": "mensaje", "texto": "Sin efecto adicional."}],
         "jump": 0,
         "activar_cylons": False,
     },


### PR DESCRIPTION
## Resumen

Elimina dos entradas **espurias** del mazo de Crisis que en realidad eran textos de **acciones de ubicación de Galactica**, coladas desde la hoja de origen del scrape.

## Análisis del origen

Las entradas `"Admirals Quarters"` y `"Brig"` tenían `texto` que empezaba por `"Action: ..."` — el formato de las acciones de ubicación, no de las crisis:

| Entrada en CRISIS_DECK | Realidad |
|---|---|
| *Admirals Quarters* — "Action: Choose a character, then pass this skill check to send him to the Brig" | Acción de la ubicación `admiral_quarters` (chequeo dif. 7 → Calabozo) |
| *Brig* — "Action: Pass this skill check to move to any location" | Acción de la ubicación `brig` (chequeo dif. 7 → escape) |

Ambas **ya están modeladas** en `Locations.UBICACIONES`. Además, sus colores en el mazo de crisis **no coincidían** con los de las ubicaciones reales, lo que confirma que son filas mal copiadas. No tenían comportamiento de crisis (efecto `"Sin efecto"`), por lo que robarlas producía un **turno muerto**.

## Cambios

- Se eliminan ambas del `CRISIS_DECK` (**61 → 59 cartas**).
- Docstring actualizado con el nuevo conteo y una nota explicativa.

El mazo se construye dinámicamente desde `CRISIS_DECK` (`[dict(c) for c in Crisis.CRISIS_DECK]`), sin dependencia de un conteo fijo.

## Validación

- `py_compile` OK.
- Verificado: 59 cartas, **sin** filas `Action:` ni títulos de ubicación, todos los `tipo` válidos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_