### PR TITLE
Add /guess command with end-game reveal and two achievements

### DIFF
--- a/SecretHitler/Achievements.py
+++ b/SecretHitler/Achievements.py
@@ -72,6 +72,10 @@ def build_context(cur, game, game_endcode, uid, player):
         if getattr(p, "killed_by_uid", None) == uid
     ]
 
+    hitler_player = game.get_hitler()
+    # El ultimo intento de /guess (maximo 2) es el definitivo, el que cuenta para logros.
+    guess_history = getattr(game, "guesses", {}).get(uid) or []
+
     return Ctx(
         cur, uid,
         role=player.role,
@@ -88,6 +92,9 @@ def build_context(cur, game, game_endcode, uid, player):
         was_investigated=getattr(player, "was_investigated", False),
         auto_ja=getattr(player, "auto_ja", False),
         preference_rol=getattr(player, "preference_rol", ""),
+        guess=guess_history[-1] if guess_history else None,
+        hitler_uid=hitler_player.uid if hitler_player else None,
+        fascist_uids=frozenset(f.uid for f in game.get_fascists()),
     )
 
 

--- a/SecretHitler/Boardgamebox/Game.py
+++ b/SecretHitler/Boardgamebox/Game.py
@@ -18,7 +18,9 @@ class Game(object):
 		self.hiddenhistory = []
 		self.is_debugging = False
 		self.groupName = groupName
-		self.tipo = 'SecretHitler'   
+		self.tipo = 'SecretHitler'
+		# {guesser_uid: [{"fascists": [uid, ...], "hitler": uid}, ...]} - historial de palpitos de /guess (maximo 2 intentos, el ultimo es definitivo)
+		self.guesses = {}
     
 	def add_player(self, uid, player):
 		if any([True for k,v in self.playerlist.items() if v.name.strip() == player.name.strip()]):

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -18,7 +18,7 @@ from collections import namedtuple
 import SecretHitler.MainController as MainController
 import SecretHitler.GamesController as GamesController
 from SecretHitler.Constants.Config import ADMIN
-from SecretHitler.Constants.Cards import opciones_choose_posible_role
+from SecretHitler.Constants.Cards import opciones_choose_posible_role, playerSets
 from SecretHitler.Boardgamebox.Board import Board
 from SecretHitler.Boardgamebox.Game import Game
 from SecretHitler.Boardgamebox.Player import Player
