### PR TITLE
Secret Hitler: agregar /startautoja y /stopautoja

### DIFF
--- a/SecretHitler/Boardgamebox/Player.py
+++ b/SecretHitler/Boardgamebox/Player.py
@@ -9,6 +9,8 @@ class Player(object):
         self.was_investigated = False
         #"Liberal","Fascista","Hitler"
         self.preference_rol = ""
+        # Si esta activo, el jugador vota Ja automaticamente apenas se propone una formula (fuera de Zona Hitler)
+        self.auto_ja = False
 
     def get_private_info(self, game):
         board = "--- *Info del Jugador {}* ---\n".format(self.name)

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -50,7 +50,9 @@ commands = [  # command description used in the "help" command
     '/history - Imprime el historial del juego actual',
     '/votes - Imprime quien ha votado',
     '/calltovote - Avisa a los jugadores que se tiene que votar',
-    '/retirar - Retira tu voto de Ja o Nein para poder votar de nuevo'
+    '/retirar - Retira tu voto de Ja o Nein para poder votar de nuevo',
+    '/startautoja - Activa tu voto automático Ja apenas se proponga una fórmula (fuera de Zona Hitler)',
+    '/stopautoja - Desactiva tu voto automático Ja'
 ]
 
 symbols = [
@@ -578,6 +580,82 @@ def callback_retract(update: Update, context: CallbackContext):
 	else:
 		retract_player_vote(bot, game, uid)
 
+def set_auto_ja(bot, game, uid, enabled):
+	# Activa o desactiva el voto Ja automático del jugador para este juego
+	game.playerlist[uid].auto_ja = enabled
+	save_game(game.cid, "auto_ja %s Round %d" % ("on" if enabled else "off", game.board.state.currentround), game)
+	if enabled:
+		bot.send_message(uid,
+			"Voto automático *Ja* activado en *{}*. Mientras no estemos en Zona Hitler (menos de 3 políticas fascistas promulgadas), tu voto Ja se registrará solo apenas se proponga una fórmula. Usa /stopautoja para desactivarlo.".format(game.groupName),
+			parse_mode=ParseMode.MARKDOWN)
+		# Si hay una votación en curso y el jugador todavia no voto, le registro el Ja ahora mismo
+		if game.dateinitvote and uid not in game.board.state.last_votes and not MainController.is_zona_hitler(game):
+			game.board.state.last_votes[uid] = "Ja"
+			save_game(game.cid, "auto_ja vote Round %d" % (game.board.state.currentround), game)
+			bot.send_message(uid, "Tu voto *Ja* para la votación en curso ya quedó registrado.", parse_mode=ParseMode.MARKDOWN)
+			if len(game.board.state.last_votes) == len(game.player_sequence):
+				MainController.count_votes(bot, game)
+	else:
+		bot.send_message(uid, "Voto automático *Ja* desactivado en *{}*.".format(game.groupName), parse_mode=ParseMode.MARKDOWN)
+
+def _command_toggle_auto_ja(update: Update, context: CallbackContext, enabled, comando_callback):
+	bot = context.bot
+	try:
+		cid, uid, groupType = update.message.chat_id, update.message.from_user.id, update.message.chat.type
+		if groupType not in ['group', 'supergroup']:
+			# En privado con el bot: busco los juegos activos donde esta el jugador
+			all_games_unfiltered = MainController.getGamesByTipo("Todos") or {}
+			candidatas = {key: "{}: {}".format(g.groupName, g.tipo) for key, g in all_games_unfiltered.items()
+				if uid in g.playerlist and g.board is not None}
+			if not candidatas:
+				bot.send_message(uid, "No tienes partidas activas de Secret Hitler.")
+			elif len(candidatas) == 1:
+				game = get_game(int(list(candidatas.keys())[0]))
+				set_auto_ja(bot, game, uid, enabled)
+			else:
+				msg = "Elige el juego donde quieres {} el voto automático Ja".format("activar" if enabled else "desactivar")
+				simple_choose_buttons(bot, cid, uid, uid, comando_callback, msg, candidatas)
+		else:
+			game = get_game(cid)
+			if not game or game.board is None:
+				bot.send_message(cid, "No hay juego en este chat. Crea un nuevo juego con /newgame")
+			elif uid not in game.playerlist:
+				bot.send_message(cid, "No estás en este juego!")
+			else:
+				set_auto_ja(bot, game, uid, enabled)
+	except Exception as e:
+		bot.send_message(update.message.chat_id, str(e))
+
+def command_startautoja(update: Update, context: CallbackContext):
+	_command_toggle_auto_ja(update, context, True, "chooseGameStartAutoJa")
+
+def command_stopautoja(update: Update, context: CallbackContext):
+	_command_toggle_auto_ja(update, context, False, "chooseGameStopAutoJa")
+
+def callback_startautoja(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_startautoja called')
+	callback = update.callback_query
+	regex = re.search(r"(-?[0-9]*)\*chooseGameStartAutoJa\*(.*)\*(-?[0-9]*)", callback.data)
+	opcion, uid = regex.group(2), int(regex.group(3))
+	game = get_game(int(opcion))
+	if not game or uid not in game.playerlist:
+		bot.send_message(uid, "No estás en ese juego.")
+	else:
+		set_auto_ja(bot, game, uid, True)
+
+def callback_stopautoja(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_stopautoja called')
+	callback = update.callback_query
+	regex = re.search(r"(-?[0-9]*)\*chooseGameStopAutoJa\*(.*)\*(-?[0-9]*)", callback.data)
+	opcion, uid = regex.group(2), int(regex.group(3))
+	game = get_game(int(opcion))
+	if not game or uid not in game.playerlist:
+		bot.send_message(uid, "No estás en ese juego.")
+	else:
+		set_auto_ja(bot, game, uid, False)
+
 def command_showhistory(update: Update, context: CallbackContext):
 	bot = context.bot
 	#game.pedrote = 3
@@ -1007,9 +1085,12 @@ def callback_fix2_chancellor(update: Update, context: CallbackContext):
 	bot.send_message(game.cid,
 		"Se nominó a *{}* como canciller. ¡Por favor, voten ahora!".format(player.name),
 		parse_mode=ParseMode.MARKDOWN)
-	MainController.vote(bot, game)
+	# Se setea la fase y se guarda antes de votar, porque vote() puede
+	# terminar la votación en el momento si todos los votos ya estan
+	# registrados por /startautoja, y eso avanza la ronda a otra fase.
 	game.board.state.fase = "vote"
 	save_game(game.cid, "vote Round %d" % game.board.state.currentround, game)
+	MainController.vote(bot, game)
 
 def command_fix3(update: Update, context: CallbackContext):
 	bot = context.bot

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -149,16 +149,22 @@ def nominate_chosen_chancellor(update: Update, context: CallbackContext):
 		bot.send_message(game.cid,
 					"El presidente %s nominó a %s como canciller. Por favor, vota ahora!" % (
 					game.board.state.nominated_president.name, game.board.state.nominated_chancellor.name))
-		vote(bot, game)
-		# Save after voting buttons send and set phase voting
+		# Se setea la fase y se guarda antes de votar, porque vote() puede
+		# terminar la votación en el momento si todos los votos ya estan
+		# registrados por /startautoja, y eso avanza la ronda a otra fase.
 		game.board.state.fase = "vote"
 		Commands.save_game(game.cid, "vote Round %d" % (game.board.state.currentround), game)
+		vote(bot, game)
 	except AttributeError as e:
 		log.error("nominate_chosen_chancellor: Game or board should not be None! Eror: " + str(e))
 	except Exception as e:
 		log.error("Unknown error: " + repr(e))
 		log.exception(e)
 		
+def is_zona_hitler(game):
+	# Zona Hitler: ya se promulgaron 3 politicas fascistas
+	return game.board.state.fascist_track >= 3
+
 def vote(bot, game):
 	log.info('vote called')
 	#When voting starts we start the counter to see later with the vote command if we can see you voted.
@@ -168,17 +174,23 @@ def vote(bot, game):
 	btns = [[InlineKeyboardButton("Ja", callback_data=strcid + "_Ja"),
 	InlineKeyboardButton("Nein", callback_data=strcid + "_Nein")]]
 	voteMarkup = InlineKeyboardMarkup(btns)
+	zona_hitler = is_zona_hitler(game)
 	for uid in game.playerlist:
 		if not game.playerlist[uid].is_dead and not game.is_debugging:
 			if game.playerlist[uid] is not game.board.state.nominated_president:
 				# the nominated president already got the board before nominating a chancellor
 				Commands.print_board(bot, game, uid)
-			groupName = ""		
+			groupName = ""
 			if hasattr(game, 'groupName'):
 				groupName += "*En el grupo {}*\n".format(game.groupName)
 			msg = "{}Quieres elegir al Presidente *{}* y al canciller *{}*?".format(groupName, game.board.state.nominated_president.name, game.board.state.nominated_chancellor.name)
+			if getattr(game.playerlist[uid], 'auto_ja', False) and not zona_hitler:
+				game.board.state.last_votes[uid] = "Ja"
+				msg += "\n\nTienes */startautoja* activado: tu voto *Ja* ya fue registrado automáticamente. Usa /retirar si querés votar distinto."
 			bot.send_message(uid, msg,	reply_markup=voteMarkup, parse_mode=ParseMode.MARKDOWN)
 
+	if len(game.board.state.last_votes) == len(game.player_sequence):
+		count_votes(bot, game)
 
 def handle_voting(update: Update, context: CallbackContext):
 	bot = context.bot
@@ -1236,6 +1248,10 @@ def main():
 	dp.add_handler(CommandHandler("calltovote", Commands.command_calltovote))
 	dp.add_handler(CommandHandler("retirar", Commands.command_retract_vote))
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameRetract\*(.*)\*(-?[0-9]*)", callback=Commands.callback_retract))
+	dp.add_handler(CommandHandler("startautoja", Commands.command_startautoja))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameStartAutoJa\*(.*)\*(-?[0-9]*)", callback=Commands.callback_startautoja))
+	dp.add_handler(CommandHandler("stopautoja", Commands.command_stopautoja))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameStopAutoJa\*(.*)\*(-?[0-9]*)", callback=Commands.callback_stopautoja))
 	dp.add_handler(CommandHandler("claim", Commands.command_claim))
 	dp.add_handler(CommandHandler("reload", Commands.command_reloadgame))
 	dp.add_handler(CommandHandler("debug", Commands.command_toggle_debugging))
@@ -1301,6 +1317,8 @@ def main():
 			BotCommand("votes", "Imprime quien ha votado"),
 			BotCommand("calltovote", "Avisa a los jugadores que hay que votar"),
 			BotCommand("retirar", "Retira tu voto de Ja o Nein para volver a votar"),
+			BotCommand("startautoja", "Activa tu voto automático Ja fuera de Zona Hitler"),
+			BotCommand("stopautoja", "Desactiva tu voto automático Ja"),
 			BotCommand("info", "Muestra tu informacion privada del juego"),
 			BotCommand("jugadores", "Muestra los jugadores del juego"),
 			BotCommand("leave", "Te saca de un juego existente"),


### PR DESCRIPTION
## Summary
- Agrega los comandos `/startautoja` y `/stopautoja` al bot de Secret Hitler.
- Cuando un jugador activa `/startautoja`, su voto **Ja** se registra automáticamente apenas se propone una fórmula (presidente + canciller), siempre que no estemos en Zona Hitler (3 o más políticas fascistas promulgadas). `/stopautoja` lo desactiva.
- Ambos comandos funcionan en el grupo o en privado con el bot (si el jugador está en más de un juego activo, elige cuál mediante botones), y quedan agregados al menú `/` de Telegram.
- Ajuste interno: se reordenó el guardado de fase/estado alrededor de `vote()` para evitar que una votación resuelta automáticamente (todos con auto-Ja) quede pisada por un guardado de fase obsoleto.

## Test plan
- [x] `python3 -m py_compile` sobre los archivos modificados.
- [x] Script standalone (stubs de telegram/DB) verificando:
  - Auto-Ja se registra fuera de Zona Hitler.
  - Auto-Ja se suprime con `fascist_track >= 3`.
  - `vote()` dispara el conteo de votos cuando todos los votos ya están auto-registrados.
  - Activar `/startautoja` a mitad de una votación registra el voto pendiente y puede completar el conteo.
- [ ] Prueba manual en Telegram (no realizada en este entorno).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FNeFL1a3XnMqJxrRWnTV5c)_