### PR TITLE
Agregar sistema de logros (achievements) a Secret Hitler

### DIFF
--- a/SecretHitler/Achievements.py
+++ b/SecretHitler/Achievements.py
@@ -1,0 +1,178 @@
+import logging as log
+import os
+import urllib.parse
+
+import psycopg2
+
+from SecretHitler.Constants.Achievements import LOGROS, LOGROS_BY_CODE, CATEGORIAS, CATEGORIA_TITULOS
+
+# DB Connection (mismo patron que StatsExtended.py / MainController.py)
+urllib.parse.uses_netloc.append("postgres")
+url = urllib.parse.urlparse(os.environ["DATABASE_URL"])
+
+
+def _connect():
+    return psycopg2.connect(
+        database=url.path[1:],
+        user=url.username,
+        password=url.password,
+        host=url.hostname,
+        port=url.port
+    )
+
+
+class Ctx(dict):
+    # dict con los datos de un jugador al final de una partida, mas acceso
+    # perezoso a su historial (para no pagar queries extra en logros que
+    # solo miran la partida actual).
+    def __init__(self, cur, uid, **kwargs):
+        super().__init__(uid=uid, **kwargs)
+        self._cur = cur
+        self._uid = uid
+        self._history = None
+        self._kills_history = None
+
+    def history(self):
+        # Filas (role, party, won, died, killed_by_uid, game_id) de todas las
+        # partidas del jugador, en orden. Corre en la misma transaccion que
+        # el INSERT de la partida actual, asi que ya la incluye.
+        if self._history is None:
+            self._cur.execute(
+                "SELECT role, party, won, died, killed_by_uid, game_id "
+                "FROM stats_secret_hitler_players WHERE uid = %s ORDER BY game_id;",
+                (self._uid,)
+            )
+            self._history = self._cur.fetchall()
+        return self._history
+
+    def kills_history(self):
+        # Rol de cada jugador que este uid ejecuto, a lo largo de su historial.
+        if self._kills_history is None:
+            self._cur.execute(
+                "SELECT role FROM stats_secret_hitler_players WHERE killed_by_uid = %s;",
+                (self._uid,)
+            )
+            self._kills_history = [row[0] for row in self._cur.fetchall()]
+        return self._kills_history
+
+
+def build_context(cur, game, game_endcode, uid, player):
+    won_liberal = game_endcode in (1, 2)
+    won_fascist = game_endcode in (-1, -2)
+    if player.party == "liberal":
+        won = won_liberal
+    elif player.party == "fascista":
+        won = won_fascist
+    else:
+        won = False
+
+    killed_roles = [
+        getattr(p, "role", None)
+        for p in game.playerlist.values()
+        if getattr(p, "killed_by_uid", None) == uid
+    ]
+
+    return Ctx(
+        cur, uid,
+        role=player.role,
+        party=player.party,
+        won=won,
+        died=player.is_dead,
+        killed_by_uid=getattr(player, "killed_by_uid", None),
+        killed_roles=killed_roles,
+        game_endcode=game_endcode,
+        num_players=game.board.num_players,
+        liberal_track=game.board.state.liberal_track,
+        fascist_track=game.board.state.fascist_track,
+        dead_count=game.board.state.dead,
+        was_investigated=getattr(player, "was_investigated", False),
+        auto_ja=getattr(player, "auto_ja", False),
+        preference_rol=getattr(player, "preference_rol", ""),
+    )
+
+
+def evaluate_and_store(cur, game, game_endcode, game_id):
+    # Corre dentro de la transaccion de StatsExtended.save_extended_game_stats,
+    # despues de insertar las filas de stats_secret_hitler_players y antes del
+    # commit. Nunca propaga excepciones: un logro roto no debe tumbar el guardado
+    # de estadisticas ni el fin de partida.
+    nuevos_por_uid = {}
+    for uid, player in game.playerlist.items():
+        try:
+            ctx = build_context(cur, game, game_endcode, uid, player)
+        except Exception as e:
+            log.error("Achievements.build_context failed for uid %s: %s" % (uid, str(e)))
+            continue
+
+        nuevos = []
+        for logro in LOGROS:
+            try:
+                if not logro.check(ctx):
+                    continue
+                cur.execute(
+                    "INSERT INTO achievements_secret_hitler_players(uid, achievement_code, game_id) "
+                    "VALUES (%s, %s, %s) ON CONFLICT (uid, achievement_code) DO NOTHING RETURNING id;",
+                    (uid, logro.code, game_id)
+                )
+                if cur.fetchone() is not None:
+                    nuevos.append(logro)
+            except Exception as e:
+                log.error("Achievements check '%s' failed for uid %s: %s" % (logro.code, uid, str(e)))
+
+        if nuevos:
+            nuevos_por_uid[uid] = nuevos
+
+    return nuevos_por_uid
+
+
+def get_unlocked_codes(uid):
+    conn = _connect()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT achievement_code FROM achievements_secret_hitler_players WHERE uid = %s;",
+            (uid,)
+        )
+        return {row[0] for row in cur.fetchall()}
+    finally:
+        conn.close()
+
+
+def format_unlock_announcement(nuevos_por_uid, game, max_lineas=6):
+    if not nuevos_por_uid:
+        return None
+
+    lineas = []
+    total = 0
+    for uid, logros in nuevos_por_uid.items():
+        player = game.playerlist.get(uid)
+        name = (player.name if player is not None else str(uid)).replace("_", " ")
+        for logro in logros:
+            total += 1
+            if len(lineas) < max_lineas:
+                lineas.append("%s desbloqueó %s *%s*" % (name, logro.emoji, logro.name))
+
+    texto = "🏆 *¡Nuevos logros!*\n\n" + "\n".join(lineas)
+    if total > len(lineas):
+        texto += "\n...y %d logro%s más (/logros)" % (total - len(lineas), "" if total - len(lineas) == 1 else "s")
+    texto += "\n\nMirá todos los tuyos con /logros"
+    return texto
+
+
+def format_logros_message(uid, name):
+    unlocked = get_unlocked_codes(uid)
+
+    texto = "🏆 *Logros de %s* (%d/%d)\n" % (name.replace("_", " "), len(unlocked), len(LOGROS))
+    for categoria in CATEGORIAS:
+        logros_categoria = [l for l in LOGROS if l.categoria == categoria]
+        if not logros_categoria:
+            continue
+        texto += "\n*%s*\n" % CATEGORIA_TITULOS[categoria]
+        for logro in logros_categoria:
+            if logro.code in unlocked:
+                texto += "✅ %s *%s* — %s\n" % (logro.emoji, logro.name, logro.description)
+            elif logro.secreto:
+                texto += "🔒 ❓ ??? — Logro secreto\n"
+            else:
+                texto += "🔒 %s %s — %s\n" % (logro.emoji, logro.name, logro.description)
+    return texto

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -26,6 +26,7 @@ from SecretHitler.Boardgamebox.State import State
 from SecretHitler.PlayerStats import PlayerStats
 from SecretHitler.EstadisticsCalculator import PrintEstadisticas
 import SecretHitler.StatsExtended as StatsExtended
