### PR TITLE
Fix bot startup crash: BSG Watch.py monkeypatch incompatible with ExtBot __slots__

### DIFF
--- a/BattlestarGalactica/Watch.py
+++ b/BattlestarGalactica/Watch.py
@@ -4,21 +4,24 @@
 que el bot envía al chat de una partida de BSG, a los uids en
 `game.board.state.watchers`.
 
-Se implementa parcheando una única vez los métodos `send_message` y
-`send_photo` del bot (ver `activar_relay`, llamado desde MainController al
-construir la Application), en vez de instrumentar cada punto de envío
-dentro de Controller.py/Commands.py — así cubre cualquier acción futura sin
-tocar el resto del módulo.
+Se implementa reasignando la clase del bot a una subclase de `ExtBot` que
+sobreescribe `send_message`/`send_photo` (ver `activar_relay`, llamado desde
+MainController al construir la Application), en vez de instrumentar cada
+punto de envío dentro de Controller.py/Commands.py — así cubre cualquier
+acción futura sin tocar el resto del módulo.
+
+No se puede lograr esto asignando `bot.send_message = ...` como atributo de
+instancia: `telegram.ext.ExtBot` define `__slots__`, así que ese tipo de
+parche crashea con `AttributeError` al arrancar el bot.
 """
 import logging as log
 
 from telegram.constants import ParseMode
+from telegram.ext import ExtBot
 
 import GamesController
 
 logger = log.getLogger(__name__)
-
-_PATCHED_ATTR = "_bsg_watch_patched"
 
 
 def _juego_bsg_con_watchers(chat_id):
@@ -42,31 +45,34 @@ async def _relay_text(bot, game, texto):
             logger.error(f"BSG watch relay error (uid {w_uid}): {e}")
 
 
-def activar_relay(bot):
-    """Parchea bot.send_message/send_photo para espejar a los espectadores.
-    Idempotente: llamar más de una vez no duplica el parche."""
-    if getattr(bot, _PATCHED_ATTR, False):
-        return
+class _WatchRelayExtBot(ExtBot):
+    """Subclase de ExtBot que espeja send_message/send_photo a los
+    espectadores de BSG. No agrega slots propios para poder reasignarse
+    como clase de una instancia de ExtBot ya construida (ver activar_relay)."""
 
-    original_send_message = bot.send_message
-    original_send_photo = bot.send_photo
+    __slots__ = ()
 
-    async def send_message_con_relay(chat_id, text="", *args, **kwargs):
-        result = await original_send_message(chat_id, text, *args, **kwargs)
+    async def send_message(self, chat_id, text="", *args, **kwargs):
+        result = await super().send_message(chat_id, text, *args, **kwargs)
         game = _juego_bsg_con_watchers(chat_id)
         if game:
-            await _relay_text(bot, game, text)
+            await _relay_text(self, game, text)
         return result
 
-    async def send_photo_con_relay(chat_id, photo, *args, caption=None, **kwargs):
-        result = await original_send_photo(chat_id, photo, *args, caption=caption, **kwargs)
+    async def send_photo(self, chat_id, photo, *args, caption=None, **kwargs):
+        result = await super().send_photo(chat_id, photo, *args, caption=caption, **kwargs)
         game = _juego_bsg_con_watchers(chat_id)
         if game:
             # No se reenvía la imagen (el stream ya fue consumido); se informa
             # el texto/caption como aviso de que hubo un envío gráfico.
-            await _relay_text(bot, game, f"📷 {caption}" if caption else "📷 (imagen del tablero)")
+            await _relay_text(self, game, f"📷 {caption}" if caption else "📷 (imagen del tablero)")
         return result
 
-    bot.send_message = send_message_con_relay
-    bot.send_photo = send_photo_con_relay
-    setattr(bot, _PATCHED_ATTR, True)
+
+def activar_relay(bot):
+    """Convierte `bot` en un espejo para los espectadores de BSG,
+    reasignando su clase a `_WatchRelayExtBot`. Idempotente: llamar más de
+    una vez no vuelve a aplicar el cambio."""
+    if isinstance(bot, _WatchRelayExtBot):
+        return
+    bot.__class__ = _WatchRelayExtBot


### PR DESCRIPTION
## Summary
- The most recent PR on `develop` (#190, BSG `/watch` spectator feature) added `BattlestarGalactica/Watch.py`, whose `activar_relay(bot)` tried to monkeypatch `bot.send_message`/`bot.send_photo` as instance attributes.
- `python-telegram-bot` v22's `ExtBot` class defines `__slots__`, so that assignment raises `AttributeError: Attribute 'send_message' of class 'ExtBot' can't be set!`.
- This runs unconditionally in `MainController.main()` right when the `Application` is built (before any command handler is registered), so the entire Multigames bot thread crashed on startup.
- Fixed by replacing the instance-attribute patch with a `__slots__`-compatible `ExtBot` subclass (`_WatchRelayExtBot`) that overrides `send_message`/`send_photo`, swapped onto the existing bot instance via `bot.__class__ = _WatchRelayExtBot`. Same relay behavior and idempotency, but compatible with `ExtBot`'s slots.

## Test plan
- [x] Reproduced the crash in isolation against the real `ExtBot`/`Application.builder()` instance, confirming the exact `AttributeError`.
- [x] Verified the fix: `activar_relay` no longer raises, and calling it twice is idempotent (no duplicate patching).
- [x] Confirmed `MainController.py` (and its full import chain, including `Commands.py` and all game controllers) imports and builds the `Application` without error after the fix.
- [x] `python3 -m py_compile` clean on the changed file.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am)_