@@ -55,7 +55,8 @@ commands = [  # command description used in the "help" command
     '/retirar - Retira tu voto de Ja o Nein para poder votar de nuevo',
     '/startautoja - Activa tu voto automático Ja apenas se proponga una fórmula (fuera de Zona Hitler)',
     '/stopautoja - Desactiva tu voto automático Ja',
-    '/logros - Muestra tus logros desbloqueados'
+    '/logros - Muestra tus logros desbloqueados',
+    '/guess - Adivina en privado quiénes son los fascistas y Hitler'
 ]
 
 symbols = [
@@ -984,11 +985,24 @@ def load_game(cid):
 		
 		# For some reason the decoding fails when bringing the dict playerlist and it changes it id from int to string.
 		# So I have to change it back the ID to int.				
-		temp_player_list = {}		
+		temp_player_list = {}
 		for uid in game.playerlist:
 			temp_player_list[int(uid)] = game.playerlist[uid]
 		game.playerlist = temp_player_list
-		
+
+		# Partidas guardadas antes de agregar /guess no tienen este atributo.
+		if not hasattr(game, "guesses"):
+			game.guesses = {}
+		temp_guesses = {}
+		for guesser_uid in game.guesses:
+			history = game.guesses[guesser_uid]
+			for entry in history:
+				entry["fascists"] = [int(u) for u in entry.get("fascists", [])]
+				if entry.get("hitler") is not None:
+					entry["hitler"] = int(entry["hitler"])
+			temp_guesses[int(guesser_uid)] = history
+		game.guesses = temp_guesses
+
 		if game.board is not None and game.board.state is not None:
 			temp_last_votes = {}	
 			for uid in game.board.state.last_votes:
@@ -1630,9 +1644,296 @@ def callback_info(update: Update, context: CallbackContext):
 		player = game.playerlist[uid]
 		msg = "--- *Info del grupo {}* ---\n".format(game.groupName)
 		msg += player.get_private_info(game)
-		bot.send_message(uid, msg, ParseMode.MARKDOWN)				
+		bot.send_message(uid, msg, ParseMode.MARKDOWN)
 	else:
 		bot.send_message(uid, "Debes ser un jugador del partido para obtener informacion.")
+
+
+def _guess_num_fascists(game):
+	roles = playerSets.get(len(game.playerlist), {}).get("roles", [])
+	return sum(1 for r in roles if r == "Fascista")
+
+def command_guess(update: Update, context: CallbackContext):
+	bot = context.bot
+	uid = update.message.from_user.id
+	cid = update.message.chat_id
+	groupType = update.message.chat.type
+
+	if groupType in ['group', 'supergroup']:
+		game = get_game(cid)
+		if game is None or game.board is None:
+			bot.send_message(cid, "No hay una partida activa en este chat.")
+			return
+		if uid not in game.playerlist:
+			bot.send_message(cid, "Debes ser un jugador de la partida para usar /guess.")
+			return
+		bot.send_message(cid, "Te mandé un mensaje privado para que hagas tu palpito. ¡Revisa tu chat privado conmigo!")
+		_start_guess_flow(bot, game, uid)
+	else:
+		all_games_unfiltered = MainController.getGamesByTipo("Todos")
+		all_games = {
+			key: "{}: {}".format(game.groupName, game.tipo)
+			for key, game in all_games_unfiltered.items()
+			if uid in game.playerlist and game.board is not None
+		}
+		if not all_games:
+			bot.send_message(cid, "No tienes partidas activas de Secret Hitler.")
+			return
+		if len(all_games) == 1:
+			game_cid = int(next(iter(all_games)))
+			game = get_game(game_cid)
+			_start_guess_flow(bot, game, uid)
+		else:
+			msg = "Elige el juego para hacer tu palpito de quién es fascista y quién es Hitler"
+			simple_choose_buttons(bot, cid, uid, uid, "chooseGameGuess", msg, all_games)
+
+def callback_guess_game(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_guess_game called')
+	callback = update.callback_query
+	regex = re.search(r"(-?[0-9]*)\*chooseGameGuess\*(.*)\*(-?[0-9]*)", callback.data)
+	game_cid = int(regex.group(2))
+	uid = int(regex.group(3))
+	game = get_game(game_cid)
+	if game is None or game.board is None:
+		bot.send_message(uid, "No hay una partida activa en ese chat.")
+		return
+	_start_guess_flow(bot, game, uid)
+
+def _start_guess_flow(bot, game, uid):
+	history = getattr(game, "guesses", {}).get(uid, [])
+	attempts_done = len(history)
+	if attempts_done >= 2:
+		bot.send_message(uid, "Ya hiciste tu palpito 2 veces. Tu segunda elección quedó *definitiva* y no se puede volver a cambiar.", parse_mode=ParseMode.MARKDOWN)
+		return
+	num_fascists = _guess_num_fascists(game)
+	if num_fascists == 0:
+		bot.send_message(uid, "No se puede adivinar en esta partida.")
+		return
+	if attempts_done == 0:
+		bot.send_message(uid,
+			"🔮 Vas a elegir quiénes creés que son los fascistas comunes y quién es Hitler. "
+			"Podés repetir esta elección una sola vez más después de confirmar; se guardan tus dos intentos, "
+			"pero la *segunda* elección es la definitiva.",
+			parse_mode=ParseMode.MARKDOWN)
+	else:
+		bot.send_message(uid,
+			"🔮 Esta es tu *última* oportunidad para adivinar: lo que confirmes ahora quedará definitivo.",
+			parse_mode=ParseMode.MARKDOWN)
+	GamesController.guess_progress[(game.cid, uid)] = {
+		"fascists": [],
+		"hitler": None,
+		"num_fascists": num_fascists,
+	}
+	texto, markup = _build_guess_fascist_prompt(game, uid)
+	bot.send_message(uid, texto, reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
+def _build_guess_fascist_prompt(game, uid):
+	progress = GamesController.guess_progress[(game.cid, uid)]
+	selected = progress["fascists"]
+	num_fascists = progress["num_fascists"]
+	texto = "🔮 *Adivina quiénes son los fascistas comunes* ({}/{})\n".format(len(selected), num_fascists)
+	if selected:
+		nombres_elegidos = ", ".join(game.playerlist[u].name for u in selected if u in game.playerlist)
+		texto += "Ya elegiste: {}\n".format(nombres_elegidos)
+	texto += "Elige a otro sospechoso:"
+	strcid = str(game.cid)
+	btns = []
+	for player_uid, player in game.playerlist.items():
+		if player_uid in selected:
+			continue
+		btns.append([InlineKeyboardButton(player.name, callback_data=strcid + "_guessf_" + str(player_uid))])
+	markup = InlineKeyboardMarkup(btns)
+	return texto, markup
+
+def callback_guess_fascist(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_guess_fascist called')
+	callback = update.callback_query
+	regex = re.search(r"(-?[0-9]*)_guessf_(-?[0-9]*)", callback.data)
+	cid = int(regex.group(1))
+	candidate_uid = int(regex.group(2))
+	uid = callback.from_user.id
+
+	game = get_game(cid)
+	if game is None or game.board is None:
+		bot.send_message(uid, "Esa partida ya no está activa.")
+		return
+	if uid not in game.playerlist:
+		bot.send_message(uid, "Debes ser un jugador de la partida para adivinar.")
+		return
+
+	progress = GamesController.guess_progress.get((cid, uid))
+	if progress is None:
+		bot.send_message(uid, "Tu sesión de /guess expiró, usa /guess de nuevo para empezar.")
+		return
+	if candidate_uid in game.playerlist and candidate_uid not in progress["fascists"]:
+		progress["fascists"].append(candidate_uid)
+
+	if len(progress["fascists"]) >= progress["num_fascists"]:
+		texto, markup = _build_guess_hitler_prompt(game, uid)
+	else:
+		texto, markup = _build_guess_fascist_prompt(game, uid)
+
+	bot.edit_message_text(texto, chat_id=callback.message.chat_id, message_id=callback.message.message_id,
+		reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
+def _build_guess_hitler_prompt(game, uid):
+	strcid = str(game.cid)
+	texto = "🔮 *¿Quién crees que es Hitler?*"
+	btns = []
+	for player_uid, player in game.playerlist.items():
+		btns.append([InlineKeyboardButton(player.name, callback_data=strcid + "_guessh_" + str(player_uid))])
+	markup = InlineKeyboardMarkup(btns)
+	return texto, markup
+
+def callback_guess_hitler(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_guess_hitler called')
+	callback = update.callback_query
+	regex = re.search(r"(-?[0-9]*)_guessh_(-?[0-9]*)", callback.data)
+	cid = int(regex.group(1))
+	candidate_uid = int(regex.group(2))
+	uid = callback.from_user.id
+
+	game = get_game(cid)
+	if game is None or game.board is None:
+		bot.send_message(uid, "Esa partida ya no está activa.")
+		return
+	if uid not in game.playerlist:
+		bot.send_message(uid, "Debes ser un jugador de la partida para adivinar.")
+		return
+
+	progress = GamesController.guess_progress.get((cid, uid))
+	if progress is None:
+		bot.send_message(uid, "Tu sesión de /guess expiró, usa /guess de nuevo para empezar.")
+		return
+	if candidate_uid in game.playerlist:
+		progress["hitler"] = candidate_uid
+
+	texto, markup = _build_guess_confirm_prompt(game, uid)
+	bot.edit_message_text(texto, chat_id=callback.message.chat_id, message_id=callback.message.message_id,
+		reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
+def _build_guess_confirm_prompt(game, uid):
+	progress = GamesController.guess_progress[(game.cid, uid)]
+	nombres_fascistas = ", ".join(game.playerlist[u].name for u in progress["fascists"] if u in game.playerlist)
+	nombre_hitler = game.playerlist[progress["hitler"]].name if progress["hitler"] in game.playerlist else "?"
+	texto = "🔮 *Confirma tu palpito*\nFascistas sospechosos: {}\nHitler: {}\n\n¿Confirmas?".format(nombres_fascistas, nombre_hitler)
+	strcid = str(game.cid)
+	btns = [
+		[InlineKeyboardButton("✅ Confirmar", callback_data=strcid + "_guessconfirm")],
+		[InlineKeyboardButton("↩️ Empezar de nuevo", callback_data=strcid + "_guessrestart")],
+	]
+	markup = InlineKeyboardMarkup(btns)
+	return texto, markup
+
+def callback_guess_confirm(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_guess_confirm called')
+	callback = update.callback_query
+	regex = re.search(r"(-?[0-9]*)_guessconfirm", callback.data)
+	cid = int(regex.group(1))
+	uid = callback.from_user.id
+
+	game = get_game(cid)
+	if game is None or game.board is None:
+		bot.send_message(uid, "Esa partida ya no está activa.")
+		return
+	progress = GamesController.guess_progress.get((cid, uid))
+	if progress is None or progress.get("hitler") is None:
+		bot.send_message(uid, "Tu sesión de /guess expiró, usa /guess de nuevo para empezar.")
+		return
+
+	if not hasattr(game, "guesses"):
+		game.guesses = {}
+	history = list(game.guesses.get(uid, []))
+	history.append({"fascists": list(progress["fascists"]), "hitler": progress["hitler"]})
+	game.guesses[uid] = history
+	save_game(game.cid, game.groupName, game)
+	del GamesController.guess_progress[(cid, uid)]
+
+	if len(history) >= 2:
+		texto_final = ("✅ ¡Listo! Esta era tu segunda vez, así que tu palpito quedó *definitivo* y ya no se puede cambiar. "
+			"Se revelará al final de la partida quién estuvo más cerca de la verdad.")
+	else:
+		texto_final = ("✅ ¡Listo! Tu palpito quedó guardado. Podés usar /guess una vez más para cambiarlo "
+			"(la segunda vez es definitiva). Se revelará al final de la partida quién estuvo más cerca de la verdad.")
+
+	bot.edit_message_text(texto_final, chat_id=callback.message.chat_id, message_id=callback.message.message_id,
+		parse_mode=ParseMode.MARKDOWN)
+
+def callback_guess_restart(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_guess_restart called')
+	callback = update.callback_query
+	regex = re.search(r"(-?[0-9]*)_guessrestart", callback.data)
+	cid = int(regex.group(1))
+	uid = callback.from_user.id
+
+	game = get_game(cid)
+	if game is None or game.board is None:
+		bot.send_message(uid, "Esa partida ya no está activa.")
+		return
+	if uid not in game.playerlist:
+		bot.send_message(uid, "Debes ser un jugador de la partida para adivinar.")
+		return
+
+	num_fascists = _guess_num_fascists(game)
+	GamesController.guess_progress[(cid, uid)] = {"fascists": [], "hitler": None, "num_fascists": num_fascists}
+	texto, markup = _build_guess_fascist_prompt(game, uid)
+	bot.edit_message_text(texto, chat_id=callback.message.chat_id, message_id=callback.message.message_id,
+		reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
+def format_guesses_reveal(game):
+	guesses = getattr(game, "guesses", {})
+	if not guesses:
+		return None
+
+	hitler = game.get_hitler()
+	hitler_uid = hitler.uid if hitler else None
+	fascist_uids = {f.uid for f in game.get_fascists()}
+	total_fascists = len(fascist_uids)
+
+	resultados = []
+	for guesser_uid, history in guesses.items():
+		if not history:
+			continue
+		guess = history[-1]
+		guesser = game.playerlist.get(guesser_uid)
+		if guesser is None:
+			continue
+		guessed_fascist_uids = [u for u in guess.get("fascists", []) if u in game.playerlist]
+		guessed_hitler_uid = guess.get("hitler")
+
+		aciertos_fascistas = [u for u in guessed_fascist_uids if u in fascist_uids]
+		hitler_acierto = guessed_hitler_uid is not None and guessed_hitler_uid == hitler_uid
+		score = len(aciertos_fascistas) + (1 if hitler_acierto else 0)
+
+		nombres_fascistas = ", ".join(game.playerlist[u].name for u in guessed_fascist_uids) or "nadie"
+		nombre_hitler = game.playerlist[guessed_hitler_uid].name if guessed_hitler_uid in game.playerlist else "nadie"
+		nota_cambio = " _(cambió su palpito una vez)_" if len(history) > 1 else ""
+
+		texto = "*{}* sospechó de: {} y dijo que Hitler era *{}*{}\n   ↳ Acertó {}/{} fascistas comunes, {} a Hitler".format(
+			guesser.name, nombres_fascistas, nombre_hitler, nota_cambio,
+			len(aciertos_fascistas), total_fascists,
+			"acertó ✅" if hitler_acierto else "no acertó ❌"
+		)
+		resultados.append((score, guesser.name, texto))
+
+	if not resultados:
+		return None
+
+	lineas = ["🔮 *Resultados de las adivinanzas* 🔮\n"]
+	for _, _, texto in resultados:
+		lineas.append(texto)
+
+	max_score = max(r[0] for r in resultados)
+	ganadores = [nombre for score, nombre, _ in resultados if score == max_score]
+	lineas.append("\n🏆 Más cerca de la verdad: *{}* ({} de {} aciertos)".format(
+		", ".join(ganadores), max_score, total_fascists + 1))
+
+	return "\n".join(lineas)
 
 
 def command_show_stats(update: Update, context: CallbackContext):

--- a/SecretHitler/Constants/Achievements.py
+++ b/SecretHitler/Constants/Achievements.py
@@ -97,6 +97,18 @@ def _check_me_toco_lo_que_pedi(ctx):
     return ctx["won"] and ctx["preference_rol"] != "" and ctx["preference_rol"] == ctx["role"]
 
 
+def _check_lo_sabia(ctx):
+    guess = ctx["guess"]
+    return guess is not None and ctx["hitler_uid"] is not None and guess.get("hitler") == ctx["hitler_uid"]
+
+
+def _check_detective(ctx):
+    guess = ctx["guess"]
+    if guess is None:
+        return False
+    return guess.get("hitler") == ctx["hitler_uid"] and set(guess.get("fascists", [])) == ctx["fascist_uids"]
+
+
 LOGROS = [
     # Roles y victorias
     Logro("hitler_ganador", "Canciller Supremo", "Ganaste una partida siendo Hitler.",
@@ -109,6 +121,10 @@ LOGROS = [
           "🔥", "roles", False, _check_regimen_consolidado),
     Logro("actor_completo", "Actor completo", "Ganaste al menos una vez como Liberal, Fascista y Hitler.",
           "🎭", "roles", False, _check_actor_completo),
+    Logro("lo_sabia", "¡Lo sabía!", "Adivinaste correctamente quién era Hitler con /guess.",
+          "🔮", "roles", False, _check_lo_sabia),
+    Logro("detective", "Detective", "Adivinaste correctamente a todos los fascistas y a Hitler con /guess.",
+          "🔍", "roles", False, _check_detective),
 
     # Muerte y ejecuciones
     Logro("bala_certera", "Bala certera", "Ejecutaste a Hitler y los liberales ganaron.",

--- a/SecretHitler/GamesController.py
+++ b/SecretHitler/GamesController.py
@@ -1,3 +1,6 @@
 def init():
     global games
     games = {}
+
+# Estado en memoria de sesiones /guess en curso: (cid, uid) -> {"fascists": [...], "hitler": uid|None, "num_fascists": int}
+guess_progress = {}

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -962,6 +962,12 @@ def end_game(bot, game, game_endcode):
 		if game_endcode == 2:
 			bot.send_message(game.cid, "Juego finalizado! Los liberales ganaron matando a Hitler!\n\n%s" % game.print_roles())
 			set_stats("liberalwinkillhitler", stats[4] + 1, bot, cid)
+		try:
+			reveal = Commands.format_guesses_reveal(game)
+			if reveal is not None:
+				bot.send_message(cid, reveal, ParseMode.MARKDOWN)
+		except Exception as e:
+			log.error("No se pudo mostrar los resultados de las adivinanzas: %s" % str(e))
 		showHiddenhistory(bot, game)
 		try:
 			anuncio = Achievements.format_unlock_announcement(nuevos_logros, game)
@@ -1301,6 +1307,12 @@ def main():
 	dp.add_handler(CommandHandler("stats", Commands.command_stats))
 	dp.add_handler(CommandHandler("stats2", Commands.command_stats2))
 	dp.add_handler(CommandHandler("logros", Commands.command_logros))
+	dp.add_handler(CommandHandler("guess", Commands.command_guess))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameGuess\*(.*)\*(-?[0-9]*)", callback=Commands.callback_guess_game))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guessf_(-?[0-9]*)", callback=Commands.callback_guess_fascist))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guessh_(-?[0-9]*)", callback=Commands.callback_guess_hitler))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guessconfirm", callback=Commands.callback_guess_confirm))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guessrestart", callback=Commands.callback_guess_restart))
 	dp.add_handler(CommandHandler("vincularstats", Commands.command_vincularstats))
 	dp.add_handler(CommandHandler("vincularstats2", Commands.command_vincularstats2))
 	dp.add_handler(CommandHandler("newgame", Commands.command_newgame))
@@ -1392,6 +1404,7 @@ def main():
 			BotCommand("stats", "Muestra las estadisticas"),
 			BotCommand("stats2", "Muestra tus estadisticas nuevas vinculadas a tu ID"),
 			BotCommand("logros", "Muestra tus logros desbloqueados"),
+			BotCommand("guess", "Adivina en privado quienes son los fascistas y Hitler"),
 		])
 	except Exception as e:
 		log.error(str(e))


### PR DESCRIPTION
## Summary
- Adds a private `/guess` command to Secret Hitler: each player picks, via inline-keyboard menus in DM, who they think the common fascists and Hitler are.
- Guessing can be done up to 2 times per game — the player is told this upfront; both attempts are saved, and the second (or only) one is the definitive one used for scoring.
- When the game ends, results are revealed to the group: what each player guessed, how many they got right, and who was closest to the truth.
- Adds two achievements: **¡Lo sabía!** 🔮 (correctly guessed Hitler) and **Detective** 🔍 (guessed the exact fascist set and Hitler correctly), wired into the existing achievements pipeline (`/logros`, unlock announcements).

## Test plan
- [x] `python3 -m py_compile` on all changed files
- [ ] Manual playtest: run a game, have a couple of players use `/guess` (including redoing it once), confirm the group announcement at game end shows guesses/closest player, and check `/logros` unlocks the two new achievements

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_