### PR TITLE
BSG: civilian ships lose/regain their identifier when recycled through the pile

### DIFF
--- a/BattlestarGalactica/Boardgamebox/Board.py
+++ b/BattlestarGalactica/Boardgamebox/Board.py
@@ -32,7 +32,8 @@ def naves_de_area(area):
     if area["vipers"]:
         piezas.append(f"✈️×{area['vipers']}")
     if area["civiles"]:
-        piezas.append(f"🛰️×{len(area['civiles'])}")
+        letras = ",".join(c.get("id", "?") for c in area["civiles"])
+        piezas.append(f"🛰️[{letras}]")
     return piezas
 
 

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -799,10 +799,20 @@ CIVILES_CARGAS = [
     {"recurso": None, "cantidad": 0},
 ]
 
-# Letra identificadora de cada nave civil (estable durante toda la partida:
-# se asigna una vez al crear la pila y viaja con la nave aunque se mueva o se
-# inspeccione, para poder reconocerla en Comunicaciones de una vez a otra).
+# Letra identificadora de una nave civil MIENTRAS ESTÁ EN EL TABLERO (viaja
+# con ella aunque se mueva o se inspeccione, para poder reconocerla en
+# Comunicaciones de una vez a otra). Se asigna recién al entrar al tablero
+# (no en la pila de reserva) y se pierde al salir de él (destruida y devuelta
+# a la pila), así una nave reciclada vuelve a entrar como una nave "nueva".
 _CIVIL_LETRAS = "ABCDEFGH"
+
+
+def _letra_civil_libre(st):
+    """Letra identificadora no usada por ninguna nave civil actualmente en el
+    tablero, para asignar a una que recién entra en juego."""
+    usadas = {c.get("id") for a in st.areas for c in a["civiles"]}
+    libres = [l for l in _CIVIL_LETRAS if l not in usadas]
+    return random.choice(libres) if libres else "?"
 
 
 def _colocar_flota_inicial(st):
@@ -821,11 +831,14 @@ def _colocar_flota_inicial(st):
     st.areas[Space.AREA_PROA]["basestars"].append(0)   # 0 tokens de daño
     st.areas[Space.AREA_PROA]["raiders"] += 3
 
-    # Naves civiles: 2 en la Popa, el resto a la pila de reserva
-    pila = [dict(c, id=letra) for letra, c in zip(_CIVIL_LETRAS, CIVILES_CARGAS)]
+    # Naves civiles: 2 en la Popa (reciben su identificador recién al entrar),
+    # el resto a la pila de reserva sin identificador.
+    pila = [dict(c) for c in CIVILES_CARGAS]
     random.shuffle(pila)
     for _ in range(min(2, len(pila))):
-        st.areas[Space.AREA_POPA]["civiles"].append(pila.pop())
+        carga = pila.pop()
+        carga["id"] = _letra_civil_libre(st)
+        st.areas[Space.AREA_POPA]["civiles"].append(carga)
     st.civiles_pile = pila
 
 
@@ -1945,7 +1958,10 @@ def _destruir_centurion_avanzado(st):
 
 
 async def _destruir_civil(bot, game, area_idx=None):
-    """Destruye una nave civil (de un área concreta o, si no, de un área al azar)."""
+    """Destruye una nave civil (de un área concreta o, si no, de un área al
+    azar). La carga vuelve a la pila de reserva para poder reaparecer más
+    adelante como una nave "nueva": pierde su identificador al salir del
+    tablero (se le asigna uno nuevo recién cuando vuelva a entrar en juego)."""
     st = game.board.state
     if area_idx is None:
         objetivos = _areas_con(st, "civiles")
@@ -1956,12 +1972,14 @@ async def _destruir_civil(bot, game, area_idx=None):
     if not area["civiles"]:
         return
     carga = area["civiles"].pop(random.randrange(len(area["civiles"])))
-    letra = carga.get("id", "?")
+    letra = carga.pop("id", "?")
     if carga["recurso"]:
         await bot.send_message(game.cid, f"🛰️💀 ¡Nave civil [{letra}] destruida en {Space.nombre(area_idx)}! Transportaba {carga['recurso']}.")
         await modificar_recurso(bot, game, carga["recurso"], -carga["cantidad"])
     else:
         await bot.send_message(game.cid, f"🛰️💀 Nave civil [{letra}] destruida en {Space.nombre(area_idx)} (estaba vacía).")
+    st.civiles_pile.append(carga)
+    random.shuffle(st.civiles_pile)
 
 
 # ===================== SABOTAJE CYLON =====================
@@ -3427,13 +3445,16 @@ async def _recall_vipers(bot, game):
 
 
 def _colocar_civiles(st, cantidad):
-    """Coloca naves civiles tras Galactica (Popa), tomándolas de la pila de reserva.
+    """Coloca naves civiles tras Galactica (Popa), tomándolas de la pila de
+    reserva y asignándoles un identificador nuevo al entrar al tablero.
     Devuelve cuántas se colocaron realmente."""
     colocadas = 0
     for _ in range(cantidad):
         if not st.civiles_pile:
             break
-        st.areas[Space.AREA_POPA]["civiles"].append(st.civiles_pile.pop())
+        carga = st.civiles_pile.pop()
+        carga["id"] = _letra_civil_libre(st)
+        st.areas[Space.AREA_POPA]["civiles"].append(carga)
         colocadas += 1
     return colocadas
 

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -799,6 +799,11 @@ CIVILES_CARGAS = [
     {"recurso": None, "cantidad": 0},
 ]
 
+# Letra identificadora de cada nave civil (estable durante toda la partida:
+# se asigna una vez al crear la pila y viaja con la nave aunque se mueva o se
+# inspeccione, para poder reconocerla en Comunicaciones de una vez a otra).
+_CIVIL_LETRAS = "ABCDEFGH"
+
 
 def _colocar_flota_inicial(st):
     """Despliega la disposición inicial del juego base sobre las áreas:
