### PR TITLE
Secret Hitler: mostrar estado de auto Ja en /info

### DIFF
--- a/SecretHitler/Boardgamebox/Player.py
+++ b/SecretHitler/Boardgamebox/Player.py
@@ -15,6 +15,7 @@ class Player(object):
     def get_private_info(self, game):
         board = "--- *Info del Jugador {}* ---\n".format(self.name)
         board += "Eres *{}* y tu afiliacion es *{}*\n".format(self.role, self.party)
+        board += "Voto automático Ja (/startautoja): *{}*\n".format("Activado" if getattr(self, 'auto_ja', False) else "Desactivado")
         player_number = len(game.playerlist)
         if self.role == "Fascista":
             fascists = game.get_fascists()


### PR DESCRIPTION
## Summary
- `/info` ahora indica si el jugador tiene `/startautoja` activado o desactivado, junto al resto de su información privada.

## Test plan
- [x] `python3 -m py_compile SecretHitler/Boardgamebox/Player.py`
- [x] Verificación manual del texto generado por `get_private_info()` con `auto_ja` en `True` y `False`.
- [ ] Prueba manual en Telegram (no realizada en este entorno).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FNeFL1a3XnMqJxrRWnTV5c)_