### PR TITLE
Add Puerto Banana game: secret-bid banana auction

### DIFF
--- a/Commands.py
+++ b/Commands.py
@@ -35,6 +35,7 @@ from SecretoCodigo.Boardgamebox.Game import Game as GameSecretoCodigo
 from SpyFall.Boardgamebox.Game import Game as GameSpyFall
 from Insider.Boardgamebox.Game import Game as GameInsider
 from BattlestarGalactica.Boardgamebox.Game import Game as GameBSG
+from PuertoBanana.Boardgamebox.Game import Game as GamePuertoBanana
 
 from Boardgamebox.Player import Player
 from Boardgamebox.State import State
@@ -668,6 +669,8 @@ async def CreateGame(cid, uid, tipo, groupName, bot):
 		GamesController.games[cid] = GameInsider(cid, uid, groupName, tipo)
 	elif tipo == 'BattlestarGalactica':
 		GamesController.games[cid] = GameBSG(cid, uid, groupName, tipo)
+	elif tipo == 'PuertoBanana':
+		GamesController.games[cid] = GamePuertoBanana(cid, uid, groupName, tipo)
 	else:
 		GamesController.games[cid] = Game(cid, uid, groupName, tipo)
 

--- a/Constants/Config.py
+++ b/Constants/Config.py
@@ -92,6 +92,11 @@ JUEGOS_DISPONIBLES = {
                     "BattlestarGalactica" : "Battlestar Galactica"
                 },
         },
+	"PuertoBanana" : {
+                "comandos" : {
+                    "PuertoBanana" : "Puerto Banana"
+                },
+        },
 }
 
 
@@ -306,6 +311,15 @@ MODULOS_DISPONIBES = {
                         },
                         "min_jugadores" : 3,
                         "max_jugadores" : 6
+                }
+        },
+	"PuertoBanana" : {
+                "Clasico" : {
+                        "comandos" : {
+                            "Clasico" : "Clásico"
+                        },
+                        "min_jugadores" : 3,
+                        "max_jugadores" : 10
                 }
         },
 }

--- a/MainController.py
+++ b/MainController.py
@@ -35,6 +35,7 @@ import SecretoCodigo.Controller as SecretoCodigoController
 import SpyFall.Controller as SpyFallController
 import Insider.Controller as InsiderController
 import BattlestarGalactica.Controller as BSGController
+import PuertoBanana.Controller as PuertoBananaController
 
 # Importo los comandos de los juegos que vaya agregando
 import JustOne.Commands as JustoneCommands
@@ -50,6 +51,7 @@ import SecretoCodigo.Commands as SecretoCodigoCommands
 import SpyFall.Commands as SpyFallCommands
 import Insider.Commands as InsiderCommands
 import BattlestarGalactica.Commands as BSGCommands
+import PuertoBanana.Commands as PuertoBananaCommands
 
 from Constants.Cards import playerSets, actions
 from Constants.Config import TOKEN, STATS, ADMIN
@@ -142,6 +144,9 @@ async def init_game(bot, game):
 	elif game.tipo == "BattlestarGalactica":
 		game.create_board()
 		await BSGController.init_game(bot, game)
+	elif game.tipo == "PuertoBanana":
+		game.create_board()
+		await PuertoBananaController.init_game(bot, game)
 
 
 async def init_lost_expedition(bot, game, player_number):
@@ -858,6 +863,11 @@ def main(stop_event):
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgCrisisSel\*([01])\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_crisis_sel))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgMod\*(-?[0-9]+)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_mod))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*chooseendBSG\*(.*)\*([0-9]*)", callback=BSGController.callback_finish_game_buttons_bsg))
+
+	# Handlers de Puerto Banana
+	app.add_handler(CommandHandler("puja", PuertoBananaCommands.command_puja))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*choosegamepujaPB\*(-?[0-9]*)\*([0-9]*)", callback=PuertoBananaCommands.callback_choose_game_puja))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-[0-9]*)\*chooseendPB\*(.*)\*([0-9]*)", callback=PuertoBananaController.callback_finish_game_buttons_pb))
 
 	app.add_handler(CommandHandler("status", command_status))
 

