### PR TITLE
Secret Hitler: avisar cuando /vincularstats empieza a correr

### DIFF
--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -336,6 +336,8 @@ def command_vincularstats(update: Update, context: CallbackContext):
 
 	name = ' '.join(args[1:])
 
+	bot.send_message(cid, "Comenzando a vincular las partidas viejas de '{0}' al ID {1}...".format(name, target_uid))
+
 	try:
 		linked = StatsExtended.migrate_legacy_stats(target_uid, name)
 		bot.send_message(cid, "Se vincularon {0} partidas viejas de '{1}' al ID {2}.".format(linked, name, target_uid))


### PR DESCRIPTION
## Summary
- `/vincularstats` ahora manda un mensaje ("Comenzando a vincular las partidas viejas de '{nombre}' al ID {uid}...") apenas valida los argumentos, antes de consultar la base, para confirmar que el comando arrancó.

## Test plan
- [x] `python3 -m py_compile SecretHitler/Commands.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_015g1FipreWe8iUPS16wFBh4)_