### PR TITLE
Puerto Banana: reveal bids and mark eliminated players; SecretoCodigo guess mentions

### DIFF
--- a/PuertoBanana/Boardgamebox/Board.py
+++ b/PuertoBanana/Boardgamebox/Board.py
@@ -20,5 +20,6 @@ class Board(BaseBoard):
         board += "--- *Jugadores* ---\n"
         for player in game.player_sequence:
             puja = " (ya pujó)" if player.uid in st.last_votes else ""
-            board += f"• {player.name}{puja}\n"
+            marca = " ✗" if player.eliminado_ronda else ""
+            board += f"• {player.name}{puja}{marca}\n"
         return board

--- a/PuertoBanana/Controller.py
+++ b/PuertoBanana/Controller.py
@@ -43,8 +43,6 @@ async def start_round(bot, game):
     st = game.board.state
     st.fase_actual = "Pujando"
     st.last_votes = {}
-    for player in game.player_sequence:
-        player.eliminado_ronda = False
     st.pozo_actual = max(player.bananas for player in game.player_sequence)
 
     await bot.send_message(
@@ -68,6 +66,16 @@ async def resolve_round(bot, game):
     st = game.board.state
     pujas = st.last_votes
 
+    pujas_ordenadas = sorted(pujas.items(), key=lambda item: item[1], reverse=True)
+    reveal = "\n".join(
+        f"• {game.playerlist[uid].name}: *{monto}* bananas" for uid, monto in pujas_ordenadas
+    )
+    await bot.send_message(
+        game.cid,
+        f"🍌 *Todos pujaron.* Así quedaron las pujas:\n{reveal}",
+        parse_mode=ParseMode.MARKDOWN
+    )
+
     mayor_puja = max(pujas.values())
     candidatos_ganador = [uid for uid, monto in pujas.items() if monto == mayor_puja]
     ganador_uid = random.choice(candidatos_ganador)
@@ -89,9 +97,11 @@ async def resolve_round(bot, game):
 
     if ganador.bananas + pozo >= diferencia:
         ganador.bananas = ganador.bananas + pozo - diferencia
+        ganador.eliminado_ronda = False
         if segundo_uid is not None:
             segundo = game.playerlist[segundo_uid]
             segundo.bananas += diferencia
+            segundo.eliminado_ronda = False
             detalle += f"{player_call(segundo)} recibe esa diferencia."
         else:
             detalle += "Nadie más pujó, así que no paga diferencia."

--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -522,22 +522,24 @@ async def command_call(bot, game):
         intentos = game.board.state.intentos_restantes
         intentos_display = "∞" if intentos >= 999 else intentos
         numero_display = format_numero_pista(numero)
+        sm = game.get_spymaster(team)
+        equipo = game.board.state.equipo_rojo if team == "Rojo" else game.board.state.equipo_azul
+        guessers = [jugador for jugador in equipo if jugador.uid != sm.uid]
+        menciones = ", ".join(player_call(jugador) for jugador in guessers)
         await bot.send_photo(
             game.cid,
             photo=game.board.render_board_image(game),
             caption=(
                 f"Equipo *{team}*: pista *{pista}* — {numero_display}. "
-                f"Intentos restantes: {intentos_display}.\nUsa `/pick NUMERO` o `/endturn`."
+                f"Intentos restantes: {intentos_display}.\nUsa `/pick NUMERO` o `/endturn`.\n"
+                f"Toca adivinar a: {menciones}"
             ),
             parse_mode=ParseMode.MARKDOWN,
         )
-        sm = game.get_spymaster(team)
-        equipo = game.board.state.equipo_rojo if team == "Rojo" else game.board.state.equipo_azul
-        for jugador in equipo:
-            if jugador.uid != sm.uid:
-                await bot.send_message(
-                    jugador.uid,
-                    f"[{game.groupName}] 🔍 Toca adivinar, equipo *{team}*. Pista: *{pista}* — {numero_display}. "
-                    f"Intentos restantes: {intentos_display}.\nUsa `/pick NUMERO` o `/endturn`.",
-                    parse_mode=ParseMode.MARKDOWN,
-                )
+        for jugador in guessers:
+            await bot.send_message(
+                jugador.uid,
+                f"[{game.groupName}] 🔍 Toca adivinar, equipo *{team}*. Pista: *{pista}* — {numero_display}. "
+                f"Intentos restantes: {intentos_display}.\nUsa `/pick NUMERO` o `/endturn`.",
+                parse_mode=ParseMode.MARKDOWN,
+            )


### PR DESCRIPTION
## Summary
- Puerto Banana now publicly reveals every player's bid in the group chat once everyone has bid, before resolving the round.
- Puerto Banana's `/board` now marks players still `eliminado_ronda` with a ✗, fixing a bug where the flag was wiped by `start_round` before it could ever be observed.
- SecretoCodigo's competitive `/call` reminder now `@mention`s the specific players who need to guess, instead of just naming the team.

## Test plan
- [x] Verified with a standalone async harness (FakeBot) that bid reveal lists all players' amounts sorted descending before resolution.
- [x] Verified the ✗ marker persists into the next round's `/board` after a catastrophic loss, and clears for winners/second-place who can pay.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SBHPDwXdmWKvMope2gZbgY)_