### PR TITLE
Secret Hitler: estadisticas vinculadas al uid de Telegram

### DIFF
--- a/SecretHitler/Boardgamebox/Player.py
+++ b/SecretHitler/Boardgamebox/Player.py
@@ -5,6 +5,8 @@ class Player(object):
         self.role = None
         self.party = None
         self.is_dead = False
+        # uid del presidente que lo ejecuto, o None si sigue vivo o murio por otra via
+        self.killed_by_uid = None
         self.inspected_players = {}
         self.was_investigated = False
         #"Liberal","Fascista","Hitler"

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -25,6 +25,7 @@ from SecretHitler.Boardgamebox.Player import Player
 from SecretHitler.Boardgamebox.State import State
 from SecretHitler.PlayerStats import PlayerStats
 from SecretHitler.EstadisticsCalculator import PrintEstadisticas
+import SecretHitler.StatsExtended as StatsExtended
 # Enable logging
 
 log.basicConfig(
@@ -273,7 +274,74 @@ def command_stats(update: Update, context: CallbackContext):
 				"Juegos cancelados: *" + str(stats[5]) + "*\n" + \
 				"Juegos totales: *" + str(stats[1] + stats[2] + stats[3] + stats[4]) + "*\n\n"		
 		bot.send_message(cid, stattext, ParseMode.MARKDOWN)
-		
+
+# estadisticas nuevas, vinculadas al uid de Telegram del que invoca el comando
+def command_stats2(update: Update, context: CallbackContext):
+	bot = context.bot
+	cid = update.message.chat_id
+	uid = update.message.from_user.id
+
+	base = StatsExtended.get_base_stats_by_uid(uid)
+	if base is None:
+		bot.send_message(cid, "No hay estadisticas nuevas todavia para vos. Pedile a un admin que use "
+			"/vincularstats para vincular tus partidas viejas, o segui jugando para generar estadisticas nuevas.")
+		return
+
+	kills = StatsExtended.get_kill_stats(uid)
+	teammates = StatsExtended.get_teammate_stats(uid)
+
+	stattext = "+++ Estadísticas +++\n" + \
+		"Partidas Jugadas: *{0}*\n".format(base["total"]) + \
+		"Partidas como liberal: *{1}/{0}* Ganó: *{2}/{1}*\n".format(base["total"], base["liberal"], base["liberal_won"]) + \
+		"Partidas como Fascista:  *{1}/{0}* Ganó: *{2}/{1}*\n".format(base["total"], base["fascista"], base["fascista_won"]) + \
+		"Partidas como Hitler:  *{1}/{0}* Ganó: *{2}/{1}*\n".format(base["total"], base["hitler"], base["hitler_won"]) + \
+		"Partidas que ganó:  *{1}/{0}* {2:.2f}%\n".format(base["total"], base["gano"], (base["gano"] / base["total"]) * 100) + \
+		"Partidas que murió:  *{1}/{0}*\n".format(base["total"], base["murio"]) + \
+		"\nGente que mató: *{0}*\n".format(kills["kills_count"])
+
+	if kills["most_killed"]:
+		_, victim_name, victim_count = kills["most_killed"]
+		stattext += "A quién más mató: *{0}* ({1} veces)\n".format(victim_name, victim_count)
+	if kills["most_frequent_killer"]:
+		killer_name, killer_count = kills["most_frequent_killer"]
+		stattext += "Quién más lo mató: *{0}* ({1} veces)\n".format(killer_name, killer_count)
+	if teammates["best_teammates"]:
+		names = ", ".join(n for n, c in teammates["best_teammates"])
+		stattext += "Ganó más partidas con: *{0}* ({1} veces)\n".format(names, teammates["best_teammates"][0][1])
+	if teammates["worst_teammates"]:
+		names = ", ".join(n for n, c in teammates["worst_teammates"])
+		stattext += "Perdió más partidas con: *{0}* ({1} veces)\n".format(names, teammates["worst_teammates"][0][1])
+
+	bot.send_message(cid, stattext, ParseMode.MARKDOWN)
+
+# vincula partidas viejas (buscadas por nombre) a un uid de Telegram, solo ADMIN
+def command_vincularstats(update: Update, context: CallbackContext):
+	bot = context.bot
+	cid = update.message.chat_id
+	uid = update.message.from_user.id
+	args = context.args
+
+	if uid != ADMIN:
+		return
+
+	if len(args) < 2:
+		bot.send_message(cid, "Uso: /vincularstats <id_telegram> <nombre>")
+		return
+
+	try:
+		target_uid = int(args[0])
+	except ValueError:
+		bot.send_message(cid, "El primer argumento debe ser un ID de Telegram numérico.")
+		return
+
+	name = ' '.join(args[1:])
+
+	try:
+		linked = StatsExtended.migrate_legacy_stats(target_uid, name)
+		bot.send_message(cid, "Se vincularon {0} partidas viejas de '{1}' al ID {2}.".format(linked, name, target_uid))
+	except Exception as e:
+		bot.send_message(cid, 'No se ejecuto el comando debido a: ' + str(e))
+
 # help page
 def command_help(update: Update, context: CallbackContext):
 	bot = context.bot

--- a/SecretHitler/DBCreate.sql
+++ b/SecretHitler/DBCreate.sql
@@ -48,6 +48,28 @@ CREATE TABLE IF NOT EXISTS achivements_secret_hitler (
     description text NOT NULL
 );
 
+-- Estadisticas nuevas vinculadas al ID de Telegram (no reemplazan stats_detail_secret_hitler,
+-- que sigue alimentando /stats por nombre).
+CREATE TABLE IF NOT EXISTS stats_secret_hitler_games (
+    id SERIAL PRIMARY KEY,
+    game_endcode INTEGER NOT NULL,
+    legacy_detail_id INTEGER UNIQUE, -- referencia a stats_detail_secret_hitler.id, solo para partidas migradas con /vincularstats
+    created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS stats_secret_hitler_players (
+    id SERIAL PRIMARY KEY,
+    game_id INTEGER NOT NULL REFERENCES stats_secret_hitler_games(id),
+    uid BIGINT NOT NULL,
+    name TEXT NOT NULL,
+    role TEXT,
+    party TEXT,
+    won BOOLEAN NOT NULL,
+    died BOOLEAN NOT NULL,
+    killed_by_uid BIGINT, -- NULL si no lo mataron o si el dato no se pudo reconstruir al migrar
+    UNIQUE (game_id, uid)
+);
+
 -- If there are no stats in the stats table I initiate it.
 DO $$
 BEGIN 

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -20,6 +20,7 @@ from SecretHitler.Boardgamebox.Game import Game
 from SecretHitler.Boardgamebox.Player import Player
 from SecretHitler.PlayerStats import PlayerStats
 import SecretHitler.GamesController as GamesController
+import SecretHitler.StatsExtended as StatsExtended
 
 import datetime
 import jsonpickle
@@ -582,6 +583,7 @@ def choose_kill(update: Update, context: CallbackContext):
         game = Commands.get_game(cid)
         chosen = game.playerlist[answer]
         chosen.is_dead = True
+        chosen.killed_by_uid = game.board.state.president.uid
         if game.player_sequence.index(chosen) <= game.board.state.player_counter:
             game.board.state.player_counter -= 1
         game.player_sequence.remove(chosen)
@@ -933,8 +935,9 @@ def end_game(bot, game, game_endcode):
 	# Grabo detalles de la partida
 	if game_endcode != 99:
 		save_game_details(bot, game.print_roles(), game_endcode, game.board.state.liberal_track, game.board.state.fascist_track, game.board.num_players)
-	
-	
+		StatsExtended.save_extended_game_stats(game, game_endcode)
+
+
 	#bot.send_message(cid, "Datos a guardar %s %s %s %s %s" % (game.print_roles(), str(game_endcode), str(game.board.state.liberal_track), str(game.board.state.fascist_track), str(game.board.num_players)))
 		
 	stats = get_stats(bot, cid)	
@@ -1238,6 +1241,8 @@ def main():
 	dp.add_handler(CommandHandler("ping", Commands.command_ping))
 	dp.add_handler(CommandHandler("symbols", Commands.command_symbols))
 	dp.add_handler(CommandHandler("stats", Commands.command_stats))
+	dp.add_handler(CommandHandler("stats2", Commands.command_stats2))
+	dp.add_handler(CommandHandler("vincularstats", Commands.command_vincularstats))
 	dp.add_handler(CommandHandler("newgame", Commands.command_newgame))
 	dp.add_handler(CommandHandler("startgame", Commands.command_startgame))
 	dp.add_handler(CommandHandler("cancelgame", Commands.command_cancelgame))
@@ -1325,6 +1330,7 @@ def main():
 			BotCommand("jugadores", "Muestra los jugadores del juego"),
 			BotCommand("leave", "Te saca de un juego existente"),
 			BotCommand("stats", "Muestra las estadisticas"),
+			BotCommand("stats2", "Muestra tus estadisticas nuevas vinculadas a tu ID"),
 		])
 	except Exception as e:
 		log.error(str(e))

