### PR TITLE
help: /help muestra también los comandos del juego activo

### DIFF
--- a/Commands.py
+++ b/Commands.py
@@ -53,7 +53,7 @@ from Constants.Cards import modos_juego
 
 from Constants.Config import JUEGOS_DISPONIBLES
 from Constants.Config import MODULOS_DISPONIBES
-from Constants.Config import HOJAS_AYUDA
+from Constants.Config import HOJAS_AYUDA, COMANDOS_JUEGO
 
 from Constants.Cards import comandos
 import random
@@ -238,7 +238,11 @@ async def command_help(update: Update, context: CallbackContext):
 	"Eventos Azules son opcionales\n"
 	'''
 	help_text = "\nLos siguientes comandos estan disponibles:\n"
-	help_text += commands	
+	help_text += commands
+	# Si hay una partida activa con comandos propios, los agregamos.
+	game = get_game(cid)
+	if game and getattr(game, "tipo", None) in COMANDOS_JUEGO:
+		help_text += "\n\n" + COMANDOS_JUEGO[game.tipo]
 	await bot.send_message(cid, help_text)
 		
 async def command_symbols(update: Update, context: CallbackContext):

--- a/Constants/Config.py
+++ b/Constants/Config.py
@@ -120,6 +120,30 @@ HOJAS_AYUDA = {
 		"`/mirol`: ver tu rol en privado."
 }
 
+# Comandos específicos de cada juego, para que /help los muestre cuando hay una
+# partida de ese tipo activa en el chat (además de los comandos generales).
+COMANDOS_JUEGO = {
+        "BattlestarGalactica":
+		"🚀 Comandos de Battlestar Galactica:\n"
+		"/estado - Resumen del estado de la partida\n"
+		"/mapa - Mapa de texto de la flota (ubicaciones y espacio)\n"
+		"/mapaimg - Imagen del tablero\n"
+		"/info - Tu personaje y tus datos (en privado)\n"
+		"/lealtad - Ver tu carta de lealtad (en privado)\n"
+		"/mano - Ver tu mano de cartas de habilidad (en privado)\n"
+		"/mover - Moverte a otra ubicación\n"
+		"/accion - Usar la acción de tu ubicación\n"
+		"/crisis - Revelar y resolver la Crisis\n"
+		"/aportar N - Aportar la carta N de tu mano a un chequeo (en privado)\n"
+		"/resolver - Resolver el chequeo de habilidad\n"
+		"/jugar - Jugar una carta de habilidad de acción\n"
+		"/quorum - (Presidente) Jugar una carta de Quórum\n"
+		"/habilidad - Usar tu habilidad de una vez por juego\n"
+		"/revelar - (Cylon) Revelarte\n"
+		"/encarcelar - Enviar a un jugador al Calabozo\n"
+		"/liberar - Liberar a un jugador del Calabozo"
+}
+
 MODULOS_DISPONIBES = {
         "LostExpedition" : {
                 "Solitario" : {


### PR DESCRIPTION
## Resumen

`/help` solo listaba los comandos **generales**. Ahora, si en el chat hay una **partida activa** cuyo tipo de juego tiene comandos propios, los muestra **debajo** de los generales.

## Cambios

- Nuevo registro **`Constants/Config.COMANDOS_JUEGO`** (`tipo de juego → texto de ayuda de comandos`), extensible a otros juegos.
- Entrada para **Battlestar Galactica** con todos sus comandos:
  `/estado`, `/mapa`, `/mapaimg`, `/info`, `/lealtad`, `/mano`, `/mover`, `/accion`, `/crisis`, `/aportar`, `/resolver`, `/jugar`, `/quorum`, `/habilidad`, `/revelar`, `/encarcelar`, `/liberar`.
- `command_help` detecta la partida con `get_game(cid)` y, si su `tipo` está en el registro, anexa su ayuda.

## Comportamiento

- Sin partida activa (o de un juego sin comandos propios): `/help` se comporta igual que antes.
- Con una partida de BSG: muestra los generales + el bloque de BSG.

## Validación

- `py_compile` OK en `Commands.py` y `Config.py`.
- `COMANDOS_JUEGO` evaluado de forma aislada: contiene la entrada de BSG con los comandos clave (`/mapaimg`, `/info`, `/crisis`, `/quorum`, `/liberar`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_