### PR TITLE
BSG: /bsgadmin - quitar una carta de habilidad a un jugador

### DIFF
--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -1661,6 +1661,7 @@ async def command_bsgadmin(update: Update, context: CallbackContext):
     btns = [
         [InlineKeyboardButton("🛸 Corregir Raiders en un área", callback_data=f"{cid}*bsgAdmin*fix_raiders*{uid}")],
         [InlineKeyboardButton("🤖 Activar naves Cylon", callback_data=f"{cid}*bsgAdmin*activar_cylon*{uid}")],
+        [InlineKeyboardButton("🃏 Quitar carta a un jugador", callback_data=f"{cid}*bsgAdmin*quitar_carta*{uid}")],
     ]
     await bot.send_message(cid, "🛠️ *Panel de Admin (BSG)* — ¿qué querés corregir?",
                            reply_markup=InlineKeyboardMarkup(btns), parse_mode=ParseMode.MARKDOWN)
@@ -1698,6 +1699,14 @@ async def callback_bsg_admin(update: Update, context: CallbackContext):
                 [InlineKeyboardButton("🛸 Lanzar Raiders (Basestars)", callback_data=f"{cid}*bsgAdminCylon*launch_raiders*{presser}")],
             ]
             texto = "🤖 ¿Qué activación Cylon querés forzar?"
+        elif opcion == "quitar_carta":
+            btns = [[InlineKeyboardButton(f"{p.name} ({len(p.skill_hand)} 🃏)",
+                                          callback_data=f"{cid}*bsgAdminCartaJug*{p_uid}*{presser}")]
+                    for p_uid, p in game.playerlist.items()]
+            if not btns:
+                await bot.send_message(cid, "No hay jugadores en la partida.")
+                return
+            texto = "🃏 ¿A qué jugador le querés quitar una carta?"
         else:
             return
 
@@ -1833,3 +1842,96 @@ async def callback_bsg_admin_cylon(update: Update, context: CallbackContext):
         except Exception:
             pass
         await bot.send_message(ADMIN[0], f"BSG admin cylon error: {e}")
+
+
+async def callback_bsg_admin_carta_jugador(update: Update, context: CallbackContext):
+    """Elegido el jugador: muestra su mano para elegir qué carta quitarle."""
+    bot = context.bot
+    callback = update.callback_query
+    presser = callback.from_user.id
+    try:
+        regex = re.search(r"(-?[0-9]*)\*bsgAdminCartaJug\*(-?[0-9]*)\*(-?[0-9]*)", callback.data)
+        cid = int(regex.group(1))
+        objetivo = int(regex.group(2))
+        ordenante = int(regex.group(3))
+        game = get_game(cid)
+        if not _validar(game):
+            await callback.answer("Partida no encontrada.")
+            return
+        if presser != ordenante or presser != ADMIN[0]:
+            await callback.answer("No puedes usar este panel.")
+            return
+        p = game.playerlist.get(objetivo)
+        if not p:
+            await callback.answer("Jugador no encontrado.")
+            return
+        if not p.skill_hand:
+            await callback.answer(f"{p.name} no tiene cartas en la mano.")
+            return
+        await callback.answer()
+        btns = [[InlineKeyboardButton(
+                    f"{Skills.EMOJI_COLOR[c['color']]} {c['color']} {c['valor']} — {c.get('nombre', '')}",
+                    callback_data=f"{cid}*bsgAdminCarta*{objetivo}_{i}*{presser}")]
+                for i, c in enumerate(p.skill_hand)]
+        texto = f"🃏 ¿Qué carta le quitás a {p.name}? (vuelve mezclada al mazo)"
+        try:
+            await bot.edit_message_text(texto, cid, callback.message.message_id,
+                                        reply_markup=InlineKeyboardMarkup(btns), parse_mode=ParseMode.MARKDOWN)
+        except Exception:
+            await bot.send_message(cid, texto, reply_markup=InlineKeyboardMarkup(btns), parse_mode=ParseMode.MARKDOWN)
+    except Exception as e:
+        logger.error(f"callback_bsg_admin_carta_jugador error: {e}")
+        try:
+            await callback.answer("Error.")
+        except Exception:
+            pass
+        await bot.send_message(ADMIN[0], f"BSG admin carta jugador error: {e}")
+
+
+async def callback_bsg_admin_carta(update: Update, context: CallbackContext):
+    """Quita la carta elegida de la mano del jugador y la devuelve mezclada
+    al mazo de su color."""
+    bot = context.bot
+    callback = update.callback_query
+    presser = callback.from_user.id
+    try:
+        regex = re.search(r"(-?[0-9]*)\*bsgAdminCarta\*(-?[0-9]+)_([0-9]+)\*(-?[0-9]*)", callback.data)
+        cid = int(regex.group(1))
+        objetivo = int(regex.group(2))
+        idx = int(regex.group(3))
+        ordenante = int(regex.group(4))
+        game = get_game(cid)
+        if not _validar(game):
+            await callback.answer("Partida no encontrada.")
+            return
+        if presser != ordenante or presser != ADMIN[0]:
+            await callback.answer("No puedes usar este panel.")
+            return
+        p = game.playerlist.get(objetivo)
+        if not p:
+            await callback.answer("Jugador no encontrado.")
+            return
+        st = game.board.state
+        carta = BSGController.quitar_carta_a_mazo(st, p, idx)
+        if not carta:
+            await callback.answer("Esa carta ya no está en su mano.")
+            return
+        desc = f"{Skills.EMOJI_COLOR[carta['color']]} {carta['color']} {carta['valor']} — {carta.get('nombre', '')}"
+        await callback.answer("Carta quitada.")
+        try:
+            await bot.edit_message_text(f"🃏 Se le quitó {desc} a {p.name}: vuelve mezclada al mazo de {carta['color']}.",
+                                        cid, callback.message.message_id, parse_mode=ParseMode.MARKDOWN)
+        except Exception:
+            pass
+        await bot.send_message(cid, f"🃏 *{p.name}* pierde una carta de habilidad ({desc}), que vuelve al mazo.",
+                               parse_mode=ParseMode.MARKDOWN)
+        await bot.send_message(p.uid, f"🃏 El admin te quitó {desc} (vuelve al mazo). Te quedan {len(p.skill_hand)} carta(s).",
+                               parse_mode=ParseMode.MARKDOWN)
+        await save(bot, cid)
+    except Exception as e:
+        logger.error(f"callback_bsg_admin_carta error: {e}")
+        try:
+            await callback.answer("Error.")
+        except Exception:
+            pass
+        await bot.send_message(ADMIN[0], f"BSG admin carta error: {e}")

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -3384,6 +3384,20 @@ async def _descartar_skills(bot, game, player, cantidad, modo="azar"):
     await bot.send_message(player.uid, f"🗑️ Descartaste {n} carta(s) de habilidad (te quedan {len(player.skill_hand)}).")
 
 
