### PR TITLE
fix(BSG): restaurar command_accion — el bot no arrancaba

### DIFF
--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -467,6 +467,9 @@ async def command_mapa_img(update: Update, context: CallbackContext):
         log.error(f"command_mapa_img error: {e}")
         await bot.send_message(cid, "No pude generar la imagen del tablero; aquí va el mapa de texto:")
         await bot.send_message(cid, game.board.print_map(game), parse_mode=ParseMode.MARKDOWN)
+
+
+async def command_accion(update: Update, context: CallbackContext):
     """Acción del jugador activo (menú simplificado en esta capa)."""
     bot = context.bot
     cid = update.message.chat_id


### PR DESCRIPTION
## 🔴 Bug crítico: el bot no arrancaba (no respondía a nada)

### Causa raíz

El cuerpo de `command_accion` había quedado **fusionado dentro de `command_mapa_img`** y se perdió su línea `async def command_accion(...)`. Es decir, `command_accion` **dejó de existir** como función.

Como `MainController.main()` registra el handler:
```python
app.add_handler(CommandHandler("accion", BSGCommands.command_accion))
```
…al arrancar lanzaba **`AttributeError: module 'BattlestarGalactica.Commands' has no attribute 'command_accion'`** en plena fase de registro de handlers. Eso aborta `main()` **antes** de que el bot empiece a recibir updates → el bot entero no levanta y **no responde a ningún comando** (de ningún juego).

### Arreglo

Se vuelven a separar las dos funciones: `command_mapa_img` termina en su `try/except`, y `command_accion` recupera su firma y su cuerpo.

### Cómo lo verifiqué

Como `telegram` no importa en CI (problema de `cryptography`/rust del entorno), reproduje el arranque con **stubs** de las dependencias externas (`telegram*`, `html2image`, `PIL`, `psycopg`):

- `MainController` importa sin errores.
- Recorrí **todas** las referencias `BSGCommands.X` / `BSGController.X` / `Commands.X` de `MainController.py` y comprobé que cada una existe en su módulo → **0 referencias rotas** (antes del fix saltaba `BSGCommands.command_accion`).
- `py_compile` OK.

### Nota

El defecto se introdujo en el merge de #142 (`/mapaimg`): la edición que insertó `command_mapa_img` justo antes de `command_accion` terminó absorbiendo su cuerpo y perdiendo la línea `def`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_