### PR TITLE
Send remaining spy count when showing Secreto Código board

### DIFF
--- a/SecretoCodigo/Commands.py
+++ b/SecretoCodigo/Commands.py
@@ -4,7 +4,7 @@ import urllib.parse
 
 import psycopg
 import SecretoCodigo.Controller as SecretoCodigoController
-from SecretoCodigo.Controller import format_numero_pista
+from SecretoCodigo.Controller import format_numero_pista, send_remaining_message
 from Utils import get_game, save, player_call, simple_choose_buttons
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
@@ -536,6 +536,7 @@ async def command_call(bot, game):
             ),
             parse_mode=ParseMode.MARKDOWN,
         )
+        await send_remaining_message(bot, game)
         for jugador in guessers:
             await bot.send_message(
                 jugador.uid,

--- a/SecretoCodigo/Controller.py
+++ b/SecretoCodigo/Controller.py
@@ -35,6 +35,16 @@ def format_numero_pista(numero: int) -> str:
     return f"{numero} (∞)" if numero in (0, -1) else str(numero)
 
 
+async def send_remaining_message(bot, game):
+    st = game.board.state
+    await bot.send_message(
+        game.cid,
+        f"🔴 Espías rojos por descubrir: *{st.palabras_rojo_restantes}*  |  "
+        f"🔵 Espías azules por descubrir: *{st.palabras_azul_restantes}*",
+        parse_mode=ParseMode.MARKDOWN,
+    )
+
+
 async def init_game(bot, game):
     try:
         log.info('SecretoCodigo init_game called')
@@ -167,6 +177,7 @@ async def start_turn(bot, game, team: str):
         caption=caption_turno,
         parse_mode=ParseMode.MARKDOWN,
     )
+    await send_remaining_message(bot, game)
     await bot.send_message(
         spymaster.uid,
         f"Es tu turno de espía ({team}). Usa `/hint PALABRA NUMERO` en este chat.\n"
@@ -492,6 +503,7 @@ async def process_hint(bot, game, spymaster_uid, word: str, number: int):
         caption=caption_pista,
         parse_mode=ParseMode.MARKDOWN,
     )
+    await send_remaining_message(bot, game)
     await save(bot, game.cid)
 
 
@@ -554,6 +566,7 @@ async def process_pick(bot, game, uid, numero: int):
                 caption=f"✅ *¡Correcto!* Intentos restantes: {'∞' if game.board.state.intentos_restantes >= 999 else game.board.state.intentos_restantes}",
                 parse_mode=ParseMode.MARKDOWN,
             )
+            await send_remaining_message(bot, game)
             await save(bot, game.cid)
     else:
         await bot.send_message(


### PR DESCRIPTION
## Summary
- Adds a message showing how many words remain undiscovered for each team (red/blue) whenever the public board is shown during a competitive game.
- Sent after every public board-image display: turn start, after a hint, after a correct pick, and on board re-display via `/tablero`-style re-call.

## Test plan
- [x] `python -c "import ast; ast.parse(...)"` syntax check on changed files
- [ ] Manual playtest of a competitive Secreto Código game to confirm the count message appears and matches the board


---
_Generated by [Claude Code](https://claude.ai/code/session_01PXXz4z5Ji76tsXGZSKEYpQ)_