### PR TITLE
BSG: /call menciona al jugador activo para que le llegue la notificación

### DIFF
--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -7,7 +7,7 @@ import re
 
 import BattlestarGalactica.Controller as BSGController
 from BattlestarGalactica.Constants import Characters, Skills, Loyalty, Locations, Space
-from Utils import get_game, save
+from Utils import get_game, save, player_call
 from Constants.Config import ADMIN
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
@@ -42,7 +42,7 @@ async def command_call(bot, game):
     if st.fase_actual == "En Juego" and st.active_player:
         await bot.send_message(
             game.cid,
-            f"🚀 *BSG en curso* — turno de *{st.active_player.name}*.\n"
+            f"🚀 *BSG en curso* — turno de {player_call(st.active_player)}.\n"
             "Mover: `/mover` · Acción: `/accion` · Crisis: `/crisis` · Tablero: `/estado` · Mapa: `/mapa`\n"
             "Mano: `/mano` · Jugar carta: `/jugar` · Aportar a chequeo: `/aportar`\n"
             "Habilidad: `/habilidad` · Presidente: `/quorum` · Cylons: `/revelar`\n"


### PR DESCRIPTION
## Summary
- `/call` (`BattlestarGalactica.Commands.command_call`) only showed the active player's name in bold (`*Nombre*`), which doesn't trigger any Telegram notification.
- Now uses `Utils.player_call` — the same mention mechanism `Controller.py` already uses at other decision points (e.g. character pick, crisis choices) — to produce a `[Nombre](tg://user?id=UID)` link, which does alert the player who needs to act.

## Test plan
- [x] `python3 -m py_compile` clean.
- [x] Simulated `/call` with a fake bot/game: message renders as `🚀 *BSG en curso* — turno de [Luis](tg://user?id=555).` followed by the usual command reminders, unchanged otherwise.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am)_