### PR TITLE
BSG: vista de costado del tablero y tubos de lanzamiento en Babor

### DIFF
--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -577,6 +577,25 @@ async def callback_bsg_accion(update: Update, context: CallbackContext):
                 await bot.send_message(cid, "¿A qué área adyacente vuelas?", reply_markup=InlineKeyboardMarkup(btns))
             return
 
+        # Lanzarte en un Viper: solo se puede salir por los tubos de lanzamiento
+        # (Babor-proa y Babor-popa). Preguntamos por cuál de los dos lados.
+        if accion == "launch":
+            await callback.answer()
+            btns = []
+            for i in Space.LAUNCH_AREAS:
+                a = st.areas[i]
+                cylons = a["raiders"] + a.get("heavy_raiders", 0) + len(a["basestars"])
+                amenaza = f" ⚠️{cylons}" if cylons else ""
+                btns.append([InlineKeyboardButton(
+                    f"🚀 {Space.nombre(i)}{amenaza}",
+                    callback_data=f"{cid}*bsgArea*launch_{i}*{presser}")])
+            try:
+                await bot.edit_message_text("¿Por qué tubo de lanzamiento despegas?", cid, callback.message.message_id,
+                                            reply_markup=InlineKeyboardMarkup(btns))
+            except Exception:
+                await bot.send_message(cid, "¿Por qué tubo de lanzamiento despegas?", reply_markup=InlineKeyboardMarkup(btns))
+            return
+
         # Acciones que requieren elegir un ÁREA del espacio → mostrar botonera de áreas
         if accion in BSGController.ACCIONES_CON_AREA:
             await callback.answer()

--- a/BattlestarGalactica/Constants/Space.py
+++ b/BattlestarGalactica/Constants/Space.py
@@ -20,14 +20,14 @@ N_AREAS = 6
 
 AREAS = [
     {"id": 0, "nombre": "Proa",          "emoji": "🔴", "launch": False},
-    {"id": 1, "nombre": "Estribor-proa", "emoji": "🚀", "launch": True},
+    {"id": 1, "nombre": "Estribor-proa", "emoji": "▫️", "launch": False},
     {"id": 2, "nombre": "Estribor-popa", "emoji": "▫️", "launch": False},
     {"id": 3, "nombre": "Popa",          "emoji": "🛰️", "launch": False},
-    {"id": 4, "nombre": "Babor-popa",    "emoji": "▫️", "launch": False},
+    {"id": 4, "nombre": "Babor-popa",    "emoji": "🚀", "launch": True},
     {"id": 5, "nombre": "Babor-proa",    "emoji": "🚀", "launch": True},
 ]
 
-LAUNCH_AREAS = [1, 5]   # áreas con tubo de lanzamiento de Vipers
+LAUNCH_AREAS = [5, 4]   # tubos de lanzamiento de Vipers: Babor-proa y Babor-popa
 AREA_PROA = 0           # amenaza Cylon inicial
 AREA_POPA = 3           # naves civiles iniciales
 

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -820,7 +820,7 @@ async def ejecutar_accion_ubicacion(bot, game, uid, accion, objetivo=None):
     elif accion == "repair":
         await _reparar_galactica(bot, game, player)
     elif accion == "launch":
-        await _lanzar_piloto(bot, game, player)
+        await _lanzar_piloto(bot, game, player, area_idx=objetivo)
     elif accion == "pilot_attack":
         await _pilot_atacar(bot, game, player)
     elif accion == "pilot_move":
@@ -1108,8 +1108,13 @@ def total_vipers_tripulados(game):
     return sum(1 for p in game.playerlist.values() if getattr(p, "viper_area", None) is not None)
 
 
-async def _lanzar_piloto(bot, game, player):
-    """El jugador despega en un Viper tripulado desde un tubo de lanzamiento."""
+async def _lanzar_piloto(bot, game, player, area_idx=None):
+    """El jugador despega en un Viper tripulado desde un tubo de lanzamiento.
+
+    Los Vipers solo pueden salir por los tubos de lanzamiento (Babor-proa y
+    Babor-popa); ``area_idx`` indica el lado elegido por el jugador. Si no se
+    especifica, despega por el tubo con menos presencia Cylon.
+    """
     st = game.board.state
     if getattr(player, "viper_area", None) is not None:
         await bot.send_message(game.cid, "Ya estás pilotando un Viper.")
