### PR TITLE
BSG: mostrar la activación Cylon de la Crisis al presentarla

### DIFF
--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -2668,6 +2668,16 @@ def _resumen_crisis(crisis):
             lineas.append(f"{alt.get('label', '🛡️ Alternativa')}: {_resumen_lista(alt.get('efectos', []))}")
     else:
         lineas.append(_resumen_lista(crisis.get("efectos", [])))
+
+    iconos = crisis.get("activaciones")
+    if iconos is None and crisis.get("activar_cylons"):
+        iconos = _activaciones_para_crisis(crisis)
+    if iconos:
+        desc = ", ".join(ICONOS_CYLON.get(i, i) for i in iconos)
+        lineas.append(f"🤖 Activación Cylon: {desc}")
+    else:
+        lineas.append("🤖 Activación Cylon: ninguna")
+
     salto = crisis.get("jump", 0)
     lineas.append(f"🌌 Salto: {'sí (+' + str(salto) + ')' if salto else 'no'}")
     return "\n".join(lineas)


### PR DESCRIPTION
## Summary
- Al presentar una Crisis, el resumen de efectos ahora también incluye la línea `🤖 Activación Cylon: ...` con la acción del ícono de abajo a la izquierda de la carta física (Activar Raiders, Activar Heavy Raiders, Activar Centuriones, Activar Basestars, Lanzar Raiders, Lanzar Heavy Raiders), o "ninguna" si la carta no la tiene.
- Reutiliza la misma función que ya calculaba esto al cerrar la Crisis (`_activaciones_para_crisis`), así el aviso previo siempre coincide con lo que realmente pasa al resolverla.

## Test plan
- [x] `python3 -m py_compile` limpio.
- [x] Ejecuté el resumen contra las 59 cartas de `Crisis.CRISIS_DECK` sin excepciones.
- [ ] Probar en un grupo real robando una Crisis y comparar el aviso previo contra la activación real al cerrarla.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am)_