--- a/PuertoBanana/Boardgamebox/Board.py
+++ b/PuertoBanana/Boardgamebox/Board.py
@@ -1,0 +1,24 @@
+from Boardgamebox.Board import Board as BaseBoard
+from PuertoBanana.Boardgamebox.State import State
+
+BANANAS_VICTORIA = 200
+
+
+class Board(BaseBoard):
+    def __init__(self, playercount, game):
+        self.state = State()
+        self.num_players = playercount
+        self.cartas = []
+        self.discards = []
+
+    def print_board(self, game):
+        st = self.state
+        board = "--- 🍌 *Puerto Banana* ---\n"
+        board += f"Fase: {st.fase_actual}\n"
+        board += f"Ronda: {st.ronda}\n"
+        board += f"Pozo actual: *{st.pozo_actual}* bananas\n\n"
+        board += "--- *Jugadores* ---\n"
+        for player in game.player_sequence:
+            puja = " (ya pujó)" if player.uid in st.last_votes else ""
+            board += f"• {player.name}{puja}\n"
+        return board

--- a/PuertoBanana/Boardgamebox/Game.py
+++ b/PuertoBanana/Boardgamebox/Game.py
@@ -1,0 +1,40 @@
+from Boardgamebox.Game import Game as BaseGame
+from PuertoBanana.Boardgamebox.Player import Player
+from PuertoBanana.Boardgamebox.Board import Board
+
+
+class Game(BaseGame):
+    def __init__(self, cid, initiator, groupName, tipo=None, modo=None):
+        BaseGame.__init__(self, cid, initiator, groupName, tipo, modo)
+
+    def add_player(self, uid, name):
+        self.playerlist[uid] = Player(name, uid)
+
+    def create_board(self):
+        self.board = Board(len(self.playerlist), self)
+
+    def get_rules(self):
+        return [
+            "Puerto Banana",
+            "Todos los jugadores empiezan con *10 bananas*, anotadas en su tablero "
+            "privado (usá `/info` para ver tu cantidad). El juego termina cuando algún "
+            "jugador llega a *200 bananas*.\n\n"
+            "En cada ronda se subasta un pozo que equivale a la cantidad de bananas que "
+            "tiene el jugador que va ganando. Cada jugador puja en privado con "
+            "`/puja CANTIDAD` cualquier cantidad que quiera, en secreto, sin estar "
+            "limitado por lo que tiene.\n\n"
+            "El jugador que pujó más alto se lleva el pozo, pero en vez de pagar lo que "
+            "pujó, paga al segundo jugador que pujó más alto la *diferencia* entre ambas "
+            "pujas.\n\n"
+            "Si esa diferencia es mayor a lo que el jugador puede pagar (sumando lo que "
+            "tenía más lo ganado en el pozo), queda *eliminado de la ronda* y pierde "
+            "todas sus bananas.\n\n"
+            "*Comandos:*\n"
+            "• `/puja CANTIDAD` — pujar en privado\n"
+            "• `/info` — ver cuántas bananas tenés"
+        ]
+
+    async def call(self, context):
+        import PuertoBanana.Commands as PuertoBananaCommands
+        if self.board is not None:
+            await PuertoBananaCommands.command_call(context.bot, self)

--- a/PuertoBanana/Boardgamebox/Player.py
+++ b/PuertoBanana/Boardgamebox/Player.py
@@ -1,0 +1,13 @@
+from Boardgamebox.Player import Player as BasePlayer
+
+BANANAS_INICIALES = 10
+
+
+class Player(BasePlayer):
+    def __init__(self, name, uid):
+        BasePlayer.__init__(self, name, uid)
+        self.bananas = BANANAS_INICIALES
+        self.eliminado_ronda = False
+
+    def get_private_info(self, game):
+        return f"--- 🍌 Info de {self.name} ---\nTenés *{self.bananas}* bananas."

--- a/PuertoBanana/Boardgamebox/State.py
+++ b/PuertoBanana/Boardgamebox/State.py
@@ -1,0 +1,14 @@
+from Boardgamebox.State import State as BaseState
+
+
+class State(BaseState):
+    def __init__(self):
+        BaseState.__init__(self)
+        # Fases: "Pujando" -> "Finalizado"
+        self.fase_actual = "Pujando"
+        self.ronda = 1
+        # Pozo de la ronda actual (bananas del jugador que va ganando)
+        self.pozo_actual = 0
+        # Pujas secretas de la ronda actual {uid: cantidad}
+        self.last_votes = {}
+        self.ganador_uid = None

