### PR TITLE
BSG: /info muestra tu personaje y los colores de habilidad que recibes

### DIFF
--- a/BattlestarGalactica/Boardgamebox/Player.py
+++ b/BattlestarGalactica/Boardgamebox/Player.py
@@ -1,4 +1,27 @@
 from Boardgamebox.Player import Player as BasePlayer
+from collections import Counter
+
+from BattlestarGalactica.Constants import Characters, Skills, Locations
+
+
+def _resumen_skill_set(skill_set):
+    """Resume el set de habilidad de un personaje en líneas legibles, indicando
+    la cantidad por color y si el slot es FIJO o de ELECCIÓN (entre 2+ colores)."""
+    fijos = Counter()
+    elecciones = Counter()
+    for slot in skill_set:
+        if isinstance(slot, (list, tuple)):
+            elecciones[tuple(slot)] += 1
+        else:
+            fijos[slot] += 1
+    lineas = []
+    for color, n in fijos.items():
+        emoji = Skills.EMOJI_COLOR.get(color, "")
+        lineas.append(f"{emoji} {n}× {color} (fijo)")
+    for opciones, n in elecciones.items():
+        ops = " o ".join(f"{Skills.EMOJI_COLOR.get(c, '')} {c}" for c in opciones)
+        lineas.append(f"🔀 {n}× a elegir entre: {ops}")
+    return lineas
 
 
 class Player(BasePlayer):
@@ -18,3 +41,32 @@ class Player(BasePlayer):
         self.en_calabozo = False
         self.habilidad_usada = False   # habilidad de "una vez por juego"
         self.viper_area = None         # índice de área si pilota un Viper (None = en una ubicación)
+
+    def get_private_info(self, game):
+        """Información privada del jugador: su personaje y datos iniciales,
+        incluyendo qué cartas de habilidad recibe cada turno (color, cantidad y
+        si son fijas o a elegir)."""
+        pj = Characters.PERSONAJES.get(self.personaje)
+        if not pj:
+            return ("🚀 *Battlestar Galactica*\n\n"
+                    "Todavía no tienes personaje asignado en esta partida.")
+        emoji_tipo = Characters.EMOJI_TIPO.get(pj["tipo"], "")
+        ubic = Locations.UBICACIONES.get(pj["ubicacion"], {}).get("nombre", pj["ubicacion"])
+        lineas = [
+            "🚀 *Battlestar Galactica — Tu personaje*",
+            "",
+            f"{emoji_tipo} *{pj['nombre']}*  ·  _{pj['tipo']}_",
+        ]
+        if pj.get("titulo"):
+            lineas.append(f"🏷️ Título inicial: *{pj['titulo']}*")
+        lineas.append(f"📍 Ubicación inicial: {ubic}")
+        lineas.append("")
+        lineas.append("🃏 *Cartas de habilidad que recibes cada turno:*")
+        for l in _resumen_skill_set(pj["skill_set"]):
+            lineas.append(f"  • {l}")
+        lineas.append(f"  _Total: {len(pj['skill_set'])} cartas por turno._")
+        lineas.append("")
+        lineas.append("✨ *Habilidades:*")
+        lineas.append(pj["abilities"])
+        return "\n".join(lineas)
+


### PR DESCRIPTION
## Resumen

El comando global **`/info`** (que envía `player.get_private_info(game)` por privado) no mostraba nada útil en Battlestar Galactica. Ahora informa al jugador **qué personaje es, sus datos iniciales y los colores de carta que recibe**.

## Qué muestra ahora

- **Personaje**: nombre y tipo (Político/Militar/Piloto/Apoyo).
- **Datos iniciales**: título de inicio (Presidente/Almirante si aplica) y ubicación inicial.
- **Cartas de habilidad por turno**: cantidad por color, indicando si el slot es **FIJO** o de **ELECCIÓN** entre 2+ colores.
- **Habilidades** del personaje (texto oficial).

### Ejemplos

**William Adama** (todo fijo):
```
🟢 3× Liderazgo (fijo)
🟣 2× Tactica (fijo)
Total: 5 cartas por turno.
```

**Lee "Apollo" Adama** (con elección):
```
🟣 1× Tactica (fijo)
🔴 2× Pilotaje (fijo)
🔀 2× a elegir entre: 🟢 Liderazgo o 🟡 Politica
Total: 5 cartas por turno.
```

## Implementación

- Se sobrescribe `get_private_info` en `BattlestarGalactica/Boardgamebox/Player.py`, más un helper `_resumen_skill_set` que agrupa los slots por color (fijos) y por conjunto de opciones (elecciones).
- **No requiere nuevos handlers**: `/info` ya está cableado en `MainController` y BSG comparte el mismo `GamesController`/`get_game`, así que basta con el override. El mensaje se envía al privado del jugador (info secreta).
- Maneja el caso de jugador sin personaje asignado.

## Validación

- `py_compile` OK.
- Probado el `get_private_info` con personajes de slots fijos (Adama, Starbuck, Baltar) y de elección (Apollo): cantidades, colores y marca fijo/elección correctas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_