### PR TITLE
Add "No debí dudar" achievement for reversing a correct Hitler guess

### DIFF
--- a/SecretHitler/Achievements.py
+++ b/SecretHitler/Achievements.py
@@ -93,6 +93,7 @@ def build_context(cur, game, game_endcode, uid, player):
         auto_ja=getattr(player, "auto_ja", False),
         preference_rol=getattr(player, "preference_rol", ""),
         guess=guess_history[-1] if guess_history else None,
+        guess_history=guess_history,
         hitler_uid=hitler_player.uid if hitler_player else None,
         fascist_uids=frozenset(f.uid for f in game.get_fascists()),
     )

--- a/SecretHitler/Constants/Achievements.py
+++ b/SecretHitler/Constants/Achievements.py
@@ -109,6 +109,15 @@ def _check_detective(ctx):
     return guess.get("hitler") == ctx["hitler_uid"] and set(guess.get("fascists", [])) == ctx["fascist_uids"]
 
 
+def _check_no_debi_dudar(ctx):
+    history = ctx["guess_history"]
+    hitler_uid = ctx["hitler_uid"]
+    if hitler_uid is None or len(history) < 2:
+        return False
+    primer_intento, segundo_intento = history[0], history[1]
+    return primer_intento.get("hitler") == hitler_uid and segundo_intento.get("hitler") != hitler_uid
+
+
 LOGROS = [
     # Roles y victorias
     Logro("hitler_ganador", "Canciller Supremo", "Ganaste una partida siendo Hitler.",
@@ -125,6 +134,8 @@ LOGROS = [
           "🔮", "roles", False, _check_lo_sabia),
     Logro("detective", "Detective", "Adivinaste correctamente a todos los fascistas y a Hitler con /guess.",
           "🔍", "roles", False, _check_detective),
+    Logro("no_debi_dudar", "No debí dudar", "En tu primer /guess acertaste quién era Hitler, pero en el segundo te equivocaste.",
+          "😩", "roles", False, _check_no_debi_dudar),
 
     # Muerte y ejecuciones
     Logro("bala_certera", "Bala certera", "Ejecutaste a Hitler y los liberales ganaron.",


### PR DESCRIPTION
## Summary
- Follow-up to #203 (the `/guess` command).
- Adds a new achievement, **No debí dudar** 😩: unlocks when a player's *first* `/guess` attempt correctly identified Hitler, but their *second* (definitive) attempt changed the pick and got it wrong.
- Threads the full guess history (not just the definitive last attempt) into the achievement context (`Achievements.build_context`) so this comparison is possible.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual playtest: as a player, use `/guess` once and correctly pick Hitler, then use `/guess` again and pick someone else as Hitler; confirm "No debí dudar" unlocks at game end and shows in `/logros`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_