### PR TITLE
Secret Hitler: agregar /vincularstats2 para vincular varios jugadores a la vez

### DIFF
--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -344,6 +344,36 @@ def command_vincularstats(update: Update, context: CallbackContext):
 	except Exception as e:
 		bot.send_message(cid, 'No se ejecuto el comando debido a: ' + str(e))
 
+# vincula varios jugadores a la vez, parseando lineas tipo "User <nombre>'s ID is <id>.", solo ADMIN
+_VINCULARSTATS2_LINE = re.compile(r"User\s+(.+?)'s\s+ID\s+is\s+(\d+)\.?", re.IGNORECASE)
+
+def command_vincularstats2(update: Update, context: CallbackContext):
+	bot = context.bot
+	cid = update.message.chat_id
+	uid = update.message.from_user.id
+
+	if uid != ADMIN:
+		return
+
+	matches = _VINCULARSTATS2_LINE.findall(update.message.text)
+	if not matches:
+		bot.send_message(cid, "Uso: /vincularstats2 seguido de lineas como:\nUser <nombre>'s ID is <id>.")
+		return
+
+	bot.send_message(cid, "Comenzando a vincular {0} jugador(es)...".format(len(matches)))
+
+	resultados = []
+	for name, uid_str in matches:
+		name = name.strip()
+		target_uid = int(uid_str)
+		try:
+			linked = StatsExtended.migrate_legacy_stats(target_uid, name)
+			resultados.append("{0} (ID {1}): {2} partidas vinculadas".format(name, target_uid, linked))
+		except Exception as e:
+			resultados.append("{0} (ID {1}): error - {2}".format(name, target_uid, str(e)))
+
+	bot.send_message(cid, "\n".join(resultados))
+
 # help page
 def command_help(update: Update, context: CallbackContext):
 	bot = context.bot

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -1292,6 +1292,7 @@ def main():
 	dp.add_handler(CommandHandler("stats", Commands.command_stats))
 	dp.add_handler(CommandHandler("stats2", Commands.command_stats2))
 	dp.add_handler(CommandHandler("vincularstats", Commands.command_vincularstats))
+	dp.add_handler(CommandHandler("vincularstats2", Commands.command_vincularstats2))
 	dp.add_handler(CommandHandler("newgame", Commands.command_newgame))
 	dp.add_handler(CommandHandler("startgame", Commands.command_startgame))
 	dp.add_handler(CommandHandler("cancelgame", Commands.command_cancelgame))


### PR DESCRIPTION
## Summary
- Nuevo comando `/vincularstats2` (solo admin) que acepta varias líneas con el formato `User <nombre>'s ID is <id>.` en un solo mensaje, y llama a `migrate_legacy_stats` para cada una.
- El `'s` se descarta correctamente del nombre (regex captura todo antes de `'s ID is`).
- Informa, por jugador, cuántas partidas se vincularon o el error si algo falló, sin cortar el procesamiento del resto si uno falla.
- Mismo backend que `/vincularstats` — no cambia su comportamiento existente.

## Test plan
- [x] `python3 -m py_compile SecretHitler/Commands.py SecretHitler/MainController.py`
- [x] Probado el regex contra el texto de ejemplo (`User Gonza's ID is 6473134.` / `User Leviatas's ID is 387393551.`) → extrae correctamente `Gonza`/`6473134` y `Leviatas`/`387393551`

---
_Generated by [Claude Code](https://claude.ai/code/session_015g1FipreWe8iUPS16wFBh4)_