### PR TITLE
Secret Hitler: agregar /fix5 para reenviar el menú de investigación

### DIFF
--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -1218,6 +1218,62 @@ def _apply_fix4(bot, game, notify_cid):
 	save_game(game.cid, "fix4 Round %d" % game.board.state.currentround, game)
 	bot.send_message(notify_cid, "Mazo reseteado: 4 liberales y 8 fascistas mezclados.\nCartas totales en el mazo: {}".format(len(game.board.policies)))
 
+def command_fix5(update: Update, context: CallbackContext):
+	bot = context.bot
+	uid = update.message.from_user.id
+	cid = update.message.chat_id
+	groupType = update.message.chat.type
+	log.info("Ingreso en FIX5")
+	if uid != ADMIN:
+		return
+
+	if groupType in ['group', 'supergroup']:
+		game = get_game(cid)
+		if game is None or game.board is None:
+			bot.send_message(cid, "No hay una partida activa en este chat.")
+			return
+		_apply_fix5(bot, game, cid)
+	else:
+		all_games_unfiltered = MainController.getGamesByTipo("Todos")
+		all_games = {
+			key: "{}: {}".format(game.groupName, game.tipo)
+			for key, game in all_games_unfiltered.items()
+			if uid in game.playerlist and game.board is not None
+		}
+		if not all_games:
+			bot.send_message(cid, "No tienes partidas activas de Secret Hitler.")
+			return
+		if len(all_games) == 1:
+			game_cid = int(next(iter(all_games)))
+			game = get_game(game_cid)
+			_apply_fix5(bot, game, uid)
+		else:
+			msg = "Elige el juego donde quieres reenviar el menú de investigación"
+			simple_choose_buttons(bot, cid, uid, uid, "chooseGameFix5", msg, all_games)
+
+def callback_fix5_game(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_fix5_game called')
+	callback = update.callback_query
+	regex = re.search(r"(-?[0-9]*)\*chooseGameFix5\*(.*)\*(-?[0-9]*)", callback.data)
+	game_cid = int(regex.group(2))
+	uid = int(regex.group(3))
+	game = get_game(game_cid)
+	if game is None or game.board is None:
+		bot.send_message(uid, "No hay una partida activa en ese chat.")
+		return
+	_apply_fix5(bot, game, uid)
+
+def _apply_fix5(bot, game, notify_cid):
+	if game.board.state.president is None:
+		bot.send_message(notify_cid, "No hay un Presidente actual en esta partida.")
+		return
+	# Reafirmo la fase por si quedó desincronizada, y reenvío el menú al Presidente
+	game.board.state.fase = "legislating power inspect"
+	save_game(game.cid, "fix5 Round %d" % game.board.state.currentround, game)
+	MainController.action_inspect(bot, game)
+	bot.send_message(notify_cid, "Se reenvió el menú de investigación al Presidente {}.".format(game.board.state.president.name))
+
 def command_player_counter(update: Update, context: CallbackContext):
 	bot = context.bot
 	args = context.args

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -1265,6 +1265,8 @@ def main():
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameFix3\*(.*)\*(-?[0-9]*)", callback=Commands.callback_fix3_game))
 	dp.add_handler(CommandHandler("fix4", Commands.command_fix4))
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameFix4\*(.*)\*(-?[0-9]*)", callback=Commands.callback_fix4_game))
+	dp.add_handler(CommandHandler("fix5", Commands.command_fix5))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameFix5\*(.*)\*(-?[0-9]*)", callback=Commands.callback_fix5_game))
 	dp.add_handler(CommandHandler("claimoculto", Commands.command_claim_oculto))
 	dp.add_handler(CommandHandler("info", Commands.command_info))
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameInfo\*(.*)\*(-?[0-9]*)", callback=Commands.callback_info))


### PR DESCRIPTION
## Summary
- Agrega `/fix5` (solo admin) para reenviar el menú de investigación de afiliación política al Presidente actual, para los casos en que ese menú no le llegó cuando se habilitó el poder presidencial "Investigar Afiliación Política".
- Sigue el mismo patrón que `/fix2`, `/fix3` y `/fix4`: funciona en el grupo directamente, o en privado con el bot (eligiendo el juego si el admin está en más de uno activo).
- Reafirma `game.board.state.fase = "legislating power inspect"` antes de reenviar, por si esa fase hubiera quedado desincronizada.

## Test plan
- [x] `python3 -m py_compile` sobre los archivos modificados.
- [x] Script standalone (stubs de telegram/DB) verificando que `_apply_fix5` reenvía el menú al Presidente correcto y que informa correctamente cuando no hay Presidente actual.
- [ ] Prueba manual en Telegram (no realizada en este entorno).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FNeFL1a3XnMqJxrRWnTV5c)_