@@ -1117,9 +1122,12 @@ async def _lanzar_piloto(bot, game, player):
     if st.vipers_reserva <= 0:
         await bot.send_message(game.cid, "No quedan Vipers en la reserva.")
         return False
-    # Despega por el tubo con menos presencia Cylon.
-    area = min(Space.LAUNCH_AREAS,
-               key=lambda k: st.areas[k]["raiders"] + st.areas[k].get("heavy_raiders", 0) + len(st.areas[k]["basestars"]))
+    if area_idx in Space.LAUNCH_AREAS:
+        area = area_idx
+    else:
+        # Despega por el tubo con menos presencia Cylon.
+        area = min(Space.LAUNCH_AREAS,
+                   key=lambda k: st.areas[k]["raiders"] + st.areas[k].get("heavy_raiders", 0) + len(st.areas[k]["basestars"]))
     st.vipers_reserva -= 1
     player.viper_area = area
     player.ubicacion = None

--- a/BattlestarGalactica/render.py
+++ b/BattlestarGalactica/render.py
@@ -34,15 +34,17 @@ _GAL_2 = ["admiral_quarters", "research", "communications", "sickbay", "brig"]
 _COLONIAL = ["press_room", "president_office", "administration"]
 _CYLON = ["caprica", "cylon_fleet", "human_fleet", "resurrection_ship"]
 
-# Posición en la rejilla 3x4 de cada área del espacio (fila, columna), 1-based.
-# El anillo rodea a Galactica, que ocupa el centro (filas 2-3, columna 2).
+# Vista de COSTADO de la nave: la proa apunta a la IZQUIERDA y la popa a la
+# derecha. Galactica ocupa la franja central (fila 2, columnas 2-3) y las 6 áreas
+# del espacio la rodean. Estribor arriba, Babor (con los tubos) abajo.
+# Posición en la rejilla 3x4 de cada área (fila, columna), 1-based.
 _AREA_GRID = {
-    0: (1, 2),  # Proa
-    1: (2, 3),  # Estribor-proa
-    2: (3, 3),  # Estribor-popa
-    3: (4, 2),  # Popa
-    4: (3, 1),  # Babor-popa
-    5: (2, 1),  # Babor-proa
+    0: (2, 1),  # Proa          (izquierda, frente a la nave)
+    1: (1, 2),  # Estribor-proa (arriba-izquierda)
+    2: (1, 3),  # Estribor-popa (arriba-derecha)
+    3: (2, 4),  # Popa          (derecha, detrás de la nave)
+    4: (3, 3),  # Babor-popa    (abajo-derecha, tubo de lanzamiento)
+    5: (3, 2),  # Babor-proa    (abajo-izquierda, tubo de lanzamiento)
 }
 
 
@@ -130,8 +132,8 @@ def render_board_html(game):
         )
 
     centro = (
-        "<div class='galactica' style='grid-row:2 / span 2;grid-column:2;'>"
-        "<div class='gtitle'>GALÁCTICA</div>"
+        "<div class='galactica' style='grid-row:2;grid-column:2 / span 2;'>"
+        "<div class='gtitle'>◄ GALÁCTICA</div>"
         f"<div class='gsub'>Daño {st.total_danos_galactica()}/{st.galactica_danos_max}</div>"
         f"<div class='gsub'>Abordaje {st.total_centuriones()} · "
         f"Reserva V {st.vipers_reserva} · Dañados {st.vipers_danados}</div>"
@@ -186,9 +188,9 @@ def render_board_html(game):
         + _res("OJIVAS", st.nukes)
     )
 
-    # Altura del lienzo: cabecera + anillo + paneles (5 filas máx.) + márgenes.
+    # Altura del lienzo: cabecera + anillo (3 filas) + paneles (5 filas máx.) + márgenes.
     canvas_w = 1180