+import SecretHitler.Achievements as Achievements
 # Enable logging
 
 log.basicConfig(
@@ -53,7 +54,8 @@ commands = [  # command description used in the "help" command
     '/calltovote - Avisa a los jugadores que se tiene que votar',
     '/retirar - Retira tu voto de Ja o Nein para poder votar de nuevo',
     '/startautoja - Activa tu voto automático Ja apenas se proponga una fórmula (fuera de Zona Hitler)',
-    '/stopautoja - Desactiva tu voto automático Ja'
+    '/stopautoja - Desactiva tu voto automático Ja',
+    '/logros - Muestra tus logros desbloqueados'
 ]
 
 symbols = [
@@ -345,6 +347,47 @@ def command_stats2(update: Update, context: CallbackContext):
 		stattext += "Perdió más partidas con: *{0}* ({1} veces)\n".format(names, teammates["worst_teammates"][0][1])
 
 	bot.send_message(cid, stattext, ParseMode.MARKDOWN)
+
+def command_logros(update: Update, context: CallbackContext):
+	bot = context.bot
+	cid = update.message.chat_id
+	caller_uid = update.message.from_user.id
+	caller_name = update.message.from_user.first_name or str(caller_uid)
+	args = context.args
+
+	if len(args) == 0:
+		target_uid = caller_uid
+		target_name = caller_name
+	elif len(args) == 1 and args[0].isdigit():
+		target_uid = int(args[0])
+		target_name = str(target_uid)
+	else:
+		name = ' '.join(args)
+		try:
+			matches = StatsExtended.get_uids_by_name(name)
+		except Exception as e:
+			bot.send_message(cid, 'No se ejecuto el comando debido a: ' + str(e))
+			return
+
+		if not matches:
+			bot.send_message(cid, "No hay estadisticas nuevas para nadie con el nombre '{0}'.".format(name))
+			return
+		if len(matches) > 1:
+			lines = ["Hay más de un jugador con el nombre '{0}':".format(name)]
+			for m_uid, m_name, total in matches:
+				lines.append("- ID {0} ({1}): {2} partidas".format(m_uid, m_name, total))
+			lines.append("\nUsá /logros <ID> para ver los logros de uno en particular.")
+			bot.send_message(cid, "\n".join(lines))
+			return
+		target_uid, target_name, _ = matches[0]
+
+	try:
+		texto = Achievements.format_logros_message(target_uid, target_name)
+	except Exception as e:
+		bot.send_message(cid, 'No se ejecuto el comando debido a: ' + str(e))
+		return
+
+	bot.send_message(cid, texto, ParseMode.MARKDOWN)
 
 # vincula partidas viejas (buscadas por nombre) a un uid de Telegram, solo ADMIN
 def command_vincularstats(update: Update, context: CallbackContext):

--- a/SecretHitler/Constants/Achievements.py
+++ b/SecretHitler/Constants/Achievements.py
@@ -1,0 +1,146 @@
+from collections import namedtuple
+
+# Catalogo de logros. `code` es el identificador estable que se persiste en
+# achievements_secret_hitler_players.achievement_code: una vez desplegado un
+# logro, nunca renombrar su `code` (perderia el vinculo con lo ya desbloqueado).
+# `name`/`description`/`emoji` se pueden editar libremente.
+# `secreto` = True oculta nombre y descripcion en /logros mientras esta bloqueado.
+# `check(ctx)` recibe un Achievements.Ctx y devuelve True/False.
+Logro = namedtuple("Logro", "code name description emoji categoria secreto check")
+
+CATEGORIAS = ["roles", "muerte", "hitos", "social"]
+CATEGORIA_TITULOS = {
+    "roles": "Roles y victorias",
+    "muerte": "Muerte y ejecuciones",
+    "hitos": "Hitos",
+    "social": "Social",
+}
+
+
+def _check_hitler_ganador(ctx):
+    return ctx["role"] == "Hitler" and ctx["won"]
+
+
+def _check_hitler_incognito(ctx):
+    return ctx["role"] == "Hitler" and ctx["won"] and not ctx["was_investigated"]
+
+
+def _check_democracia_impecable(ctx):
+    return ctx["party"] == "liberal" and ctx["won"] and ctx["game_endcode"] == 1 and ctx["dead_count"] == 0
+
+
+def _check_regimen_consolidado(ctx):
+    return ctx["party"] == "fascista" and ctx["won"] and ctx["game_endcode"] == -1
+
+
+def _check_actor_completo(ctx):
+    roles_ganados = {row[0] for row in ctx.history() if row[2]}  # row = (role, party, won, died, killed_by_uid, game_id)
+    return {"Liberal", "Fascista", "Hitler"}.issubset(roles_ganados)
+
+
+def _check_bala_certera(ctx):
+    return ctx["game_endcode"] == 2 and "Hitler" in ctx["killed_roles"]
+
+
+def _check_martir(ctx):
+    return ctx["died"] and ctx["party"] == "liberal" and ctx["won"]
+
+
+def _check_error_de_calculo(ctx):
+    return ctx["party"] == "liberal" and "Liberal" in ctx["killed_roles"]
+
+
+def _check_verdugo(ctx):
+    return len(ctx.kills_history()) >= 3
+
+
+def _check_intocable(ctx):
+    hist = ctx.history()
+    return len(hist) >= 10 and all(not row[3] for row in hist)  # row[3] = died
+
+
+def _check_cazador_de_hitler(ctx):
+    return sum(1 for role in ctx.kills_history() if role == "Hitler") >= 2
+
+
+def _check_primera_partida(ctx):
+    return len(ctx.history()) == 1
+
+
+def _check_veterano(ctx):
+    return len(ctx.history()) >= 25
+
+
+def _check_leyenda(ctx):
+    return len(ctx.history()) >= 100
+
+
+def _check_en_racha(ctx):
+    hist = ctx.history()
+    if len(hist) < 3:
+        return False
+    return all(row[2] for row in hist[-3:])  # row[2] = won
+
+
+def _check_imparable(ctx):
+    hist = ctx.history()
+    if len(hist) < 5:
+        return False
+    return all(row[2] for row in hist[-5:])
+
+
+def _check_piloto_automatico(ctx):
+    return ctx["won"] and ctx["auto_ja"]
+
+
+def _check_me_toco_lo_que_pedi(ctx):
+    return ctx["won"] and ctx["preference_rol"] != "" and ctx["preference_rol"] == ctx["role"]
+
+
+LOGROS = [
+    # Roles y victorias
+    Logro("hitler_ganador", "Canciller Supremo", "Ganaste una partida siendo Hitler.",
+          "🎩", "roles", False, _check_hitler_ganador),
+    Logro("hitler_incognito", "Escondido a plena vista", "Ganaste como Hitler sin ser investigado nunca.",
+          "🕵️", "roles", False, _check_hitler_incognito),
+    Logro("democracia_impecable", "Democracia impecable", "Ganaste como liberal con 5 políticas liberales y nadie ejecutado.",
+          "🕊", "roles", False, _check_democracia_impecable),
+    Logro("regimen_consolidado", "Régimen consolidado", "Ganaste como fascista promulgando 6 políticas fascistas.",
+          "🔥", "roles", False, _check_regimen_consolidado),
+    Logro("actor_completo", "Actor completo", "Ganaste al menos una vez como Liberal, Fascista y Hitler.",
+          "🎭", "roles", False, _check_actor_completo),
+
+    # Muerte y ejecuciones
+    Logro("bala_certera", "Bala certera", "Ejecutaste a Hitler y los liberales ganaron.",
+          "🗡", "muerte", False, _check_bala_certera),
+    Logro("martir", "Mártir de la República", "Te ejecutaron siendo liberal y tu equipo ganó igual.",
+          "☠", "muerte", False, _check_martir),
+    Logro("error_de_calculo", "Error de cálculo", "Siendo liberal, ejecutaste a otro liberal.",
+          "🤦", "muerte", True, _check_error_de_calculo),
+    Logro("verdugo", "Verdugo", "Ejecutaste a 3 jugadores en total.",
+          "🔪", "muerte", False, _check_verdugo),
+    Logro("intocable", "Intocable", "Jugaste 10 partidas sin que te ejecuten nunca.",
+          "🛡", "muerte", False, _check_intocable),
+    Logro("cazador_de_hitler", "Cazador de Hitler", "Ejecutaste a Hitler en 2 partidas distintas.",
+          "🎯", "muerte", False, _check_cazador_de_hitler),
+
+    # Hitos
+    Logro("primera_partida", "Primera vez", "Jugaste tu primera partida.",
+          "🎬", "hitos", False, _check_primera_partida),
+    Logro("veterano", "Veterano", "Jugaste 25 partidas.",
+          "🏅", "hitos", False, _check_veterano),
+    Logro("leyenda", "Leyenda", "Jugaste 100 partidas.",
+          "👑", "hitos", False, _check_leyenda),
+    Logro("en_racha", "En racha", "Ganaste 3 partidas seguidas.",
+          "🔥", "hitos", False, _check_en_racha),
+    Logro("imparable", "Imparable", "Ganaste 5 partidas seguidas.",
+          "⚡", "hitos", False, _check_imparable),
+
+    # Social / comportamiento
+    Logro("piloto_automatico", "Piloto automático", "Ganaste una partida con el voto automático Ja activado.",
+          "🤖", "social", False, _check_piloto_automatico),
+    Logro("me_toco_lo_que_pedi", "Me tocó lo que pedí", "Te tocó el rol que pediste y ganaste.",
+          "🎲", "social", False, _check_me_toco_lo_que_pedi),
+]
+
+LOGROS_BY_CODE = {logro.code: logro for logro in LOGROS}

--- a/SecretHitler/DBCreate.sql
+++ b/SecretHitler/DBCreate.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS user_stats (
     data text NOT NULL
 ); 
 
+-- legacy, no usada: el catalogo de logros vive en Constants/Achievements.py
 CREATE TABLE IF NOT EXISTS achivements_secret_hitler (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
@@ -69,6 +70,19 @@ CREATE TABLE IF NOT EXISTS stats_secret_hitler_players (
     killed_by_uid BIGINT, -- NULL si no lo mataron o si el dato no se pudo reconstruir al migrar
     UNIQUE (game_id, uid)
 );
+
+-- Logros desbloqueados por jugador. El catalogo (nombre, descripcion, condicion)
+-- vive en SecretHitler/Constants/Achievements.py; aca solo se guarda quien
+-- desbloqueo cual (identificado por achievement_code, el Logro.code estable).
+CREATE TABLE IF NOT EXISTS achievements_secret_hitler_players (
+    id SERIAL PRIMARY KEY,
+    uid BIGINT NOT NULL,
+    achievement_code TEXT NOT NULL,
+    game_id INTEGER REFERENCES stats_secret_hitler_games(id), -- NULL si se otorgo fuera de una partida (ej. backfill)
+    earned_at TIMESTAMP DEFAULT now(),
+    UNIQUE (uid, achievement_code)
+);
+CREATE INDEX IF NOT EXISTS idx_achievements_shp_uid ON achievements_secret_hitler_players(uid);
 
 -- If there are no stats in the stats table I initiate it.
 DO $$

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -21,6 +21,7 @@ from SecretHitler.Boardgamebox.Player import Player
 from SecretHitler.PlayerStats import PlayerStats
 import SecretHitler.GamesController as GamesController
 import SecretHitler.StatsExtended as StatsExtended
+import SecretHitler.Achievements as Achievements
 
 import datetime
 import jsonpickle
@@ -933,9 +934,10 @@ def end_game(bot, game, game_endcode):
 	cid = game.cid
 	
 	# Grabo detalles de la partida
+	nuevos_logros = {}
 	if game_endcode != 99:
 		save_game_details(bot, game.print_roles(), game_endcode, game.board.state.liberal_track, game.board.state.fascist_track, game.board.num_players)
-		StatsExtended.save_extended_game_stats(game, game_endcode)
+		nuevos_logros = StatsExtended.save_extended_game_stats(game, game_endcode)
 
 
 	#bot.send_message(cid, "Datos a guardar %s %s %s %s %s" % (game.print_roles(), str(game_endcode), str(game.board.state.liberal_track), str(game.board.state.fascist_track), str(game.board.num_players)))
@@ -961,6 +963,12 @@ def end_game(bot, game, game_endcode):
 			bot.send_message(game.cid, "Juego finalizado! Los liberales ganaron matando a Hitler!\n\n%s" % game.print_roles())
 			set_stats("liberalwinkillhitler", stats[4] + 1, bot, cid)
 		showHiddenhistory(bot, game)
+		try:
+			anuncio = Achievements.format_unlock_announcement(nuevos_logros, game)
+			if anuncio is not None:
+				bot.send_message(cid, anuncio, ParseMode.MARKDOWN)
+		except Exception as e:
+			log.error("No se pudo anunciar los logros nuevos: %s" % str(e))
 	del GamesController.games[cid]
 	Commands.delete_game(cid)
 	
@@ -1193,6 +1201,7 @@ SECRET_HITLER_TABLES = [
 	"achivements_secret_hitler",
 	"stats_secret_hitler_games",
 	"stats_secret_hitler_players",
+	"achievements_secret_hitler_players",
 ]
 
 def _existing_tables(cur, table_names):
@@ -1291,6 +1300,7 @@ def main():
 	dp.add_handler(CommandHandler("symbols", Commands.command_symbols))
 	dp.add_handler(CommandHandler("stats", Commands.command_stats))
 	dp.add_handler(CommandHandler("stats2", Commands.command_stats2))
+	dp.add_handler(CommandHandler("logros", Commands.command_logros))
 	dp.add_handler(CommandHandler("vincularstats", Commands.command_vincularstats))
 	dp.add_handler(CommandHandler("vincularstats2", Commands.command_vincularstats2))
 	dp.add_handler(CommandHandler("newgame", Commands.command_newgame))
@@ -1381,6 +1391,7 @@ def main():
 			BotCommand("leave", "Te saca de un juego existente"),
 			BotCommand("stats", "Muestra las estadisticas"),
 			BotCommand("stats2", "Muestra tus estadisticas nuevas vinculadas a tu ID"),
+			BotCommand("logros", "Muestra tus logros desbloqueados"),
 		])
 	except Exception as e:
 		log.error(str(e))

--- a/SecretHitler/StatsExtended.py
+++ b/SecretHitler/StatsExtended.py
@@ -5,6 +5,8 @@ import urllib.parse
 
 import psycopg2
 
+import SecretHitler.Achievements as Achievements
+
 # DB Connection (mismo patron que MainController.py / Commands.py)
 urllib.parse.uses_netloc.append("postgres")
 url = urllib.parse.urlparse(os.environ["DATABASE_URL"])
@@ -21,10 +23,12 @@ def _connect():
 
 
 def save_extended_game_stats(game, game_endcode):
-    # Guarda, ademas de lo que ya se guarda hoy, un registro por jugador vinculado a su uid.
+    # Guarda, ademas de lo que ya se guarda hoy, un registro por jugador vinculado a su uid,
+    # y evalua/otorga logros nuevos con ese mismo registro ya escrito.
     # No propaga excepciones: un fallo aca nunca debe impedir que end_game() termine su flujo normal.
+    # Devuelve {uid: [Logro nuevo, ...]} (vacio si no hubo logros nuevos, error, o game_endcode==99).
     if game_endcode == 99:
-        return
+        return {}
     conn = None
     try:
         won_liberal = game_endcode in (1, 2)
@@ -54,9 +58,13 @@ def save_extended_game_stats(game, game_endcode):
                  player.is_dead, getattr(player, "killed_by_uid", None))
             )
 
+        nuevos_por_uid = Achievements.evaluate_and_store(cur, game, game_endcode, game_id)
+
         conn.commit()
+        return nuevos_por_uid
     except Exception as e:
         log.error("save_extended_game_stats failed: %s" % str(e))
+        return {}
     finally:
         if conn is not None:
             conn.close()


### PR DESCRIPTION
Catalogo de 18 logros en Constants/Achievements.py, evaluados y
otorgados en la misma transaccion que guarda las estadisticas
extendidas de cada partida (StatsExtended.save_extended_game_stats).
Los desbloqueos se anuncian al final de la partida y se pueden
consultar en cualquier momento con /logros.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MRVrpSSfkDKkp7z4FUeWuP