--- a/PuertoBanana/Commands.py
+++ b/PuertoBanana/Commands.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import logging as log
+import re
+
+import PuertoBanana.Controller as PuertoBananaController
+from Utils import get_game, save
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.constants import ParseMode
+from telegram.ext import CallbackContext
+
+import GamesController
+
+log.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=log.INFO)
+logger = log.getLogger(__name__)
+
+
+def _validar_partida(game):
+    return game and game.tipo == "PuertoBanana" and game.board
+
+
+async def command_call(bot, game):
+    """Recordatorio de quién no pujó todavía."""
+    if not _validar_partida(game):
+        return
+    st = game.board.state
+    if st.fase_actual != "Pujando":
+        return
+    faltantes = [p for p in game.player_sequence if p.uid not in st.last_votes]
+    if not faltantes:
+        return
+    nombres = ", ".join(p.name for p in faltantes)
+    await bot.send_message(
+        game.cid,
+        f"🍌 Todavía faltan pujar (en privado, con `/puja CANTIDAD`): {nombres}",
+        parse_mode=ParseMode.MARKDOWN
+    )
+
+
+async def _aplicar_puja(bot, game, uid, monto):
+    st = game.board.state
+    if uid not in game.playerlist:
+        await bot.send_message(uid, "No estás en esa partida de Puerto Banana.")
+        return
+    if st.fase_actual != "Pujando":
+        await bot.send_message(uid, "No es momento de pujar.")
+        return
+    if uid in st.last_votes:
+        await bot.send_message(uid, "Ya hiciste tu puja esta ronda.")
+        return
+
+    st.last_votes[uid] = monto
+    await bot.send_message(uid, f"Tu puja de *{monto}* bananas fue registrada.", parse_mode=ParseMode.MARKDOWN)
+    await bot.send_message(game.cid, f"El jugador *{game.playerlist[uid].name}* ya pujó.", parse_mode=ParseMode.MARKDOWN)
+    await save(bot, game.cid)
+
+    if len(st.last_votes) >= len(game.player_sequence):
+        await PuertoBananaController.resolve_round(bot, game)
+
+
+async def command_puja(update: Update, context: CallbackContext):
+    bot = context.bot
+    args = context.args
+    uid = update.message.from_user.id
+
+    if update.effective_message.chat.type in ['group', 'supergroup']:
+        await bot.delete_message(update.message.chat_id, update.message.message_id)
+        await bot.send_message(uid, "El comando /puja solo se puede usar en privado con el bot.")
+        return
+
+    if len(args) != 1 or not args[0].lstrip('-').isdigit():
+        await bot.send_message(uid, "Uso correcto: /puja CANTIDAD. Ej: /puja 15")
+        return
+
+    monto = int(args[0])
+    if monto < 0:
+        await bot.send_message(uid, "No podés pujar una cantidad negativa.")
+        return
+
+    import MainController
+    juegos = MainController.getGamesByTipo("PuertoBanana")
+    if not juegos:
+        await bot.send_message(uid, "No hay partidas de Puerto Banana en las que puedas pujar.")
+        return
+
+    candidatas = {
+        cid: game for cid, game in juegos.items()
+        if _validar_partida(game) and uid in game.playerlist
+        and game.board.state.fase_actual == "Pujando" and uid not in game.board.state.last_votes
+    }
+
+    if not candidatas:
+        await bot.send_message(uid, "No tenés ninguna puja pendiente en Puerto Banana.")
+        return
+
+    if len(candidatas) == 1:
+        cid, game = next(iter(candidatas.items()))
+        await _aplicar_puja(bot, game, uid, monto)
+        return
+
+    btns = []
+    for cid, game in candidatas.items():
+        datos = f"{cid}*choosegamepujaPB*{monto}*{uid}"
+        btns.append([InlineKeyboardButton(game.groupName, callback_data=datos)])
+    await bot.send_message(
+        uid, "¿En cuál de estas partidas querés pujar?",
+        reply_markup=InlineKeyboardMarkup(btns)
+    )
+
+
+async def callback_choose_game_puja(update: Update, context: CallbackContext):
+    bot = context.bot
+    callback = update.callback_query
+    regex = re.search(r"(-[0-9]*)\*choosegamepujaPB\*(-?[0-9]*)\*([0-9]*)", callback.data)
+    cid, monto, uid = int(regex.group(1)), int(regex.group(2)), int(regex.group(3))
+
+    game = get_game(cid)
+    try:
+        await bot.edit_message_text(f"Has elegido la partida {game.groupName}", uid, callback.message.message_id)
+    except Exception:
+        pass
+    await _aplicar_puja(bot, game, uid, monto)

