### PR TITLE
Split pot on tied highest bid in Puerto Banana

### DIFF
--- a/PuertoBanana/Controller.py
+++ b/PuertoBanana/Controller.py
@@ -93,7 +93,24 @@ async def resolve_round(bot, game):
     while True:
         mayor_puja = max(restantes.values())
         candidatos_ganador = [uid for uid, monto in restantes.items() if monto == mayor_puja]
-        ganador_uid = random.choice(candidatos_ganador)
+
+        if len(candidatos_ganador) > 1:
+            empatados = [game.playerlist[uid] for uid in candidatos_ganador]
+            reparto = pozo // len(empatados)
+            resto = pozo % len(empatados)
+            for jugador in empatados:
+                jugador.bananas += reparto
+                jugador.eliminado_ronda = False
+            if resto:
+                random.choice(empatados).bananas += resto
+            nombres_empatados = ", ".join(player_call(j) for j in empatados)
+            detalle_lineas.append(
+                f"{nombres_empatados} empataron en la puja más alta (*{mayor_puja}*) y se "
+                f"reparten el pozo de *{pozo}* bananas entre ellos, sin pagarle nada a nadie más."
+            )
+            break
+
+        ganador_uid = candidatos_ganador[0]
         ganador = game.playerlist[ganador_uid]
 
         candidatos_resto = {uid: monto for uid, monto in restantes.items() if uid != ganador_uid}


### PR DESCRIPTION
## Summary
- `resolve_round` in `PuertoBanana/Controller.py` now detects when two or more players tie for the highest bid and splits the pot evenly between them (any indivisible remainder goes to one of them at random), with no payment to a "second place" player.
- Previously, a tie at the top picked a single random winner among the tied bidders, but the "second highest" bid used to compute the difference owed was identical to the winner's bid (since it came from another tied player), so the difference was always 0 and the random winner took the whole pot for free.

## Test plan
- Simulated `resolve_round` with two players tied at the highest bid: confirmed the pot is split evenly between them and the third (lower) player is unaffected.
- Simulated `resolve_round` with three players tied at the highest bid and a non-divisible pot: confirmed each gets the floor share and the remainder goes to one of them.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PXXz4z5Ji76tsXGZSKEYpQ)_