### PR TITLE
BSG: mano inicial elegible + anunciar el mazo robado en el grupo

### DIFF
--- a/BattlestarGalactica/Boardgamebox/Player.py
+++ b/BattlestarGalactica/Boardgamebox/Player.py
@@ -38,6 +38,7 @@ class Player(BasePlayer):
         self.skill_choices_pendientes = []  # slots de elección del reparto inicial por decidir
         self.setup_slots = []          # slots del skill set aún disponibles en la mano inicial
         self.setup_restantes = 0       # cartas de la mano inicial que el jugador debe elegir
+        self.setup_robadas = []        # colores ya elegidos de la mano inicial (para anunciar)
         self.quorum_hand = []          # cartas de Quórum (Presidente)
         self.super_crisis = None       # Súper Crisis en mano (Cylon revelado): se juega en Caprica
         self.en_calabozo = False

--- a/BattlestarGalactica/Boardgamebox/Player.py
+++ b/BattlestarGalactica/Boardgamebox/Player.py
@@ -36,6 +36,8 @@ class Player(BasePlayer):
         self.revealed = False          # si ya se reveló como Cylon
         self.skill_hand = []           # lista de cartas {color, valor}
         self.skill_choices_pendientes = []  # slots de elección del reparto inicial por decidir
+        self.setup_slots = []          # slots del skill set aún disponibles en la mano inicial
+        self.setup_restantes = 0       # cartas de la mano inicial que el jugador debe elegir
         self.quorum_hand = []          # cartas de Quórum (Presidente)
         self.super_crisis = None       # Súper Crisis en mano (Cylon revelado): se juega en Caprica
         self.en_calabozo = False

--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -153,8 +153,12 @@ async def callback_bsg_setup(update: Update, context: CallbackContext):
             await callback.answer("No es tu mano.")
             return
         player = game.playerlist.get(presser)
-        if not player or not player.skill_choices_pendientes \
-                or color not in player.skill_choices_pendientes[0]:
+        disponibles = []
+        for slot in (getattr(player, "setup_slots", None) or []):
+            for c in slot:
+                if c not in disponibles:
+                    disponibles.append(c)
+        if not player or getattr(player, "setup_restantes", 0) <= 0 or color not in disponibles:
             await callback.answer("Color no disponible.")
             return
         await callback.answer(f"Robaste {color}.")

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -235,19 +235,17 @@ async def finalizar_setup(bot, game):
     _colocar_flota_inicial(st)
 
     # --- Mano inicial de habilidades (regla del juego base) ---
-    # Todos los jugadores EXCEPTO el primero roban su set completo de habilidades
-    # al empezar. Los slots fijos se reparten solos; los de elección (p. ej. Apolo,
-    # Liderazgo/Política) los decide el propio jugador por privado. El primer
-    # jugador robará su mano en su primer turno (su ventaja es jugar primero).
+    # Todos los jugadores EXCEPTO el primero roban su MANO INICIAL de 3 cartas de
+    # habilidad (tomadas de dentro de su skill set). Los slots fijos se reparten
+    # solos; los de elección los decide el propio jugador por privado. El primer
+    # jugador NO roba ahora: tomará su mano normal completa en su primer turno
+    # (esa es la ventaja de jugar primero).
     primer_jugador = game.player_sequence[0]
     for player in game.player_sequence:
         if player.uid == primer_jugador.uid:
             continue
-        player.skill_choices_pendientes = _repartir_set_fijo(st, player)
-        if player.skill_choices_pendientes:
-            await _prompt_setup_choice(bot, game, player)
-        else:
-            await _dm_mano(bot, player)
+        _iniciar_mano_inicial(player)
+        await _prompt_mano_inicial(bot, game, player)
 
     st.fase_actual = "En Juego"
     st.player_counter = 0
@@ -296,19 +294,25 @@ def _slots_personaje(skill_set):
     return [list(s) if isinstance(s, (list, tuple)) else [s] for s in skill_set]
 
 
-def _repartir_set_fijo(st, player):
-    """Reparte a la mano los slots FIJOS del set del personaje y devuelve la lista
-    de slots de ELECCIÓN pendientes (para que el jugador los decida por privado)."""
+MANO_INICIAL = 3  # cartas de la mano inicial (regla del juego base)
+
+
+def _iniciar_mano_inicial(player):
+    """Prepara la elección de la mano inicial: el jugador elegirá MANO_INICIAL
+    cartas de dentro de su skill set (sin exceder el cupo de cada color)."""
     pj = Characters.PERSONAJES[player.personaje]
