### PR TITLE
BSG: mostrar las cartas de lealtad que tiene cada jugador

### DIFF
--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -199,10 +199,11 @@ async def command_lealtad(update: Update, context: CallbackContext):
     es_cylon = Loyalty.CYLON in player.loyalty_cards
     rol = "🤖 *ERES UN CYLON*" if es_cylon else "🧑 No eres un Cylon (por ahora)"
     nombre_pj = pj["nombre"] if pj else "sin asignar"
+    detalle = "\n".join(f"• {Loyalty.NOMBRE_CARTA.get(c, c)}" for c in player.loyalty_cards)
     await bot.send_message(
         uid,
         f"{rol}\n\nPersonaje: *{nombre_pj}*\n"
-        f"Cartas de lealtad: {len(player.loyalty_cards)}",
+        f"Cartas de lealtad ({len(player.loyalty_cards)}):\n{detalle}",
         parse_mode=ParseMode.MARKDOWN,
     )
 

--- a/BattlestarGalactica/Constants/Loyalty.py
+++ b/BattlestarGalactica/Constants/Loyalty.py
@@ -24,6 +24,13 @@ CYLON = "cylon"
 HUMANO = "humano"
 SIMPATIZANTE = "simpatizante"
 
+# Nombre visible de cada carta de lealtad.
+NOMBRE_CARTA = {
+    CYLON: "🤖 Eres un Cylon",
+    HUMANO: "🧑 No eres un Cylon",
+    SIMPATIZANTE: "🕵️ Eres un Simpatizante",
+}
+
 # Número de cartas "Eres un Cylon" en el mazo, por cantidad de jugadores
 # (valores oficiales del reglamento del juego base).
 CYLON_CARDS_POR_JUGADORES = {

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -399,15 +399,17 @@ async def _dm_lealtad(bot, player):
     cartas = player.loyalty_cards
     es_cylon = Loyalty.CYLON in cartas
     es_simp = Loyalty.SIMPATIZANTE in cartas
+    detalle = "\n".join(f"• {Loyalty.NOMBRE_CARTA.get(c, c)}" for c in cartas)
+    txt = f"🃏 *Tus cartas de lealtad ({len(cartas)}):*\n{detalle}\n\n"
     if es_cylon:
-        txt = ("🤖 *ERES UN CYLON.*\nSabotea a la flota sin que te descubran. "
-               "Podrás revelarte más adelante para causar más daño.")
+        txt += ("🤖 *ERES UN CYLON.*\nSabotea a la flota sin que te descubran. "
+                "Podrás revelarte más adelante para causar más daño.")
     elif es_simp:
-        txt = ("🕵️ Tienes la carta de *Simpatizante*: se revela de inmediato. "
-               "Si algún recurso está en zona roja te unes a los Cylons; "
-               "si no, vas al Calabozo (sigues siendo humano).")
+        txt += ("🕵️ Tienes la carta de *Simpatizante*: se revela de inmediato. "
+                "Si algún recurso está en zona roja te unes a los Cylons; "
+                "si no, vas al Calabozo (sigues siendo humano).")
     else:
-        txt = "🧑 *No eres un Cylon* (por ahora). Ayuda a la flota a sobrevivir."
+        txt += "🧑 *No eres un Cylon* (por ahora). Ayuda a la flota a sobrevivir."
     await bot.send_message(player.uid, txt, parse_mode=ParseMode.MARKDOWN)
 
 
@@ -2281,7 +2283,8 @@ async def resolver_habilidad_pendiente(bot, game, uid, token):
             return
         st.habilidad_pendiente = None
         player.habilidad_usada = True
-        cartas = ", ".join(target.loyalty_cards) if target.loyalty_cards else "ninguna"
+        cartas = (", ".join(Loyalty.NOMBRE_CARTA.get(c, c) for c in target.loyalty_cards)
+                  if target.loyalty_cards else "ninguna")
         await bot.send_message(uid, f"🔎 Cartas de lealtad de *{target.name}*: {cartas}", parse_mode=ParseMode.MARKDOWN)
         await bot.send_message(game.cid, f"🔎 *{player.name}* (Detector de Cylons) analiza en privado TODA la lealtad de *{target.name}*.",
                                parse_mode=ParseMode.MARKDOWN)
@@ -2442,7 +2445,8 @@ async def resolver_quorum_objetivo(bot, game, objetivo_uid):
                 objetivo.titulos.append("Almirante")
             await bot.send_message(game.cid, f"🎲 Tirada {r}: *{objetivo.name}* se vuelve Almirante.", parse_mode=ParseMode.MARKDOWN)
     elif ef == "mugshots":
-        cartas = ", ".join(objetivo.loyalty_cards) if objetivo.loyalty_cards else "ninguna"
+        cartas = (", ".join(Loyalty.NOMBRE_CARTA.get(c, c) for c in objetivo.loyalty_cards)
+                  if objetivo.loyalty_cards else "ninguna")
         await bot.send_message(st.presidente_uid or ADMIN[0],
                                f"🔎 Lealtad de {objetivo.name}: {cartas}")
         await bot.send_message(game.cid, f"🔎 El Presidente revisa la ficha de *{objetivo.name}*.", parse_mode=ParseMode.MARKDOWN)
@@ -3283,12 +3287,7 @@ async def _inspeccionar_lealtad(bot, game, chooser, target):
         await bot.send_message(game.cid, f"🔍 {target.name if target else 'El objetivo'} no tiene cartas de lealtad para inspeccionar.")
         return
     carta = random.choice(target.loyalty_cards)
-    if carta == Loyalty.CYLON:
-        desc = "🤖 *ERES UN CYLON*"
-    elif carta == Loyalty.SIMPATIZANTE:
-        desc = "🕵️ *Simpatizante*"
-    else:
-        desc = "🧑 *No eres un Cylon*"
+    desc = f"*{Loyalty.NOMBRE_CARTA.get(carta, carta)}*"
     await bot.send_message(chooser.uid, f"🔍 Carta de lealtad de *{target.name}*: {desc}", parse_mode=ParseMode.MARKDOWN)
     await bot.send_message(game.cid, f"🔍 *{chooser.name}* inspecciona en privado una carta de lealtad de *{target.name}*.", parse_mode=ParseMode.MARKDOWN)
 


### PR DESCRIPTION
## Resumen

La desventaja de Gaius Baltar (*Cobarde: empieza con 2 cartas de lealtad*) **ya se aplicaba** en el reparto (`loyalty_extra: 1` en `Characters.py`, usado por `finalizar_setup`), pero era invisible para el jugador: el DM de lealtad enviaba el mismo texto genérico a todos, sin indicar cuántas cartas se recibieron ni cuáles son.

## Cambios

- **`_dm_lealtad`** (reparto inicial y Fase del Agente Durmiente): ahora lista las cartas recibidas con su cantidad, así Baltar ve sus 2 cartas iniciales.
- **`/lealtad`**: detalla las cartas en vez de mostrar solo el número.
- **`Constants/Loyalty.py`**: nuevo mapa `NOMBRE_CARTA` con los nombres visibles de cada carta.
- **Detector de Cylons (Baltar), Mugshots e inspección al azar**: usan los nombres visibles en vez de los strings internos (`humano, cylon`).

## Verificación

- Simulación del reparto de una partida de 5 con Baltar y Boomer: Baltar recibe 2 cartas, el resto 1, y el mazo restante queda con la cantidad exacta para la Fase Durmiente.
- Render del nuevo DM (con dependencias stubbeadas) para Baltar con 2 humanas, Baltar con humana+cylon y un jugador normal: los tres mensajes salen correctos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYrfyi75SdkuhH8zgZXtbv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYrfyi75SdkuhH8zgZXtbv)_