### PR TITLE
Fix swapped winner/loser in Secreto Código win message

### DIFF
--- a/SecretoCodigo/Controller.py
+++ b/SecretoCodigo/Controller.py
@@ -602,14 +602,14 @@ async def end_game(bot, game, winner: str, reason: str):
     await save(bot, game.cid)
 
     emoji = "🔴" if winner == "Rojo" else "🔵"
-    motivo = "tocó al *ASESINO* 💀" if reason == "asesino" else "reveló todas sus palabras"
     perdedor = "Azul" if winner == "Rojo" else "Rojo"
 
-    await bot.send_message(
-        game.cid,
-        f"{emoji} ¡El equipo *{winner}* ha GANADO porque el equipo *{perdedor}* {motivo}!",
-        parse_mode=ParseMode.MARKDOWN,
-    )
+    if reason == "asesino":
+        mensaje = f"{emoji} ¡El equipo *{winner}* ha GANADO porque el equipo *{perdedor}* tocó al *ASESINO* 💀!"
+    else:
+        mensaje = f"{emoji} ¡El equipo *{winner}* ha GANADO porque reveló todas sus palabras!"
+
+    await bot.send_message(game.cid, mensaje, parse_mode=ParseMode.MARKDOWN)
     await bot.send_message(game.cid, _reveal_full_board(game), parse_mode=ParseMode.MARKDOWN)
     await continue_playing(bot, game)
 


### PR DESCRIPTION
## Summary
- The end-of-game message in Secreto Código said the *losing* team "revealed all their words" — but the win condition is the opposite: a team wins by finishing its own words first. The message now correctly credits the winning team.
- The assassin-loss case was already correct and is unchanged in meaning.

## Test plan
- [x] Syntax check on changed file
- [ ] Manual playtest: have one team find all their words and confirm the win message reads correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01PXXz4z5Ji76tsXGZSKEYpQ)_