@@ -817,7 +822,7 @@ def _colocar_flota_inicial(st):
     st.areas[Space.AREA_PROA]["raiders"] += 3
 
     # Naves civiles: 2 en la Popa, el resto a la pila de reserva
-    pila = [dict(c) for c in CIVILES_CARGAS]
+    pila = [dict(c, id=letra) for letra, c in zip(_CIVIL_LETRAS, CIVILES_CARGAS)]
     random.shuffle(pila)
     for _ in range(min(2, len(pila))):
         st.areas[Space.AREA_POPA]["civiles"].append(pila.pop())
@@ -1054,7 +1059,7 @@ async def ejecutar_accion_ubicacion(bot, game, uid, accion, objetivo=None):
         lineas = []
         for i, a in enumerate(st.areas):
             for c in a["civiles"]:
-                lineas.append(f"{Space.nombre(i)}: {c['recurso'] or 'vacía'}")
+                lineas.append(f"[{c.get('id', '?')}] {Space.nombre(i)}: {c['recurso'] or 'vacía'}")
         info = "\n".join(lineas) or "ninguna"
         await bot.send_message(uid, f"🔭 Cargas de las naves civiles:\n{info}")
         await bot.send_message(game.cid, f"🔭 {player.name} inspecciona las naves civiles.")
@@ -1315,9 +1320,10 @@ async def mover_civil(bot, game, area_idx):
         return
     civil = st.areas[area_idx]["civiles"].pop()
     st.areas[destino]["civiles"].append(civil)
+    letra = civil.get("id", "?")
     await bot.send_message(
         game.cid,
-        f"🚚 Una nave civil se reposiciona de {Space.nombre(area_idx)} a {Space.nombre(destino)}.",
+        f"🚚 La nave civil [{letra}] se reposiciona de {Space.nombre(area_idx)} a {Space.nombre(destino)}.",
     )
     await save(bot, game.cid)
 
@@ -1950,11 +1956,12 @@ async def _destruir_civil(bot, game, area_idx=None):
     if not area["civiles"]:
         return
     carga = area["civiles"].pop(random.randrange(len(area["civiles"])))
+    letra = carga.get("id", "?")
     if carga["recurso"]:
-        await bot.send_message(game.cid, f"🛰️💀 ¡Nave civil destruida en {Space.nombre(area_idx)}! Transportaba {carga['recurso']}.")
+        await bot.send_message(game.cid, f"🛰️💀 ¡Nave civil [{letra}] destruida en {Space.nombre(area_idx)}! Transportaba {carga['recurso']}.")
         await modificar_recurso(bot, game, carga["recurso"], -carga["cantidad"])
     else:
-        await bot.send_message(game.cid, f"🛰️💀 Nave civil destruida en {Space.nombre(area_idx)} (estaba vacía).")
+        await bot.send_message(game.cid, f"🛰️💀 Nave civil [{letra}] destruida en {Space.nombre(area_idx)} (estaba vacía).")
 
 
 # ===================== SABOTAJE CYLON =====================

--- a/BattlestarGalactica/render.py
+++ b/BattlestarGalactica/render.py
@@ -73,7 +73,8 @@ def _naves_html(area):
     if area["vipers"]:
         piezas.append(f"<span class='ship vp'>V×{area['vipers']}</span>")
     if area["civiles"]:
-        piezas.append(f"<span class='ship cv'>C×{len(area['civiles'])}</span>")
+        letras = ",".join(c.get("id", "?") for c in area["civiles"])
+        piezas.append(f"<span class='ship cv'>C[{letras}]</span>")
     return "".join(piezas)
 
 


### PR DESCRIPTION
## Summary
- Includes the not-yet-merged `_CIVIL_LETRAS` civilian-ship-identifier feature (commit `e0620a9`), plus a follow-up fix on top of it.
- The letter identifier is meant to track a civilian ship only while it's on the board, but it was being assigned once at pile creation and never touched again, and a destroyed ship's cargo was discarded instead of returning to `civiles_pile` — so the reserve could run dry over a long game.
- Fixed per spec: **a ship loses its identifier when it's removed from the board and returned to the pile, and gets a (freshly assigned, currently-unused) identifier when it enters the board again.**
  - `civiles_pile` entries now carry no `id` (anonymous reserve).
  - `_colocar_flota_inicial` and `_colocar_civiles` assign a fresh, currently-unused letter only when a ship actually enters the board.
  - `_destruir_civil` strips the `id` and pushes the cargo back onto `civiles_pile` (reshuffled in) instead of discarding it, so a destroyed ship's card can reappear later as a "new" ship with a new identifier.

## Test plan
- [x] `python3 -m py_compile` clean.
- [x] Simulated the full lifecycle with fake state: initial deploy gives the 2 on-board ships ids and leaves the other 6 in the pile without ids; destroying a ship removes its id and returns it to the pile; drawing from the pile assigns a fresh id never used by a ship currently on the board.
- [x] Stress-tested 20 destroy/redraw cycles confirming no duplicate ids ever appear among ships simultaneously on the board, and the total ship count (board + pile) stays constant at 8.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am)_