### PR TITLE
Fix Puerto Banana round-start crash when a player can't be DMed

### DIFF
--- a/PuertoBanana/Controller.py
+++ b/PuertoBanana/Controller.py
@@ -53,13 +53,22 @@ async def start_round(bot, game):
     )
     await bot.send_message(game.cid, game.board.print_board(game), parse_mode=ParseMode.MARKDOWN)
     for player in game.player_sequence:
-        await bot.send_message(
-            player.uid,
-            f"🍌 Partida *{game.groupName}* — Ronda {st.ronda}.\n"
-            f"El pozo es de *{st.pozo_actual}* bananas.\n"
-            "Hacé tu puja secreta con `/puja CANTIDAD` (no estás limitado por lo que tenés).",
-            parse_mode=ParseMode.MARKDOWN
-        )
+        try:
+            await bot.send_message(
+                player.uid,
+                f"🍌 Partida *{game.groupName}* — Ronda {st.ronda}.\n"
+                f"El pozo es de *{st.pozo_actual}* bananas.\n"
+                "Hacé tu puja secreta con `/puja CANTIDAD` (no estás limitado por lo que tenés).",
+                parse_mode=ParseMode.MARKDOWN
+            )
+        except Exception as e:
+            logger.error(f"PuertoBanana start_round no pudo avisar a {player.name} ({player.uid}): {e}")
+            await bot.send_message(
+                game.cid,
+                f"⚠️ No pude avisarle por privado a *{player.name}*. "
+                "Debe iniciar una conversación privada con el bot (`/start`) para poder pujar.",
+                parse_mode=ParseMode.MARKDOWN
+            )
     await save(bot, game.cid)
 
 


### PR DESCRIPTION
## Summary
- In `PuertoBanana/Controller.py`'s `start_round`, sending the private bid-request DM to each player is now wrapped in a try/except.
- Previously, if Telegram rejected the DM to a single player (e.g. that player never started a private chat with the bot), the exception propagated up through `init_game`/`resolve_round`, skipping DMs to the rest of the players and skipping `save()` entirely — silently breaking the round for everyone except the admin.
- Now a failed DM is isolated: the other players still get their private message, the game state still gets saved, and the group chat gets a warning naming the player who needs to `/start` the bot.

## Test plan
- Simulated `init_game` → `start_round` with a fake bot where one player's `send_message` raises (mimicking "bot can't initiate conversation with a user"):
  - Confirmed the other players still receive their private bid prompts.
  - Confirmed `save()` is still called.
  - Confirmed the group receives a warning naming the affected player.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PXXz4z5Ji76tsXGZSKEYpQ)_