### PR TITLE
Stop revealing destiny deck card contents at BSG game start

### DIFF
--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -116,11 +116,9 @@ async def init_game(bot, game):
             random.shuffle(st.skill_decks[color])
         st.skill_discards = {color: [] for color in Skills.COLORES}
 
-        # Mazo de Destino: 2 cartas de cada color, barajadas
+        # Mazo de Destino: 2 cartas de cada color, barajadas (contenido secreto)
         st.destiny_deck = []
-        lineas_destino = []
         for color in Skills.COLORES:
-            cartas_color = []
             for _ in range(2):
                 if not st.skill_decks.get(color) and st.skill_discards.get(color):
                     await bot.send_message(
@@ -131,17 +129,12 @@ async def init_game(bot, game):
                     )
                 carta = _robar_carta_color(st, color)
                 if carta:
-                    cartas_color.append(carta)
                     st.destiny_deck.append(carta)
-            nombres = ", ".join(
-                f"{c['valor']} ({c.get('nombre', '')})" for c in cartas_color
-            )
-            lineas_destino.append(f"{Skills.EMOJI_COLOR[color]} *{color}*: {nombres}")
         random.shuffle(st.destiny_deck)
 
         await bot.send_message(
             game.cid,
-            "🎴 *Creando el Mazo de Destino* (2 cartas de cada tipo):\n" + "\n".join(lineas_destino),
+            "🎴 *Creando el Mazo de Destino* (2 cartas de cada tipo de habilidad, contenido secreto)...",
             parse_mode=ParseMode.MARKDOWN,
         )
 


### PR DESCRIPTION
## Summary
- Follow-up to #159: the destiny deck must stay secret when it's built at game start — its specific cards are only meant to be revealed later, when 2 are drawn from it to help resolve a crisis check (existing `_robar_destino` flow).
- Removed the per-color card listing from the "creating the destiny deck" message; it now just announces that the deck is being created, without leaking its contents.
- Kept the reshuffle notice when a color's skill deck runs out (it only names the color, not any card).

## Test plan
- [x] Syntax check on changed file


---
_Generated by [Claude Code](https://claude.ai/code/session_01PXXz4z5Ji76tsXGZSKEYpQ)_