+def quitar_carta_a_mazo(st, player, idx):
+    """Herramienta de admin: quita la carta en la posición 'idx' (0-based) de
+    la mano del jugador y la devuelve mezclada al mazo de su color (no al
+    descarte, para que pueda volver a salir enseguida). Devuelve la carta
+    quitada, o None si el índice ya no es válido."""
+    if idx < 0 or idx >= len(player.skill_hand):
+        return None
+    carta = player.skill_hand.pop(idx)
+    mazo = st.skill_decks.setdefault(carta["color"], [])
+    mazo.append(carta)
+    random.shuffle(mazo)
+    return carta
+
+
 async def _danar_vipers(bot, game, cantidad, donde="reserva"):
     """Daña Vipers (pasan a 'dañados', fuera de combate hasta repararlos).
     donde: 'reserva' (de la reserva) | 'espacio' (desplegados en las áreas)."""

--- a/MainController.py
+++ b/MainController.py
@@ -854,6 +854,8 @@ def main(stop_event):
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgAdminArea\*([0-9]+)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_admin_area))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgAdminRaiders\*([0-9]+)_(m5|m1|p1|p5|done)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_admin_raiders))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgAdminCylon\*(raiders|heavy_raiders|launch_raiders)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_admin_cylon))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgAdminCartaJug\*(-?[0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_admin_carta_jugador))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgAdminCarta\*(-?[0-9]+)_([0-9]+)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_admin_carta))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgPick\*([a-z_]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_pick))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgDraw\*([A-Za-z]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_draw))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgSetup\*([A-Za-z]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_setup))


### PR DESCRIPTION
## Summary
- Adds a third option to the `/bsgadmin` panel: **"🃏 Quitar carta a un jugador"**.
- Flow: pick a player → pick which card from their hand (shown as color/valor/nombre, e.g. "🔵 Ingenieria 2 — Repair") → that card is removed from their hand and returned mixed into the skill deck of its color (not the discard pile, so it can come back out right away — matches "que vuelva al mazo de skills").
- Notifies the group/admin and the affected player of what was removed and how many cards they have left.
- `Controller.quitar_carta_a_mazo(st, player, idx)` does the actual work (pop from hand, push into `skill_decks[color]`, shuffle); `Commands.callback_bsg_admin_carta_jugador` lists the hand, `Commands.callback_bsg_admin_carta` applies the choice. Both wired in `MainController.py` alongside the rest of the `bsgAdmin` panel.

## Test plan
- [x] `python3 -m py_compile` clean on all three changed files.
- [x] Verified the new callback-data regex patterns (`bsgAdminCartaJug`, `bsgAdminCarta`) don't cross-match each other or the existing `bsgAdmin`/`bsgAdminCarta*` patterns.
- [x] End-to-end simulation with fake Telegram objects: menu → quitar_carta → pick player → pick an Ingeniería card → card removed from hand (remaining hand correct), Ingeniería deck size grows by 1; non-admin rejected; player with an empty hand handled gracefully (no crash, clear message).

---
_Generated by [Claude Code](https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am)_