--- a/SecretHitler/StatsExtended.py
+++ b/SecretHitler/StatsExtended.py
@@ -1,0 +1,242 @@
+import logging as log
+import os
+import re
+import urllib.parse
+
+import psycopg2
+
+# DB Connection (mismo patron que MainController.py / Commands.py)
+urllib.parse.uses_netloc.append("postgres")
+url = urllib.parse.urlparse(os.environ["DATABASE_URL"])
+
+
+def _connect():
+    return psycopg2.connect(
+        database=url.path[1:],
+        user=url.username,
+        password=url.password,
+        host=url.hostname,
+        port=url.port
+    )
+
+
+def save_extended_game_stats(game, game_endcode):
+    # Guarda, ademas de lo que ya se guarda hoy, un registro por jugador vinculado a su uid.
+    # No propaga excepciones: un fallo aca nunca debe impedir que end_game() termine su flujo normal.
+    if game_endcode == 99:
+        return
+    try:
+        won_liberal = game_endcode in (1, 2)
+        won_fascist = game_endcode in (-1, -2)
+
+        conn = _connect()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO stats_secret_hitler_games(game_endcode) VALUES (%s) RETURNING id;",
+            (game_endcode,)
+        )
+        game_id = cur.fetchone()[0]
+
+        for uid, player in game.playerlist.items():
+            if player.party == "liberal":
+                won = won_liberal
+            elif player.party == "fascista":
+                won = won_fascist
+            else:
+                won = False
+            cur.execute(
+                "INSERT INTO stats_secret_hitler_players"
+                "(game_id, uid, name, role, party, won, died, killed_by_uid) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) "
+                "ON CONFLICT (game_id, uid) DO NOTHING;",
+                (game_id, uid, player.name, player.role, player.party, won,
+                 player.is_dead, getattr(player, "killed_by_uid", None))
+            )
+
+        conn.commit()
+        conn.close()
+    except Exception as e:
+        log.error("save_extended_game_stats failed: %s" % str(e))
+
+
+def get_base_stats_by_uid(uid):
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT role, won, died FROM stats_secret_hitler_players WHERE uid = %s;",
+        (uid,)
+    )
+    rows = cur.fetchall()
+    conn.close()
+
+    if not rows:
+        return None
+
+    def _count(role, won_only=False):
+        return sum(1 for r in rows if r[0] == role and (r[1] if won_only else True))
+
+    return {
+        "total": len(rows),
+        "liberal": _count("Liberal"),
+        "liberal_won": _count("Liberal", won_only=True),
+        "fascista": _count("Fascista"),
+        "fascista_won": _count("Fascista", won_only=True),
+        "hitler": _count("Hitler"),
+        "hitler_won": _count("Hitler", won_only=True),
+        "murio": sum(1 for r in rows if r[2]),
+        "gano": sum(1 for r in rows if r[1]),
+    }
+
+
+def get_kill_stats(uid):
+    conn = _connect()
+    cur = conn.cursor()
+
+    cur.execute(
+        "SELECT COUNT(*) FROM stats_secret_hitler_players WHERE killed_by_uid = %s;",
+        (uid,)
+    )
+    kills_count = cur.fetchone()[0]
+
+    cur.execute(
+        "SELECT uid, name, COUNT(*) c FROM stats_secret_hitler_players "
+        "WHERE killed_by_uid = %s GROUP BY uid, name ORDER BY c DESC, uid LIMIT 1;",
+        (uid,)
+    )
+    most_killed = cur.fetchone()
+
+    cur.execute(
+        "SELECT killed_by_uid, COUNT(*) c FROM stats_secret_hitler_players "
+        "WHERE uid = %s AND killed_by_uid IS NOT NULL "
+        "GROUP BY killed_by_uid ORDER BY c DESC LIMIT 1;",
+        (uid,)
+    )
+    row = cur.fetchone()
+    most_frequent_killer = None
+    if row is not None:
+        killer_uid, killer_count = row
+        cur.execute(
+            "SELECT name FROM stats_secret_hitler_players WHERE uid = %s "
+            "ORDER BY game_id DESC LIMIT 1;",
+            (killer_uid,)
+        )
+        namerow = cur.fetchone()
+        killer_name = namerow[0] if namerow else str(killer_uid)
+        most_frequent_killer = (killer_name, killer_count)
+
+    conn.close()
+    return {
+        "kills_count": kills_count,
+        "most_killed": most_killed,
+        "most_frequent_killer": most_frequent_killer,
+    }
+
+
+def get_teammate_stats(uid):
+    conn = _connect()
+    cur = conn.cursor()
+
+    def _top_teammates(won_value):
+        cur.execute(
+            "SELECT b.uid, MAX(b.name), COUNT(*) c "
+            "FROM stats_secret_hitler_players a "
+            "JOIN stats_secret_hitler_players b "
+            "  ON a.game_id = b.game_id AND a.party = b.party AND a.uid != b.uid "
+            "WHERE a.uid = %s AND a.won = %s "
+            "GROUP BY b.uid ORDER BY c DESC;",
+            (uid, won_value)
+        )
+        rows = cur.fetchall()
+        if not rows:
+            return []
+        top_count = rows[0][2]
+        return [(name, c) for (_, name, c) in rows if c == top_count]
+
+    best_teammates = _top_teammates(True)
+    worst_teammates = _top_teammates(False)
+    conn.close()
+    return {
+        "best_teammates": best_teammates,
+        "worst_teammates": worst_teammates,
+    }
+
+
+def _normalize_role(raw):
+    raw = raw.lower()
+    if raw.startswith("fasc"):
+        return "Fascista"
+    if raw.startswith("hitl"):
+        return "Hitler"
+    if raw.startswith("libe"):
+        return "Liberal"
+    return None
+
+
+def _extract_legacy_role(stripped_playerlist, name):
+    escaped = re.escape(name)
+    patterns = [
+        r"%s\s*secret role was\s*(Fasc\w*|Hitl\w*|Libe\w*)" % escaped,
+        r"El rol de %s\s*(?:era|sera)\s*(Fasc\w*|Hitl\w*|Libe\w*)" % escaped,
+    ]
+    for pattern in patterns:
+        m = re.search(pattern, stripped_playerlist, re.IGNORECASE)
+        if m:
+            return _normalize_role(m.group(1))
+    return None
+
+
+def _legacy_player_died(raw_playerlist, name):
+    return ("%s (dead)" % name) in raw_playerlist or ("%s (muerto)" % name) in raw_playerlist
+
+
+def migrate_legacy_stats(uid, name):
+    # Busca en stats_detail_secret_hitler (el TEXT que usa /stats <nombre>) las partidas
+    # donde aparece `name` y crea filas nuevas vinculadas a `uid`. Idempotente: correrlo
+    # de nuevo no duplica partidas ni filas de jugador (ON CONFLICT DO NOTHING).
+    # killed_by_uid queda en NULL porque el texto legacy no registra quien mato a quien.
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, playerlist, game_endcode FROM stats_detail_secret_hitler WHERE playerlist LIKE %s;",
+        ("%{0}%".format(name),)
+    )
+    rows = cur.fetchall()
+
+    linked = 0
+    for legacy_id, playerlist_text, game_endcode in rows:
+        stripped = re.sub(r"\s*\((?:dead|muerto)\)", "", playerlist_text)
+        role = _extract_legacy_role(stripped, name)
+        if role is None:
+            continue
+        died = _legacy_player_died(playerlist_text, name)
+        party = "fascista" if role in ("Fascista", "Hitler") else "liberal"
+        won = (game_endcode in (1, 2)) if party == "liberal" else (game_endcode in (-1, -2))
+
+        cur.execute(
+            "SELECT id FROM stats_secret_hitler_games WHERE legacy_detail_id = %s;",
+            (legacy_id,)
+        )
+        existing = cur.fetchone()
+        if existing:
+            game_id = existing[0]
+        else:
+            cur.execute(
+                "INSERT INTO stats_secret_hitler_games(game_endcode, legacy_detail_id) "
+                "VALUES (%s, %s) RETURNING id;",
+                (game_endcode, legacy_id)
+            )
+            game_id = cur.fetchone()[0]
+
+        cur.execute(
+            "INSERT INTO stats_secret_hitler_players"
+            "(game_id, uid, name, role, party, won, died, killed_by_uid) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, NULL) "
+            "ON CONFLICT (game_id, uid) DO NOTHING RETURNING id;",
+            (game_id, uid, name, role, party, won, died)
+        )
+        if cur.fetchone() is not None:
+            linked += 1
+
+    conn.commit()
+    conn.close()
+    return linked


### PR DESCRIPTION
Agrega un sistema de estadisticas nuevo y aislado (StatsExtended.py +
tablas stats_secret_hitler_games/stats_secret_hitler_players), keyed
por uid en vez de nombre de pantalla, sin tocar /stats ni las tablas
existentes:

- Se registra rol, faccion, si gano, si murio y quien lo mato en cada
  partida (choose_kill ahora guarda killed_by_uid).
- /stats2 muestra esas estadisticas para quien lo invoca, mas
  cantidad de gente que mato, a quien mato mas, quien lo mato mas, y
  con quien gano/perdio mas partidas juntos.
- /vincularstats <uid> <nombre> (admin) migra partidas viejas
  (buscadas por nombre en stats_detail_secret_hitler) al uid dado, de
  forma idempotente, dejando en NULL lo que no se puede reconstruir.
- El guardado nuevo ocurre en end_game() envuelto en manejo de
  errores propio, para no romper el cierre de partida existente.