-    canvas_h = 150 + 560 + 40 + 5 * 78 + 70
+    canvas_h = 150 + 470 + 40 + 5 * 78 + 70
 
     html = f"""<!DOCTYPE html><html><head><meta charset="utf-8"><style>
 * {{ box-sizing: border-box; margin: 0; padding: 0; }}
@@ -201,8 +203,8 @@ body {{ width: {canvas_w}px; background: #0b1020; color: #e7ecf5;
         flex-direction: column; align-items: center; line-height: 1.1; }}
 .res i {{ font-style: normal; font-size: 10px; font-weight: 700; color: #7f93c4;
           letter-spacing: .5px; }}
-.ring {{ display: grid; grid-template-columns: repeat(3, 1fr);
-         grid-template-rows: 130px 130px 130px 130px; gap: 10px; margin-bottom: 16px; }}
+.ring {{ display: grid; grid-template-columns: repeat(4, 1fr);
+         grid-template-rows: 150px 150px 150px; gap: 10px; margin-bottom: 16px; }}
 .area {{ background: #111a30; border: 1px solid #29365c; border-radius: 12px;
          padding: 8px; display: flex; flex-direction: column; }}
 .area-h {{ font-size: 14px; font-weight: 700; color: #9fb6e8; margin-bottom: 6px;
@@ -210,10 +212,10 @@ body {{ width: {canvas_w}px; background: #0b1020; color: #e7ecf5;
 .area-b {{ display: flex; flex-wrap: wrap; gap: 4px; align-content: flex-start; }}
 .tube {{ font-size: 11px; background: #1d4ed8; color: #fff; border-radius: 6px;
          padding: 1px 5px; font-weight: 700; }}
-.galactica {{ background: radial-gradient(circle at 50% 40%, #34507f, #16213d);
-              border: 2px solid #5b7cc0; border-radius: 16px; display: flex;
-              flex-direction: column; align-items: center; justify-content: center;
-              text-align: center; padding: 10px; }}
+.galactica {{ background: linear-gradient(90deg, #1a2b4d 0%, #3a5a92 55%, #22335a 100%);
+              clip-path: polygon(0 50%, 13% 0, 100% 0, 100% 100%, 13% 100%);
+              display: flex; flex-direction: column; align-items: center;
+              justify-content: center; text-align: center; padding: 10px 10px 10px 60px; }}
 .gtitle {{ font-size: 30px; font-weight: 900; color: #dfe9ff; letter-spacing: 2px; }}
 .gsub {{ font-size: 14px; color: #b9c8ec; margin-top: 4px; }}
 .ship {{ font-size: 13px; font-weight: 800; color: #fff; border-radius: 6px;


### PR DESCRIPTION
## Resumen

Ajustes pedidos sobre el módulo de **Battlestar Galactica**:

### 1. Mapa de la nave de costado (`/mapaimg`)
- El tablero ahora se renderiza **de costado**, con la **proa apuntando a la izquierda** y la popa a la derecha.
- Las 6 áreas del espacio rodean a Galáctica: **Estribor arriba**, **Babor abajo** (donde están los tubos de lanzamiento).
- La silueta de Galáctica se dibuja con el morro apuntando a la izquierda (`◄ GALÁCTICA`).

### 2. Tubos de lanzamiento solo en Babor
- Los Vipers **solo pueden salir por Babor-proa y Babor-popa** (antes eran Estribor-proa y Babor-proa).
- Al elegir **«Lanzarte en un Viper»**, el bot **pregunta por cuál de los dos tubos** despegar (mostrando la amenaza Cylon de cada lado), tanto para Vipers pilotados como para el despliegue.

### 3. Setup inicial corregido
- El Viper que aparecía mal en **Estribor-proa** ahora se despliega en **Babor-popa**. Se mantiene 1 Viper en cada tubo de Babor.

## Archivos
- `BattlestarGalactica/Constants/Space.py` — `LAUNCH_AREAS = [5, 4]` y flags de tubo en Babor.
- `BattlestarGalactica/Controller.py` — `_lanzar_piloto` acepta el tubo elegido; la acción `launch` lo propaga.
- `BattlestarGalactica/Commands.py` — botonera de selección de tubo al lanzarte.
- `BattlestarGalactica/render.py` — rejilla horizontal (vista de costado) y silueta apuntando a la izquierda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvp9c311x3ZC2LZ5nDMavk)_