### PR TITLE
Add confirmation dialogs for game cancellation/deletion

### DIFF
--- a/Commands.py
+++ b/Commands.py
@@ -350,16 +350,36 @@ def command_cancelgame(update: Update, context: CallbackContext):
 	log.info('command_cancelgame called {}'.format(args))
 	cid = update.message.chat_id
 	uid = update.effective_user.id
-	#Always try to delete in DB	
+	#Always try to delete in DB
 	if len(args) > 0 and uid == ADMIN[0]:
-		cid = int(args[0])	
-	try:
-		delete_game(cid)
-		if cid in GamesController.games.keys():
-			del GamesController.games[cid]
-		bot.send_message(cid, "Borrado exitoso.")
-	except Exception as e:
-		bot.send_message(cid, "El borrado ha fallado debido a: "+str(e))	
+		cid = int(args[0])
+	btns = [[InlineKeyboardButton("Sí, eliminar", callback_data="{}*confirmDelete*si*{}".format(cid, uid)),
+			InlineKeyboardButton("No, cancelar", callback_data="{}*confirmDelete*no*{}".format(cid, uid))]]
+	bot.send_message(update.message.chat_id, "¿Estás seguro de que quieres eliminar el partido? Todos los datos del juego se perderán.", reply_markup=InlineKeyboardMarkup(btns))
+
+def callback_cancelgame_confirm(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_cancelgame_confirm called')
+	callback = update.callback_query
+
+	regex = re.search(r"(-?[0-9]*)\*confirmDelete\*(si|no)\*(-?[0-9]*)", callback.data)
+	cid, opcion, uid = int(regex.group(1)), regex.group(2), int(regex.group(3))
+
+	if callback.from_user.id != uid:
+		callback.answer("Solo quien ejecutó el comando puede confirmar.")
+		return
+
+	chat_id = callback.message.chat_id
+	if opcion == "si":
+		try:
+			delete_game(cid)
+			if cid in GamesController.games.keys():
+				del GamesController.games[cid]
+			bot.edit_message_text("Borrado exitoso.", chat_id, callback.message.message_id)
+		except Exception as e:
+			bot.edit_message_text("El borrado ha fallado debido a: "+str(e), chat_id, callback.message.message_id)
+	else:
+		bot.edit_message_text("Eliminación cancelada, el partido sigue en pie.", chat_id, callback.message.message_id)
 
 def command_votes(update: Update, context: CallbackContext):
 	bot = context.bot

--- a/MainController.py
+++ b/MainController.py
@@ -573,6 +573,7 @@ def main():
 	dp.add_handler(CommandHandler("newgame", Commands.command_newgame))
 	dp.add_handler(CommandHandler("startgame", Commands.command_startgame))
 	dp.add_handler(CommandHandler("delete", Commands.command_cancelgame))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*confirmDelete\*(si|no)\*(-?[0-9]*)", callback=Commands.callback_cancelgame_confirm))
 	dp.add_handler(CommandHandler("join", Commands.command_join))
 	dp.add_handler(CommandHandler("leave", Commands.command_leave))
 	dp.add_handler(CommandHandler("history", Commands.command_showhistory))

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -396,20 +396,45 @@ def command_startgame(update: Update, context: CallbackContext):
 def command_cancelgame(update: Update, context: CallbackContext):
 	bot = context.bot
 	log.info('command_cancelgame called')
-	cid = update.message.chat_id	
+	cid = update.message.chat_id
+	uid = update.message.from_user.id
 	#Always try to delete in DB
-	
+
 	game = get_game(cid)
-	
+
 	#delete_game(cid)
-	if game:		
-		status = bot.getChatMember(cid, update.message.from_user.id).status
-		if update.message.from_user.id == game.initiator or status in ("administrator", "creator"):
-			MainController.end_game(bot, game, 99)
+	if game:
+		status = bot.getChatMember(cid, uid).status
+		if uid == game.initiator or status in ("administrator", "creator"):
+			btns = [[InlineKeyboardButton("Sí, cancelar el juego", callback_data="{}*confirmCancel*si*{}".format(cid, uid)),
+					InlineKeyboardButton("No", callback_data="{}*confirmCancel*no*{}".format(cid, uid))]]
+			bot.send_message(cid, "¿Estás seguro de que quieres cancelar el juego? Todos los datos del juego serán borrados.", reply_markup=InlineKeyboardMarkup(btns))
 		else:
 			bot.send_message(cid, "Solo el creador del juego o el administrador del grupo pueden cancelar el juego con /cancelgame")
 	else:
 		bot.send_message(cid, "No hay juego en este chat. Crea un nuevo juego con /newgame")
+
+def callback_cancelgame_confirm(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_cancelgame_confirm called')
+	callback = update.callback_query
+
+	regex = re.search(r"(-?[0-9]*)\*confirmCancel\*(si|no)\*(-?[0-9]*)", callback.data)
+	cid, opcion, uid = int(regex.group(1)), regex.group(2), int(regex.group(3))
+
+	if callback.from_user.id != uid:
+		callback.answer("Solo quien ejecutó /cancelgame puede confirmar.")
+		return
+
+	if opcion == "si":
+		game = get_game(cid)
+		if game:
+			bot.edit_message_text("Juego cancelado.", cid, callback.message.message_id)
+			MainController.end_game(bot, game, 99)
+		else:
+			bot.edit_message_text("No hay juego en este chat. Crea un nuevo juego con /newgame", cid, callback.message.message_id)
+	else:
+		bot.edit_message_text("Cancelación abortada, el juego continúa.", cid, callback.message.message_id)
 
 def command_votes(update: Update, context: CallbackContext):
 	bot = context.bot

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -1229,6 +1229,7 @@ def main():
 	dp.add_handler(CommandHandler("newgame", Commands.command_newgame))
 	dp.add_handler(CommandHandler("startgame", Commands.command_startgame))
 	dp.add_handler(CommandHandler("cancelgame", Commands.command_cancelgame))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*confirmCancel\*(si|no)\*(-?[0-9]*)", callback=Commands.callback_cancelgame_confirm))
 	dp.add_handler(CommandHandler("join", Commands.command_join))
 	dp.add_handler(CommandHandler("history", Commands.command_showhistory))
 	dp.add_handler(CommandHandler("votes", Commands.command_votes))


### PR DESCRIPTION
## Summary
Adds confirmation dialogs to the `/cancelgame` and `/delete` commands to prevent accidental game termination. Users must now confirm their action via inline keyboard buttons before the game is actually cancelled or deleted.

## Key Changes

- **`SecretHitler/Commands.py`**:
  - Modified `command_cancelgame()` to display a confirmation dialog instead of immediately ending the game
  - Added `callback_cancelgame_confirm()` handler to process confirmation responses
  - Confirmation is restricted to the user who executed `/cancelgame`
  - Uses inline keyboard with "Sí, cancelar el juego" / "No" buttons

- **`Commands.py`** (main bot):
  - Modified `command_cancelgame()` (aliased as `/delete`) to display a confirmation dialog
  - Added `callback_cancelgame_confirm()` handler to process confirmation responses
  - Confirmation is restricted to the user who executed the command
  - Uses inline keyboard with "Sí, eliminar" / "No, cancelar" buttons

- **`SecretHitler/MainController.py`**:
  - Registered `CallbackQueryHandler` for the confirmation pattern `confirmCancel`

- **`MainController.py`** (main bot):
  - Registered `CallbackQueryHandler` for the confirmation pattern `confirmDelete`

## Implementation Details

- Both handlers use the standard callback data format: `{cid}*{comando}*{opcion}*{uid}`
- Regex parsing extracts chat ID, user choice (si/no), and user ID from callback data
- User identity verification prevents unauthorized confirmations
- On confirmation, the original message is edited with the result (success/failure/abort)
- Follows existing callback handler patterns used throughout the codebase

https://claude.ai/code/session_01Tvqg5XVjzXSc7t9uYcf9G3