-    pendientes = []
-    for opciones in _slots_personaje(pj["skill_set"]):
-        if len(opciones) == 1:
-            carta = _robar_carta_color(st, opciones[0])
-            if carta:
-                player.skill_hand.append(carta)
-        else:
-            pendientes.append(list(opciones))
-    return pendientes
+    player.setup_slots = _slots_personaje(pj["skill_set"])
+    player.setup_restantes = min(MANO_INICIAL, len(player.setup_slots))
+
+
+def _colores_disponibles(slots):
+    """Colores que los slots restantes todavía permiten elegir (sin repetir)."""
+    colores = []
+    for slot in slots:
+        for c in slot:
+            if c not in colores:
+                colores.append(c)
+    return colores
 
 
 LIMITE_MANO = 10
@@ -465,39 +469,51 @@ async def _entregar_carta_skill(bot, game, player, color):
         await bot.send_message(player.uid, f"(No quedan cartas de {color}.)")
 
 
-async def _prompt_setup_choice(bot, game, player):
-    """Pide por privado al jugador el color del siguiente slot de elección de su
-    mano inicial (reparto de setup)."""
-    if not player.skill_choices_pendientes:
+async def _prompt_mano_inicial(bot, game, player):
+    """Pide por privado al jugador que elija la siguiente carta de su mano inicial
+    entre los colores que su skill set todavía permite."""
+    if getattr(player, "setup_restantes", 0) <= 0 or not getattr(player, "setup_slots", None):
+        player.setup_slots = []
+        player.setup_restantes = 0
         await _dm_mano(bot, player)
         return
-    opciones = player.skill_choices_pendientes[0]
+    nro = MANO_INICIAL - player.setup_restantes + 1
+    colores = _colores_disponibles(player.setup_slots)
     btns = [[InlineKeyboardButton(
                 f"{Skills.EMOJI_COLOR[c]} {c}",
                 callback_data=f"{game.cid}*bsgSetup*{c}*{player.uid}")]
-            for c in opciones]
+            for c in colores]
     await bot.send_message(
         player.uid,
-        f"🃏 *Mano inicial* — te quedan *{len(player.skill_choices_pendientes)}* carta(s) a elegir.\n"
-        f"Elige el tipo de esta carta ({' / '.join(opciones)}):",
+        f"🃏 *Mano inicial* — elige tu carta *{nro}/{MANO_INICIAL}* "
+        f"(dentro de tu skill set):",
         reply_markup=InlineKeyboardMarkup(btns),
         parse_mode=ParseMode.MARKDOWN,
     )
 
 
 async def resolver_setup_choice(bot, game, uid, color):
-    """Resuelve un slot de elección del reparto inicial con el color elegido."""
+    """Resuelve una elección de la mano inicial: roba una carta del color elegido,
+    consumiendo un slot del skill set que lo admita (prioriza un slot fijo de ese
+    color para conservar los slots de elección)."""
     player = game.playerlist.get(uid)
-    if not player or not player.skill_choices_pendientes:
+    if not player or getattr(player, "setup_restantes", 0) <= 0:
         return
-    if color not in player.skill_choices_pendientes[0]:
-        return
-    player.skill_choices_pendientes.pop(0)
+    slots = player.setup_slots or []
+    idx = next((i for i, s in enumerate(slots) if color in s and len(s) == 1), None)
+    if idx is None:
+        idx = next((i for i, s in enumerate(slots) if color in s), None)
+    if idx is None:
+        return  # color no permitido por el skill set restante
+    slots.pop(idx)
+    player.setup_restantes -= 1
     await _entregar_carta_skill(bot, game, player, color)
-    if player.skill_choices_pendientes:
+    if player.setup_restantes > 0 and slots:
         await save(bot, game.cid)
-        await _prompt_setup_choice(bot, game, player)
+        await _prompt_mano_inicial(bot, game, player)
     else:
+        player.setup_slots = []
+        player.setup_restantes = 0
         await _dm_mano(bot, player)
         await save(bot, game.cid)
 

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -58,6 +58,7 @@ import logging as log
 import copy
 import random
 import re
+from collections import Counter
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.constants import ParseMode
@@ -303,6 +304,7 @@ def _iniciar_mano_inicial(player):
     pj = Characters.PERSONAJES[player.personaje]
     player.setup_slots = _slots_personaje(pj["skill_set"])
     player.setup_restantes = min(MANO_INICIAL, len(player.setup_slots))
+    player.setup_robadas = []
 
 
 def _colores_disponibles(slots):
@@ -418,7 +420,7 @@ async def iniciar_turno(bot, game):
         slots = _slots_personaje(pj["skill_set"])
         encabezado = f"🎬 *Turno de {player.name}*"
 
