### PR TITLE
Avoid duplicate words on the Secreto Código board

### DIFF
--- a/SecretoCodigo/Controller.py
+++ b/SecretoCodigo/Controller.py
@@ -92,7 +92,12 @@ async def finish_config(bot, game):
     opcion = game.configs.get('diccionario', 'original')
     url_palabras = os.path.join(_TXT_DIR, f'spanish-{opcion}.txt')
     with open(url_palabras, 'r') as f:
-        palabras_posibles = [w.strip() for w in f.readlines() if w.strip()]
+        vistas = set()
+        palabras_posibles = []
+        for w in (line.strip() for line in f.readlines()):
+            if w and w.lower() not in vistas:
+                vistas.add(w.lower())
+                palabras_posibles.append(w)
 
     palabras = random.sample(palabras_posibles, 25)
     game.board.state.tablero = [


### PR DESCRIPTION
## Summary
- `random.sample(palabras_posibles, 25)` only guarantees 25 distinct *positions* in the list, not distinct *words*. If the word list file ever contains a duplicate entry (exact or differing only in case), the board could end up with the same word twice.
- The word list is now deduplicated case-insensitively at load time, before sampling, so the 25 board words are always guaranteed to be distinct.

## Test plan
- [x] Verified the current `spanish-original.txt` has no duplicates
- [x] Simulated loading with injected duplicate/case-variant entries and confirmed sampling still yields 25 unique words


---
_Generated by [Claude Code](https://claude.ai/code/session_01PXXz4z5Ji76tsXGZSKEYpQ)_