### PR TITLE
Announce destiny deck cards drawn per color in Battlestar Galactica

### DIFF
--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -118,11 +118,32 @@ async def init_game(bot, game):
 
         # Mazo de Destino: 2 cartas de cada color, barajadas
         st.destiny_deck = []
+        lineas_destino = []
         for color in Skills.COLORES:
+            cartas_color = []
             for _ in range(2):
-                if st.skill_decks[color]:
-                    st.destiny_deck.append(st.skill_decks[color].pop())
+                if not st.skill_decks.get(color) and st.skill_discards.get(color):
+                    await bot.send_message(
+                        game.cid,
+                        f"🔄 El mazo {Skills.EMOJI_COLOR[color]} *{color}* se quedó sin cartas; "
+                        "se rebaraja con sus descartes.",
+                        parse_mode=ParseMode.MARKDOWN,
+                    )
+                carta = _robar_carta_color(st, color)
+                if carta:
+                    cartas_color.append(carta)
+                    st.destiny_deck.append(carta)
+            nombres = ", ".join(
+                f"{c['valor']} ({c.get('nombre', '')})" for c in cartas_color
+            )
+            lineas_destino.append(f"{Skills.EMOJI_COLOR[color]} *{color}*: {nombres}")
         random.shuffle(st.destiny_deck)
+
+        await bot.send_message(
+            game.cid,
+            "🎴 *Creando el Mazo de Destino* (2 cartas de cada tipo):\n" + "\n".join(lineas_destino),
+            parse_mode=ParseMode.MARKDOWN,
+        )
 
         # Mazo de crisis
         st.crisis_deck = [dict(c) for c in Crisis.CRISIS_DECK]


### PR DESCRIPTION
## Summary
- When the Destiny deck is built at game start (2 cards from each of the 5 skill colors), the group now gets a message listing exactly which cards were drawn from each color's deck.
- Reused the existing `_robar_carta_color` helper (already used elsewhere for normal skill draws) to draw the 2 cards per color, so depleted decks are reshuffled from their discards instead of silently skipping a draw:
  - 0 cards left in a color deck → reshuffle its discards into the deck, then draw.
  - 1 card left → draw that card, then reshuffle discards for the second draw.
- Added a message announcing when a color deck gets reshuffled this way.

## Test plan
- [x] Simulated the draw logic standalone for: normal full decks, a color starting with 0 cards, and a color starting with 1 card — confirmed 10 total destiny cards and correct reshuffle behavior in all three cases.
- [ ] Manual playtest: start a BSG game and confirm the group sees the per-color destiny deck breakdown message.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PXXz4z5Ji76tsXGZSKEYpQ)_