--- a/PuertoBanana/Controller.py
+++ b/PuertoBanana/Controller.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import logging as log
+import random
+import re
+
+from telegram import Update
+from telegram.constants import ParseMode
+from telegram.ext import CallbackContext
+
+from Utils import get_game, save, simple_choose_buttons, player_call
+from Constants.Config import ADMIN
+from PuertoBanana.Boardgamebox.Game import Game
+from PuertoBanana.Boardgamebox.Board import BANANAS_VICTORIA
+
+import GamesController
+
+log.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=log.INFO)
+logger = log.getLogger(__name__)
+
+
+async def init_game(bot, game):
+    try:
+        log.info("PuertoBanana init_game called")
+        game.shuffle_player_sequence()
+        await bot.send_message(
+            game.cid,
+            "🍌 *¡Puerto Banana ha comenzado!*\n\n"
+            "Todos arrancan con *10 bananas*. Gana el primero en llegar a "
+            f"*{BANANAS_VICTORIA}*.\n"
+            "Usá `/info` en cualquier momento para ver tu cantidad en privado.",
+            parse_mode=ParseMode.MARKDOWN
+        )
+        await start_round(bot, game)
+    except Exception as e:
+        logger.error(f"PuertoBanana init_game error: {e}")
+        await bot.send_message(ADMIN[0], f"PuertoBanana init_game error: {e}")
+        raise
+
+
+async def start_round(bot, game):
+    st = game.board.state
+    st.fase_actual = "Pujando"
+    st.last_votes = {}
+    for player in game.player_sequence:
+        player.eliminado_ronda = False
+    st.pozo_actual = max(player.bananas for player in game.player_sequence)
+
+    await bot.send_message(
+        game.cid,
+        f"🍌 *Ronda {st.ronda}* — El pozo es de *{st.pozo_actual}* bananas.\n"
+        "Cada jugador debe pujar en privado con `/puja CANTIDAD`.",
+        parse_mode=ParseMode.MARKDOWN
+    )
+    for player in game.player_sequence:
+        await bot.send_message(
+            player.uid,
+            f"🍌 Partida *{game.groupName}* — Ronda {st.ronda}.\n"
+            f"El pozo es de *{st.pozo_actual}* bananas.\n"
+            "Hacé tu puja secreta con `/puja CANTIDAD` (no estás limitado por lo que tenés).",
+            parse_mode=ParseMode.MARKDOWN
+        )
+    await save(bot, game.cid)
+
+
+async def resolve_round(bot, game):
+    st = game.board.state
+    pujas = st.last_votes
+
+    mayor_puja = max(pujas.values())
+    candidatos_ganador = [uid for uid, monto in pujas.items() if monto == mayor_puja]
+    ganador_uid = random.choice(candidatos_ganador)
+
+    restantes = {uid: monto for uid, monto in pujas.items() if uid != ganador_uid}
+    segunda_puja = max(restantes.values()) if restantes else mayor_puja
+    candidatos_segundo = [uid for uid, monto in restantes.items() if monto == segunda_puja] if restantes else []
+    segundo_uid = random.choice(candidatos_segundo) if candidatos_segundo else None
+
+    diferencia = mayor_puja - segunda_puja
+    ganador = game.playerlist[ganador_uid]
+    pozo = st.pozo_actual
+
+    detalle = (
+        f"🍌 *Resultado de la ronda {st.ronda}:*\n"
+        f"{player_call(ganador)} pujó más alto y se lleva el pozo de *{pozo}* bananas, "
+        f"debiendo pagar la diferencia de *{diferencia}* bananas al segundo mejor postor.\n"
+    )
+
+    if ganador.bananas + pozo >= diferencia:
+        ganador.bananas = ganador.bananas + pozo - diferencia
+        if segundo_uid is not None:
+            segundo = game.playerlist[segundo_uid]
+            segundo.bananas += diferencia
+            detalle += f"{player_call(segundo)} recibe esa diferencia."
+        else:
+            detalle += "Nadie más pujó, así que no paga diferencia."
+    else:
+        ganador.bananas = 0
+        ganador.eliminado_ronda = True
+        detalle += (
+            f"¡Pero {player_call(ganador)} no puede pagar esa diferencia! Queda "
+            "*eliminado de la ronda* y pierde todas sus bananas."
+        )
+
+    await bot.send_message(game.cid, detalle, parse_mode=ParseMode.MARKDOWN)
+    await save(bot, game.cid)
+
+    ganador_partida = next(
+        (p for p in game.player_sequence if p.bananas >= BANANAS_VICTORIA),
+        None
+    )
+    if ganador_partida is not None:
+        await finish_game(bot, game, ganador_partida)
+        return
+
+    st.ronda += 1
+    await start_round(bot, game)
+
+
+async def finish_game(bot, game, ganador):
+    st = game.board.state
+    st.fase_actual = "Finalizado"
+    st.ganador_uid = ganador.uid
+    await save(bot, game.cid)
+
+    resumen = "\n".join(
+        f"• {p.name}: {p.bananas} bananas" for p in game.player_sequence
+    )
+    await bot.send_message(
+        game.cid,
+        f"🏆 *¡{ganador.name} ganó Puerto Banana con {ganador.bananas} bananas!*\n\n"
+        f"*Resultado final:*\n{resumen}",
+        parse_mode=ParseMode.MARKDOWN
+    )
+    await continue_playing(bot, game)
+
+
+async def continue_playing(bot, game):
+    opciones_botones = {
+        "Nuevo": "Nuevo partido con nuevos jugadores",
+        "Mismos": "Misma partida, mismos jugadores",
+    }
+    await simple_choose_buttons(
+        bot, game.cid, 1, game.cid,
+        "chooseendPB",
+        "¿Quieres continuar jugando?",
+        opciones_botones,
+    )
+
+
+async def callback_finish_game_buttons_pb(update: Update, context: CallbackContext):
+    bot = context.bot
+    callback = update.callback_query
+    try:
+        regex = re.search(r"(-[0-9]*)\*chooseendPB\*(.*)\*([0-9]*)", callback.data)
+        cid, opcion, uid = int(regex.group(1)), regex.group(2), int(regex.group(3))
+        mensaje_edit = f"Has elegido: {opcion}"
+        try:
+            await bot.edit_message_text(mensaje_edit, cid, callback.message.message_id)
+        except Exception:
+            await bot.edit_message_text(mensaje_edit, uid, callback.message.message_id)
+
+        game = get_game(cid)
+        groupName = game.groupName
+        tipo = game.tipo
+        modo = game.modo
+        players = game.playerlist.copy()
+
+        new_game = Game(cid, uid, groupName, tipo, modo)
+        GamesController.games[cid] = new_game
+
+        if opcion == "Nuevo":
+            await bot.send_message(
+                cid,
+                "Cada jugador puede unirse con /join. El iniciador puede escribir /startgame cuando todos estén listos.",
+            )
+            return
+
+        for player in players.values():
+            player.bananas = 10
+            player.eliminado_ronda = False
+        new_game.playerlist = players
+        new_game.create_board()
+        await init_game(bot, new_game)
+    except Exception as e:
+        await bot.send_message(ADMIN[0], f'callback_finish_game_buttons_pb error: {e}')
+        await bot.send_message(ADMIN[0], callback.data)


### PR DESCRIPTION
## Summary
- New game **Puerto Banana**: players start with 10 bananas each; every round auctions a pot equal to the current leader's banana count.
- Bids are placed privately via `/puja CANTIDAD`. Highest bidder wins the pot but pays the runner-up the difference between their bids; if they can't cover that difference they're eliminated from the round and lose all their bananas.
- First player to reach 200 bananas wins.
- Wired into `Constants/Config.py` (3–10 players), `Commands.py` (`CreateGame`), and `MainController.py` (init/handlers), following the existing game-module pattern (`CONTRIBUTING_NEW_GAME.md`).

## Test plan
- [x] Verified all new/modified modules import cleanly with no circular imports
- [x] Standalone simulation of round resolution (normal win, tied bids, can't-pay elimination, 200-banana victory condition)
- [ ] Manual playtest with a real Telegram group (`/puja`, `/info`, `/board`, `/rules`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBHPDwXdmWKvMope2gZbgY


---
_Generated by [Claude Code](https://claude.ai/code/session_01SBHPDwXdmWKvMope2gZbgY)_