-    st.skill_draw = {"uid": player.uid, "slots": slots}
+    st.skill_draw = {"uid": player.uid, "slots": slots, "robadas": []}
     await bot.send_message(
         game.cid,
         f"{encabezado} — *Recibir Habilidades*.\n"
@@ -447,26 +449,45 @@ async def _procesar_slots_skill(bot, game):
         await save(bot, game.cid)
         await _prompt_color_skill(bot, game)
         return
+    robadas = sd.get("robadas", [])
     st.skill_draw = None
+    await _anunciar_robo_grupo(bot, game, player, robadas)
     await _dm_mano(bot, player)
     await save(bot, game.cid)
     await _anunciar_turno(bot, game)
 
 
+async def _anunciar_robo_grupo(bot, game, player, colores):
+    """Anuncia en el grupo de qué mazo(s) robó el jugador (sin revelar el valor)."""
+    if not colores:
+        return
+    partes = [f"{Skills.EMOJI_COLOR.get(c, '')} {c}×{n}" for c, n in Counter(colores).items()]
+    await bot.send_message(
+        game.cid,
+        f"🃏 *{player.name}* roba {len(colores)} carta(s) de habilidad: " + ", ".join(partes),
+        parse_mode=ParseMode.MARKDOWN,
+    )
+
+
 async def _entregar_carta_skill(bot, game, player, color):
-    """Roba 1 carta del color dado a la mano del jugador y lo notifica por privado."""
+    """Roba 1 carta del color dado a la mano del jugador y lo notifica por privado.
+    Devuelve el color robado (o None si el mazo estaba vacío)."""
     st = game.board.state
     carta = _robar_carta_color(st, color)
     if carta:
         player.skill_hand.append(carta)
+        # Registrar el mazo robado para el anuncio público del paso de robo del turno.
+        if st.skill_draw and st.skill_draw.get("uid") == player.uid:
+            st.skill_draw.setdefault("robadas", []).append(carta["color"])
         await bot.send_message(
             player.uid,
             f"➕ Robaste {Skills.EMOJI_COLOR[carta['color']]} {carta['color']} {carta['valor']} "
             f"— _{carta.get('nombre','')}_",
             parse_mode=ParseMode.MARKDOWN,
         )
-    else:
-        await bot.send_message(player.uid, f"(No quedan cartas de {color}.)")
+        return carta["color"]
+    await bot.send_message(player.uid, f"(No quedan cartas de {color}.)")
+    return None
 
 
 async def _prompt_mano_inicial(bot, game, player):
@@ -507,13 +528,18 @@ async def resolver_setup_choice(bot, game, uid, color):
         return  # color no permitido por el skill set restante
     slots.pop(idx)
     player.setup_restantes -= 1
-    await _entregar_carta_skill(bot, game, player, color)
+    robado = await _entregar_carta_skill(bot, game, player, color)
+    if robado:
+        player.setup_robadas.append(robado)
     if player.setup_restantes > 0 and slots:
         await save(bot, game.cid)
         await _prompt_mano_inicial(bot, game, player)
     else:
+        robadas = list(getattr(player, "setup_robadas", []) or [])
         player.setup_slots = []
         player.setup_restantes = 0
+        player.setup_robadas = []
+        await _anunciar_robo_grupo(bot, game, player, robadas)
         await _dm_mano(bot, player)
         await save(bot, game.cid)
 


### PR DESCRIPTION
## Resumen

Dos mejoras relacionadas con el robo de cartas de habilidad en Battlestar Galactica.

### 1. Mano inicial de 3 cartas elegidas por cada jugador
Regla del juego base: cada jugador *excepto el primero* roba **3** cartas de habilidad de dentro de su skill set; el primer jugador roba su mano normal completa en su primer turno.

- Antes el setup repartía el **set completo** (4–6 cartas) automáticamente. Ahora cada jugador (salvo el primero) **elige** sus 3 cartas por privado, entre los colores que su skill set permite.
- Se respeta el **cupo por color**: no se puede tomar más de un color que la cantidad de slots de ese color; los slots de elección se conservan para dar flexibilidad.
- El robo **por turno** (mano normal = set completo) queda sin cambios.

### 2. Anunciar en el grupo de qué mazo roba cada jugador
Cuando un jugador roba cartas de habilidad, ahora se anuncia públicamente **de qué mazo/color** saca (sin revelar el valor, que sigue siendo privado):

- Paso **«Recibir Habilidades»** (robo por turno): resumen al completar el robo. Ej.: `🃏 Leo roba 5 carta(s) de habilidad: 🟢 Liderazgo×3, 🟣 Tactica×2`.
- **Mano inicial** (setup): resumen al terminar de elegir. Ej.: `🃏 Ana roba 3 carta(s) de habilidad: 🟡 Politica×2, 🟢 Liderazgo×1`.
- El robo por **acción de ubicación** y el de **Quórum** ya se anunciaban.

### Verificación
Simulaciones con stubs:
- Elección de mano inicial con control de cupos (Apolo, Roslin). ✅
- Anuncios públicos disparados tanto en setup como en el robo por turno, con el valor en privado. ✅

## Archivos
- `BattlestarGalactica/Controller.py`
- `BattlestarGalactica/Commands.py`
- `BattlestarGalactica/Boardgamebox/Player.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)