### PR TITLE
fix(BSG): backfill de campos nuevos en partidas guardadas (evita crashes)

### DIFF
--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -21,7 +21,10 @@ logger = log.getLogger(__name__)
 
 
 def _validar(game):
-    return game and game.tipo == "BattlestarGalactica" and game.board
+    if game and game.tipo == "BattlestarGalactica" and game.board:
+        BSGController.asegurar_estado(game)  # backfill de campos nuevos en juegos viejos
+        return True
+    return False
 
 
 def _turno_de(st, uid):

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -55,6 +55,7 @@ Implementado en esta capa:
 """
 
 import logging as log
+import copy
 import random
 import re
 
@@ -71,6 +72,33 @@ import GamesController
 
 log.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=log.INFO)
 logger = log.getLogger(__name__)
+
+
+def asegurar_estado(game):
+    """Rellena los atributos que falten en partidas guardadas antes de que esos
+    campos existieran. jsonpickle restaura el __dict__ sin ejecutar __init__, así
+    que un juego viejo puede no tener campos nuevos del State/Player y romper al
+    accederlos (p. ej. st.nukes en print_board). Backfill desde instancias
+    frescas: no pisa valores existentes, solo agrega los ausentes."""
+    try:
+        if game is None or getattr(game, "board", None) is None:
+            return
+        st = getattr(game.board, "state", None)
+        if st is not None:
+            ref = type(st)()
+            for k, v in ref.__dict__.items():
+                if not hasattr(st, k):
+                    setattr(st, k, copy.deepcopy(v))
+        for p in list(getattr(game, "playerlist", {}).values()):
+            try:
+                refp = type(p)(p.name, p.uid)
+            except Exception:
+                continue
+            for k, v in refp.__dict__.items():
+                if not hasattr(p, k):
+                    setattr(p, k, copy.deepcopy(v))
+    except Exception as e:
+        logger.error(f"asegurar_estado error: {e}")
 
 
 # ===================== SETUP =====================


### PR DESCRIPTION
## Contexto

Tras el bug de `command_accion`, audité el código en busca de otros problemas. Resumen:

- ✅ **Sin funciones duplicadas ni fusionadas** (el de `command_accion` era el único).
- ✅ **Todos los `/comandos` registrados resuelven a funciones reales** (0 referencias rotas).
- ✅ **Todos los botones tienen handler** y todos los handlers se usan (21 prefijos `bsg*`, simetría perfecta).
- 🔴 **Encontré un riesgo real de crash**: compatibilidad de partidas guardadas (este PR).

## El problema

`jsonpickle` restaura el `__dict__` **sin ejecutar `__init__`**, por lo que una partida iniciada **antes** de esta sesión no tiene los campos nuevos de `State`/`Player` (`nukes`, `ubicaciones_bloqueadas`, `target_select`, `recrisis_pendiente`, `super_crisis`, `skill_choices_pendientes`, …).

Al accederlos **directamente** —p. ej. `st.nukes` en `Board.print_board`, que corre en **cada turno**— lanzaría `AttributeError`. Es decir: justo al desplegar, una partida en curso se rompería al mostrar el tablero.

## El arreglo

- Nueva **`Controller.asegurar_estado(game)`**: backfill genérico desde instancias frescas (`type(st)()` y `type(p)(name, uid)`). **No pisa** valores existentes, solo agrega los ausentes — y es *future-proof* para campos que se añadan más adelante.
- **`_validar()`** la invoca para toda partida BSG válida, de modo que **cada comando** normaliza el juego cargado antes de usarlo.

## Validación

- `py_compile` OK.
- Probado con un juego "viejo" simulado: un `State` sin `nukes` recupera `nukes=2`; sin `ubicaciones_bloqueadas` → `[]`; un `Player` sin `super_crisis` → `None`; `skill_choices_pendientes` → `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_