### PR TITLE
Secret Hitler: usar ruta absoluta para DBCreate.sql

### DIFF
--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -1220,7 +1220,11 @@ def init_db():
 	log.info('Init DB Secret Hitler')
 	db_init_error = None
 	try:
-		cur.execute(open("DBCreate.sql", "r").read())
+		# Ruta absoluta: "DBCreate.sql" a secas se resuelve contra el cwd del proceso
+		# (Main.py corre con cwd "/"), no contra esta carpeta, y terminaba leyendo
+		# /DBCreate.sql (el del bot principal) en vez de SecretHitler/DBCreate.sql.
+		sql_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "DBCreate.sql")
+		cur.execute(open(sql_path, "r").read())
 		log.info('DB Created/Updated Secret Hitler')
 	except Exception as e:
 		db_init_error = str(e)


### PR DESCRIPTION
## Summary
- El aviso de estado de tablas agregado en el PR anterior reportó que `achivements_secret_hitler`, `stats_secret_hitler_games`, `stats_secret_hitler_players` y `user_stats` no se pudieron crear.
- Causa raíz: `SecretHitler/MainController.py` abría `"DBCreate.sql"` con ruta relativa. El `Dockerfile` no define `WORKDIR`, así que el proceso corre con cwd `/`, y esa ruta relativa terminaba resolviendo a `/DBCreate.sql` (el `DBCreate.sql` del bot principal, con tablas `games`/`config`/`stats`/`stats_detail`), nunca a `SecretHitler/DBCreate.sql`. Por eso esas 4 tablas nunca se crearon en producción, aunque el resto (creadas antes, probablemente cuando Secret Hitler corría como deploy standalone) sí existían.
- Fix: resolver la ruta de forma absoluta con `os.path.join(os.path.dirname(os.path.abspath(__file__)), "DBCreate.sql")`, para que siempre apunte al `DBCreate.sql` de la carpeta `SecretHitler/` sin importar el cwd del proceso.

## Test plan
- [x] `python3 -m py_compile SecretHitler/MainController.py`
- [ ] Verificar en producción que el próximo arranque reporte "Todas las tablas de la base de datos ya existian" o "Se crearon las tablas faltantes: ..." (y no más el aviso de ATENCION)

---
_Generated by [Claude Code](https://claude.ai/code/session_015g1FipreWe8iUPS16wFBh4)_