### PR TITLE
BSG: /mano funciona por privado y muestra el efecto de cada carta al tocarla

### DIFF
--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -212,24 +212,74 @@ async def command_lealtad(update: Update, context: CallbackContext):
 
 
 async def command_mano(update: Update, context: CallbackContext):
-    """Muestra la mano de habilidad por privado."""
+    """Muestra la mano de habilidad por privado, con un botón por carta:
+    tocarla te dice qué hace. Funciona tanto desde el grupo como escrito
+    directamente por privado al bot."""
     bot = context.bot
-    cid = update.message.chat_id
     uid = update.message.from_user.id
+    cid = update.message.chat_id
+    # Localizar la partida (también funciona desde el privado).
     game = get_game(cid)
-    if not _validar(game):
-        await bot.send_message(cid, "No hay partida de Battlestar Galactica activa aquí.")
-        return
-    if uid not in game.playerlist:
-        await bot.send_message(uid, "No estás en esta partida.")
+    if not (_validar(game) and uid in getattr(game, "playerlist", {})):
+        game = None
+        for g in GamesController.games.values():
+            if getattr(g, "tipo", None) == "BattlestarGalactica" and uid in getattr(g, "playerlist", {}):
+                game = g
+                break
+    if not game or not game.board:
+        await bot.send_message(uid, "No estás en una partida activa de BSG.")
         return
     player = game.playerlist[uid]
     if not player.skill_hand:
         await bot.send_message(uid, "No tienes cartas de habilidad.")
         return
-    lineas = [f"{i+1}. {Skills.EMOJI_COLOR[c['color']]} {c['color']} {c['valor']} — _{c.get('nombre','')}_"
-              for i, c in enumerate(player.skill_hand)]
-    await bot.send_message(uid, "🃏 *Tu mano:*\n" + "\n".join(lineas), parse_mode=ParseMode.MARKDOWN)
+    btns = [[InlineKeyboardButton(
+                f"{i+1}. {Skills.EMOJI_COLOR[c['color']]} {c['color']} {c['valor']} — {c.get('nombre','')}",
+                callback_data=f"{game.cid}*bsgManoCarta*{i}*{uid}")]
+            for i, c in enumerate(player.skill_hand)]
+    await bot.send_message(
+        uid,
+        "🃏 *Tu mano* — tocá una carta para ver qué hace (usá `/aportar N` para aportarla a un chequeo):",
+        reply_markup=InlineKeyboardMarkup(btns), parse_mode=ParseMode.MARKDOWN,
+    )
+
+
+async def callback_bsg_mano_carta(update: Update, context: CallbackContext):
+    """Muestra el efecto de la carta elegida desde /mano."""
+    bot = context.bot
+    callback = update.callback_query
+    presser = callback.from_user.id
+    try:
+        regex = re.search(r"(-?[0-9]*)\*bsgManoCarta\*([0-9]+)\*(-?[0-9]*)", callback.data)
+        cid = int(regex.group(1))
+        idx = int(regex.group(2))
+        ordenante = int(regex.group(3))
+        if presser != ordenante:
+            await callback.answer("Esta no es tu mano.")
+            return
+        game = get_game(cid)
+        if not _validar(game) or presser not in game.playerlist:
+            await callback.answer("Partida no encontrada.")
+            return
+        player = game.playerlist[presser]
+        if idx < 0 or idx >= len(player.skill_hand):
+            await callback.answer("Esa carta ya no está en tu mano.")
+            return
+        c = player.skill_hand[idx]
+        await callback.answer()
+        texto = c.get("texto") or "No tiene un efecto especial: solo suma su valor en un chequeo."
+        await bot.send_message(
+            presser,
+            f"{Skills.EMOJI_COLOR[c['color']]} *{c['color']} {c['valor']} — {c.get('nombre','')}*\n{texto}",
+            parse_mode=ParseMode.MARKDOWN,
+        )
+    except Exception as e:
+        logger.error(f"callback_bsg_mano_carta error: {e}")
+        try:
+            await callback.answer("Error.")
+        except Exception:
+            pass
+        await bot.send_message(ADMIN[0], f"BSG mano carta error: {e}")
 
 
 async def command_jugar(update: Update, context: CallbackContext):

--- a/MainController.py
+++ b/MainController.py
@@ -831,6 +831,7 @@ def main(stop_event):
 	# Handlers de Battlestar Galactica
 	app.add_handler(CommandHandler("lealtad", BSGCommands.command_lealtad))
 	app.add_handler(CommandHandler("mano", BSGCommands.command_mano))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgManoCarta\*([0-9]+)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_mano_carta))
 	app.add_handler(CommandHandler("estado", BSGCommands.command_estado))
 	app.add_handler(CommandHandler("watch", BSGCommands.command_watch))
 	app.add_handler(CommandHandler("mapa", BSGCommands.command_mapa))


### PR DESCRIPTION
## Summary
- `/mano` required an active game keyed to the chat where it was run, so executing it directly by DM (`chat_id == uid`) always failed with "No hay partida de Battlestar Galactica activa aquí" — even though its own docstring/help text says "en privado". Now it uses the same fallback `/jugar` and `/aportar` already use: if the invoking chat has no game, search for the player's active BSG game by membership. Works the same whether run from the group or DMed straight to the bot.
- The hand is now shown as buttons (same numbering as the old plain-text list, so it still works as the reference for `/aportar N`) instead of static text.
- Tapping a card DMs its full effect text (`Skills.TEXTOS`, already stored per-card as `"texto"`).
- New callback `callback_bsg_mano_carta`, registered in `MainController.py` alongside the existing `/mano` handler.

## Test plan
- [x] `python3 -m py_compile` clean on both changed files.
- [x] Simulated end-to-end with fake Telegram objects: `/mano` invoked with `chat_id == uid` (private) correctly finds the game via the membership fallback and DMs the numbered button list; invoked from the group chat also DMs the player; the button `callback_data` correctly carries the group's `cid` (not the private chat id) so the follow-up lookup resolves; pressing a card DMs its color/valor/nombre plus the exact `Skills.TEXTOS` effect text; pressing someone else's button is rejected; a stale index (hand changed after the list was shown) is handled gracefully instead of crashing.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am)_