### PR TITLE
Add /mvp command and make /guess role-aware, with new achievements

### DIFF
--- a/SecretHitler/Achievements.py
+++ b/SecretHitler/Achievements.py
@@ -31,6 +31,7 @@ class Ctx(dict):
         self._uid = uid
         self._history = None
         self._kills_history = None
+        self._mvp_count = None
 
     def history(self):
         # Filas (role, party, won, died, killed_by_uid, game_id) de todas las
@@ -54,6 +55,17 @@ class Ctx(dict):
             )
             self._kills_history = [row[0] for row in self._cur.fetchall()]
         return self._kills_history
+
+    def mvp_count(self):
+        # Cantidad de partidas en las que este uid fue elegido MVP. Corre en la
+        # misma transaccion que el INSERT de la partida actual, asi que ya la incluye.
+        if self._mvp_count is None:
+            self._cur.execute(
+                "SELECT COUNT(*) FROM stats_secret_hitler_players WHERE uid = %s AND mvp = TRUE;",
+                (self._uid,)
+            )
+            self._mvp_count = self._cur.fetchone()[0]
+        return self._mvp_count
 
 
 def build_context(cur, game, game_endcode, uid, player):

--- a/SecretHitler/Achievements.py
+++ b/SecretHitler/Achievements.py
@@ -108,6 +108,7 @@ def build_context(cur, game, game_endcode, uid, player):
         guess_history=guess_history,
         hitler_uid=hitler_player.uid if hitler_player else None,
         fascist_uids=frozenset(f.uid for f in game.get_fascists()),
+        best_guessers=frozenset(game.compute_best_guessers()),
     )
 
 

--- a/SecretHitler/Boardgamebox/Game.py
+++ b/SecretHitler/Boardgamebox/Game.py
@@ -57,6 +57,33 @@ class Game(object):
 			return None
 		return top[0]
 
+	def compute_best_guessers(self):
+		# Devuelve el conjunto de uids de Liberales con mas aciertos en el /guess
+		# "completo" (fascistas comunes + Hitler). Vacio si ningun liberal adivino.
+		hitler = self.get_hitler()
+		hitler_uid = hitler.uid if hitler else None
+		fascist_uids = {f.uid for f in self.get_fascists()}
+		guesses = getattr(self, "guesses", {})
+
+		scores = {}
+		for guesser_uid, history in guesses.items():
+			if not history:
+				continue
+			guesser = self.playerlist.get(guesser_uid)
+			if guesser is None or guesser.role != "Liberal":
+				continue
+			guess = history[-1]
+			guessed_fascist_uids = [u for u in guess.get("fascists", []) if u in self.playerlist]
+			guessed_hitler_uid = guess.get("hitler")
+			aciertos = len([u for u in guessed_fascist_uids if u in fascist_uids])
+			acierto_hitler = 1 if (guessed_hitler_uid is not None and guessed_hitler_uid == hitler_uid) else 0
+			scores[guesser_uid] = aciertos + acierto_hitler
+
+		if not scores:
+			return set()
+		max_score = max(scores.values())
+		return {u for u, s in scores.items() if s == max_score}
+
 	def shuffle_player_sequence(self):
 		for uid in self.playerlist:
 			self.player_sequence.append(self.playerlist[uid])

--- a/SecretHitler/Boardgamebox/Game.py
+++ b/SecretHitler/Boardgamebox/Game.py
@@ -21,7 +21,9 @@ class Game(object):
 		self.tipo = 'SecretHitler'
 		# {guesser_uid: [{"fascists": [uid, ...], "hitler": uid}, ...]} - historial de palpitos de /guess (maximo 2 intentos, el ultimo es definitivo)
 		self.guesses = {}
-    
+		# {voter_uid: voted_uid} - voto de /mvp, uno por jugador, se puede cambiar hasta el fin de la partida
+		self.mvp_votes = {}
+
 	def add_player(self, uid, player):
 		if any([True for k,v in self.playerlist.items() if v.name.strip() == player.name.strip()]):
 			# Pongo al player con su uid
@@ -39,6 +41,21 @@ class Game(object):
 			if self.playerlist[uid].role == "Fascista":
 				fascists.append(self.playerlist[uid])
 		return fascists
+
+	def compute_mvp(self):
+		# Devuelve el uid con mas votos de /mvp, o None si nadie voto o hay empate.
+		votes = getattr(self, "mvp_votes", {})
+		tally = {}
+		for voter_uid, voted_uid in votes.items():
+			if voted_uid in self.playerlist:
+				tally[voted_uid] = tally.get(voted_uid, 0) + 1
+		if not tally:
+			return None
+		max_votes = max(tally.values())
+		top = [uid for uid, count in tally.items() if count == max_votes]
+		if len(top) != 1:
+			return None
+		return top[0]
 
 	def shuffle_player_sequence(self):
 		for uid in self.playerlist:

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -56,7 +56,8 @@ commands = [  # command description used in the "help" command
     '/startautoja - Activa tu voto automático Ja apenas se proponga una fórmula (fuera de Zona Hitler)',
     '/stopautoja - Desactiva tu voto automático Ja',
     '/logros - Muestra tus logros desbloqueados',
-    '/guess - Adivina en privado quiénes son los fascistas y Hitler'
+    '/guess - Adivina en privado quiénes son los fascistas y Hitler',
+    '/mvp - Vota en privado al mejor jugador de la partida'
 ]
 
 symbols = [
@@ -1003,6 +1004,14 @@ def load_game(cid):
 			temp_guesses[int(guesser_uid)] = history
 		game.guesses = temp_guesses
 
+		# Partidas guardadas antes de agregar /mvp no tienen este atributo.
+		if not hasattr(game, "mvp_votes"):
+			game.mvp_votes = {}
+		temp_mvp_votes = {}
+		for voter_uid in game.mvp_votes:
+			temp_mvp_votes[int(voter_uid)] = int(game.mvp_votes[voter_uid])
+		game.mvp_votes = temp_mvp_votes
+
 		if game.board is not None and game.board.state is not None:
 			temp_last_votes = {}	
 			for uid in game.board.state.last_votes:
@@ -1932,6 +1941,126 @@ def format_guesses_reveal(game):
 	ganadores = [nombre for score, nombre, _ in resultados if score == max_score]
 	lineas.append("\n🏆 Más cerca de la verdad: *{}* ({} de {} aciertos)".format(
 		", ".join(ganadores), max_score, total_fascists + 1))
+
+	return "\n".join(lineas)
+
+
+def command_mvp(update: Update, context: CallbackContext):
+	bot = context.bot
+	uid = update.message.from_user.id
+	cid = update.message.chat_id
+	groupType = update.message.chat.type
+
+	if groupType in ['group', 'supergroup']:
+		game = get_game(cid)
+		if game is None or game.board is None:
+			bot.send_message(cid, "No hay una partida activa en este chat.")
+			return
+		if uid not in game.playerlist:
+			bot.send_message(cid, "Debes ser un jugador de la partida para usar /mvp.")
+			return
+		bot.send_message(cid, "Te mandé un mensaje privado para que votes al MVP. ¡Revisa tu chat privado conmigo!")
+		_send_mvp_buttons(bot, game, uid)
+	else:
+		all_games_unfiltered = MainController.getGamesByTipo("Todos")
+		all_games = {
+			key: "{}: {}".format(game.groupName, game.tipo)
+			for key, game in all_games_unfiltered.items()
+			if uid in game.playerlist and game.board is not None
+		}
+		if not all_games:
+			bot.send_message(cid, "No tienes partidas activas de Secret Hitler.")
+			return
+		if len(all_games) == 1:
+			game_cid = int(next(iter(all_games)))
+			game = get_game(game_cid)
+			_send_mvp_buttons(bot, game, uid)
+		else:
+			msg = "Elige el juego donde quieres votar al MVP"
+			simple_choose_buttons(bot, cid, uid, uid, "chooseGameMvp", msg, all_games)
+
+def callback_mvp_game(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_mvp_game called')
+	callback = update.callback_query
+	regex = re.search(r"(-?[0-9]*)\*chooseGameMvp\*(.*)\*(-?[0-9]*)", callback.data)
+	game_cid = int(regex.group(2))
+	uid = int(regex.group(3))
+	game = get_game(game_cid)
+	if game is None or game.board is None:
+		bot.send_message(uid, "No hay una partida activa en ese chat.")
+		return
+	_send_mvp_buttons(bot, game, uid)
+
+def _send_mvp_buttons(bot, game, uid):
+	strcid = str(game.cid)
+	current_vote = getattr(game, "mvp_votes", {}).get(uid)
+	texto = "🏅 *¿Quién fue el MVP de la partida?*\n(No podés votarte a vos mismo)"
+	if current_vote in game.playerlist:
+		texto += "\n\nVotaste actualmente a: *{}*. Podés cambiarlo eligiendo otro jugador.".format(game.playerlist[current_vote].name)
+	btns = []
+	for player_uid, player in game.playerlist.items():
+		if player_uid == uid:
+			continue
+		btns.append([InlineKeyboardButton(player.name, callback_data=strcid + "_mvpvote_" + str(player_uid))])
+	if not btns:
+		bot.send_message(uid, "No hay otros jugadores a quien votar en esta partida.")
+		return
+	markup = InlineKeyboardMarkup(btns)
+	bot.send_message(uid, texto, reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
+def callback_mvp_vote(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_mvp_vote called')
+	callback = update.callback_query
+	regex = re.search(r"(-?[0-9]*)_mvpvote_(-?[0-9]*)", callback.data)
+	cid = int(regex.group(1))
+	candidate_uid = int(regex.group(2))
+	uid = callback.from_user.id
+
+	game = get_game(cid)
+	if game is None or game.board is None:
+		bot.send_message(uid, "Esa partida ya no está activa.")
+		return
+	if uid not in game.playerlist:
+		bot.send_message(uid, "Debes ser un jugador de la partida para votar.")
+		return
+	if candidate_uid == uid:
+		bot.send_message(uid, "No podés votarte a vos mismo como MVP.")
+		return
+	if candidate_uid not in game.playerlist:
+		bot.send_message(uid, "Ese jugador ya no está en la partida.")
+		return
+
+	if not hasattr(game, "mvp_votes"):
+		game.mvp_votes = {}
+	game.mvp_votes[uid] = candidate_uid
+	save_game(game.cid, game.groupName, game)
+
+	bot.edit_message_text(
+		"✅ ¡Listo! Votaste a *{}* como MVP de la partida. Podés cambiar tu voto en cualquier momento con /mvp.".format(
+			game.playerlist[candidate_uid].name),
+		chat_id=callback.message.chat_id, message_id=callback.message.message_id, parse_mode=ParseMode.MARKDOWN)
+
+def format_mvp_reveal(game):
+	votes = getattr(game, "mvp_votes", {})
+	tally = {}
+	for voter_uid, voted_uid in votes.items():
+		if voted_uid in game.playerlist:
+			tally[voted_uid] = tally.get(voted_uid, 0) + 1
+	if not tally:
+		return None
+
+	lineas = ["🏅 *Votación a MVP de la partida* 🏅\n"]
+	for voted_uid, count in sorted(tally.items(), key=lambda kv: -kv[1]):
+		nombre = game.playerlist[voted_uid].name
+		lineas.append("{}: {} voto{}".format(nombre, count, "" if count == 1 else "s"))
+
+	mvp_uid = game.compute_mvp()
+	if mvp_uid is not None:
+		lineas.append("\n🏆 El MVP de la partida es *{}*!".format(game.playerlist[mvp_uid].name))
+	else:
+		lineas.append("\n🤝 Hubo un empate en la votación, no hay MVP esta partida.")
 
 	return "\n".join(lineas)
 

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -2013,7 +2013,6 @@ def format_guesses_reveal(game):
 	total_fascists = len(fascist_uids)
 
 	liberal_resultados = []  # (score, name, texto) - flujo completo, arma el ranking "mas cerca de la verdad"
-	liberal_scores = {}      # uid -> score, para chequear la prediccion de los fascistas
 	hitler_lineas = []
 	fascista_entries = []    # (predicted_uid, texto)
 
@@ -2050,7 +2049,6 @@ def format_guesses_reveal(game):
 		aciertos_fascistas = [u for u in guessed_fascist_uids if u in fascist_uids]
 		hitler_acierto = guessed_hitler_uid is not None and guessed_hitler_uid == hitler_uid
 		score = len(aciertos_fascistas) + (1 if hitler_acierto else 0)
-		liberal_scores[guesser_uid] = score
 
 		nombres_fascistas = ", ".join(game.playerlist[u].name for u in guessed_fascist_uids) or "nadie"
 		nombre_hitler = game.playerlist[guessed_hitler_uid].name if guessed_hitler_uid in game.playerlist else "nadie"
@@ -2067,12 +2065,11 @@ def format_guesses_reveal(game):
 
 	lineas = ["🔮 *Resultados de las adivinanzas* 🔮\n"]
 
-	mejores_liberales = set()
+	mejores_liberales = game.compute_best_guessers()
 	if liberal_resultados:
 		for _, _, texto in liberal_resultados:
 			lineas.append(texto)
 		max_score = max(r[0] for r in liberal_resultados)
-		mejores_liberales = {u for u, score in liberal_scores.items() if score == max_score}
 		ganadores = [nombre for score, nombre, _ in liberal_resultados if score == max_score]
 		lineas.append("\n🏆 Más cerca de la verdad: *{}* ({} de {} aciertos)".format(
 			", ".join(ganadores), max_score, total_fascists + 1))

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -998,9 +998,12 @@ def load_game(cid):
 		for guesser_uid in game.guesses:
 			history = game.guesses[guesser_uid]
 			for entry in history:
-				entry["fascists"] = [int(u) for u in entry.get("fascists", [])]
+				if "fascists" in entry:
+					entry["fascists"] = [int(u) for u in entry.get("fascists", [])]
 				if entry.get("hitler") is not None:
 					entry["hitler"] = int(entry["hitler"])
+				if entry.get("predicted") is not None:
+					entry["predicted"] = int(entry["predicted"])
 			temp_guesses[int(guesser_uid)] = history
 		game.guesses = temp_guesses
 
@@ -1709,39 +1712,71 @@ def callback_guess_game(update: Update, context: CallbackContext):
 		return
 	_start_guess_flow(bot, game, uid)
 
+def _init_guess_progress(game, uid):
+	# El rol determina que tiene que adivinar cada jugador:
+	# - Liberal (o sin rol): adivina los fascistas comunes Y a Hitler ("full").
+	# - Hitler: ya sabe que es Hitler, solo adivina a sus compañeros fascistas ("hitler").
+	# - Fascista: ya sabe todo, en vez de adivinar predice quien sera el jugador que
+	#   mas acierte en el modo "full" ("fascist_prediction").
+	player = game.playerlist.get(uid)
+	role = player.role if player else None
+	if role == "Hitler":
+		progress = {"mode": "hitler", "fascists": [], "num_fascists": _guess_num_fascists(game)}
+	elif role == "Fascista":
+		progress = {"mode": "fascist_prediction", "predicted": None}
+	else:
+		progress = {"mode": "full", "fascists": [], "hitler": None, "num_fascists": _guess_num_fascists(game)}
+	GamesController.guess_progress[(game.cid, uid)] = progress
+	return progress
+
+def _build_first_guess_prompt(game, uid):
+	progress = GamesController.guess_progress[(game.cid, uid)]
+	if progress["mode"] == "fascist_prediction":
+		return _build_guess_prediction_prompt(game, uid)
+	return _build_guess_fascist_prompt(game, uid)
+
 def _start_guess_flow(bot, game, uid):
 	history = getattr(game, "guesses", {}).get(uid, [])
 	attempts_done = len(history)
 	if attempts_done >= 2:
 		bot.send_message(uid, "Ya hiciste tu palpito 2 veces. Tu segunda elección quedó *definitiva* y no se puede volver a cambiar.", parse_mode=ParseMode.MARKDOWN)
 		return
-	num_fascists = _guess_num_fascists(game)
-	if num_fascists == 0:
+
+	player = game.playerlist.get(uid)
+	role = player.role if player else None
+	if role != "Fascista" and _guess_num_fascists(game) == 0:
 		bot.send_message(uid, "No se puede adivinar en esta partida.")
 		return
+
 	if attempts_done == 0:
-		bot.send_message(uid,
-			"🔮 Vas a elegir quiénes creés que son los fascistas comunes y quién es Hitler. "
-			"Podés repetir esta elección una sola vez más después de confirmar; se guardan tus dos intentos, "
-			"pero la *segunda* elección es la definitiva.",
-			parse_mode=ParseMode.MARKDOWN)
+		if role == "Hitler":
+			intro = ("🔮 Sos *Hitler*, así que en vez de adivinar quién es Hitler vas a intentar identificar a tus "
+				"compañeros fascistas. Podés repetir esta elección una sola vez más después de confirmar; "
+				"se guardan tus dos intentos, pero la *segunda* elección es la definitiva.")
+		elif role == "Fascista":
+			intro = ("🔮 Sos *fascista*, así que en vez de adivinar roles vas a predecir quién creés que será el "
+				"jugador que más acierte a Hitler y a los fascistas comunes. Podés repetir esta elección una sola "
+				"vez más después de confirmar; se guardan tus dos intentos, pero la *segunda* elección es la definitiva.")
+		else:
+			intro = ("🔮 Vas a elegir quiénes creés que son los fascistas comunes y quién es Hitler. "
+				"Podés repetir esta elección una sola vez más después de confirmar; se guardan tus dos intentos, "
+				"pero la *segunda* elección es la definitiva.")
+		bot.send_message(uid, intro, parse_mode=ParseMode.MARKDOWN)
 	else:
 		bot.send_message(uid,
 			"🔮 Esta es tu *última* oportunidad para adivinar: lo que confirmes ahora quedará definitivo.",
 			parse_mode=ParseMode.MARKDOWN)
-	GamesController.guess_progress[(game.cid, uid)] = {
-		"fascists": [],
-		"hitler": None,
-		"num_fascists": num_fascists,
-	}
-	texto, markup = _build_guess_fascist_prompt(game, uid)
+
+	_init_guess_progress(game, uid)
+	texto, markup = _build_first_guess_prompt(game, uid)
 	bot.send_message(uid, texto, reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
 
 def _build_guess_fascist_prompt(game, uid):
 	progress = GamesController.guess_progress[(game.cid, uid)]
 	selected = progress["fascists"]
 	num_fascists = progress["num_fascists"]
-	texto = "🔮 *Adivina quiénes son los fascistas comunes* ({}/{})\n".format(len(selected), num_fascists)
+	titulo = "tus compañeros fascistas" if progress["mode"] == "hitler" else "los fascistas comunes"
+	texto = "🔮 *Adivina quiénes son {}* ({}/{})\n".format(titulo, len(selected), num_fascists)
 	if selected:
 		nombres_elegidos = ", ".join(game.playerlist[u].name for u in selected if u in game.playerlist)
 		texto += "Ya elegiste: {}\n".format(nombres_elegidos)
@@ -1780,7 +1815,10 @@ def callback_guess_fascist(update: Update, context: CallbackContext):
 		progress["fascists"].append(candidate_uid)
 
 	if len(progress["fascists"]) >= progress["num_fascists"]:
-		texto, markup = _build_guess_hitler_prompt(game, uid)
+		if progress["mode"] == "full":
+			texto, markup = _build_guess_hitler_prompt(game, uid)
+		else:
+			texto, markup = _build_guess_confirm_prompt(game, uid)
 	else:
 		texto, markup = _build_guess_fascist_prompt(game, uid)
 
@@ -1824,12 +1862,70 @@ def callback_guess_hitler(update: Update, context: CallbackContext):
 	bot.edit_message_text(texto, chat_id=callback.message.chat_id, message_id=callback.message.message_id,
 		reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
 
+def _build_guess_prediction_prompt(game, uid):
+	texto = "🔮 *¿Quién creés que será el jugador que más acierte a Hitler y a los fascistas comunes?*"
+	strcid = str(game.cid)
+	hitler = game.get_hitler()
+	excluded = {f.uid for f in game.get_fascists()}
+	if hitler is not None:
+		excluded.add(hitler.uid)
+	btns = []
+	for player_uid, player in game.playerlist.items():
+		if player_uid in excluded:
+			continue
+		btns.append([InlineKeyboardButton(player.name, callback_data=strcid + "_guesspred_" + str(player_uid))])
+	if not btns:
+		for player_uid, player in game.playerlist.items():
+			if player_uid == uid:
+				continue
+			btns.append([InlineKeyboardButton(player.name, callback_data=strcid + "_guesspred_" + str(player_uid))])
+	markup = InlineKeyboardMarkup(btns)
+	return texto, markup
+
+def callback_guess_prediction(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_guess_prediction called')
+	callback = update.callback_query
+	regex = re.search(r"(-?[0-9]*)_guesspred_(-?[0-9]*)", callback.data)
+	cid = int(regex.group(1))
+	candidate_uid = int(regex.group(2))
+	uid = callback.from_user.id
+
+	game = get_game(cid)
+	if game is None or game.board is None:
+		bot.send_message(uid, "Esa partida ya no está activa.")
+		return
+	if uid not in game.playerlist:
+		bot.send_message(uid, "Debes ser un jugador de la partida para adivinar.")
+		return
+
+	progress = GamesController.guess_progress.get((cid, uid))
+	if progress is None:
+		bot.send_message(uid, "Tu sesión de /guess expiró, usa /guess de nuevo para empezar.")
+		return
+	if candidate_uid in game.playerlist:
+		progress["predicted"] = candidate_uid
+
+	texto, markup = _build_guess_confirm_prompt(game, uid)
+	bot.edit_message_text(texto, chat_id=callback.message.chat_id, message_id=callback.message.message_id,
+		reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
 def _build_guess_confirm_prompt(game, uid):
 	progress = GamesController.guess_progress[(game.cid, uid)]
-	nombres_fascistas = ", ".join(game.playerlist[u].name for u in progress["fascists"] if u in game.playerlist)
-	nombre_hitler = game.playerlist[progress["hitler"]].name if progress["hitler"] in game.playerlist else "?"
-	texto = "🔮 *Confirma tu palpito*\nFascistas sospechosos: {}\nHitler: {}\n\n¿Confirmas?".format(nombres_fascistas, nombre_hitler)
 	strcid = str(game.cid)
+
+	if progress["mode"] == "hitler":
+		nombres_fascistas = ", ".join(game.playerlist[u].name for u in progress["fascists"] if u in game.playerlist)
+		texto = "🔮 *Confirma tu palpito*\nCompañeros fascistas sospechosos: {}\n\n¿Confirmas?".format(nombres_fascistas)
+	elif progress["mode"] == "fascist_prediction":
+		predicted = progress.get("predicted")
+		nombre = game.playerlist[predicted].name if predicted in game.playerlist else "?"
+		texto = "🔮 *Confirma tu predicción*\n¿Quién más acierte a Hitler y a los fascistas?: *{}*\n\n¿Confirmas?".format(nombre)
+	else:
+		nombres_fascistas = ", ".join(game.playerlist[u].name for u in progress["fascists"] if u in game.playerlist)
+		nombre_hitler = game.playerlist[progress["hitler"]].name if progress["hitler"] in game.playerlist else "?"
+		texto = "🔮 *Confirma tu palpito*\nFascistas sospechosos: {}\nHitler: {}\n\n¿Confirmas?".format(nombres_fascistas, nombre_hitler)
+
 	btns = [
 		[InlineKeyboardButton("✅ Confirmar", callback_data=strcid + "_guessconfirm")],
 		[InlineKeyboardButton("↩️ Empezar de nuevo", callback_data=strcid + "_guessrestart")],
@@ -1850,14 +1946,27 @@ def callback_guess_confirm(update: Update, context: CallbackContext):
 		bot.send_message(uid, "Esa partida ya no está activa.")
 		return
 	progress = GamesController.guess_progress.get((cid, uid))
-	if progress is None or progress.get("hitler") is None:
+	if progress is None:
 		bot.send_message(uid, "Tu sesión de /guess expiró, usa /guess de nuevo para empezar.")
 		return
+
+	if progress["mode"] == "hitler":
+		entry = {"fascists": list(progress["fascists"])}
+	elif progress["mode"] == "fascist_prediction":
+		if progress.get("predicted") is None:
+			bot.send_message(uid, "Tenés que elegir a alguien antes de confirmar.")
+			return
+		entry = {"predicted": progress["predicted"]}
+	else:
+		if progress.get("hitler") is None:
+			bot.send_message(uid, "Tenés que elegir quién es Hitler antes de confirmar.")
+			return
+		entry = {"fascists": list(progress["fascists"]), "hitler": progress["hitler"]}
 
 	if not hasattr(game, "guesses"):
 		game.guesses = {}
 	history = list(game.guesses.get(uid, []))
-	history.append({"fascists": list(progress["fascists"]), "hitler": progress["hitler"]})
+	history.append(entry)
 	game.guesses[uid] = history
 	save_game(game.cid, game.groupName, game)
 	del GamesController.guess_progress[(cid, uid)]
@@ -1888,9 +1997,8 @@ def callback_guess_restart(update: Update, context: CallbackContext):
 		bot.send_message(uid, "Debes ser un jugador de la partida para adivinar.")
 		return
 
-	num_fascists = _guess_num_fascists(game)
-	GamesController.guess_progress[(cid, uid)] = {"fascists": [], "hitler": None, "num_fascists": num_fascists}
-	texto, markup = _build_guess_fascist_prompt(game, uid)
+	_init_guess_progress(game, uid)
+	texto, markup = _build_first_guess_prompt(game, uid)
 	bot.edit_message_text(texto, chat_id=callback.message.chat_id, message_id=callback.message.message_id,
 		reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
 
@@ -1904,7 +2012,11 @@ def format_guesses_reveal(game):
 	fascist_uids = {f.uid for f in game.get_fascists()}
 	total_fascists = len(fascist_uids)
 
-	resultados = []
+	liberal_resultados = []  # (score, name, texto) - flujo completo, arma el ranking "mas cerca de la verdad"
+	liberal_scores = {}      # uid -> score, para chequear la prediccion de los fascistas
+	hitler_lineas = []
+	fascista_entries = []    # (predicted_uid, texto)
+
 	for guesser_uid, history in guesses.items():
 		if not history:
 			continue
@@ -1912,35 +2024,68 @@ def format_guesses_reveal(game):
 		guesser = game.playerlist.get(guesser_uid)
 		if guesser is None:
 			continue
+		nota_cambio = " _(cambió su palpito una vez)_" if len(history) > 1 else ""
+
+		if guesser.role == "Hitler":
+			guessed_fascist_uids = [u for u in guess.get("fascists", []) if u in game.playerlist]
+			aciertos = [u for u in guessed_fascist_uids if u in fascist_uids]
+			nombres = ", ".join(game.playerlist[u].name for u in guessed_fascist_uids) or "nadie"
+			hitler_lineas.append(
+				"*{}* (Hitler) sospechó que sus compañeros fascistas eran: {}{}\n   ↳ Acertó {}/{} compañeros".format(
+					guesser.name, nombres, nota_cambio, len(aciertos), total_fascists))
+			continue
+
+		if guesser.role == "Fascista":
+			predicted_uid = guess.get("predicted")
+			nombre_prediccion = game.playerlist[predicted_uid].name if predicted_uid in game.playerlist else "nadie"
+			texto = "*{}* (fascista) predijo que *{}* sería quien más acierte a Hitler y a los fascistas{}".format(
+				guesser.name, nombre_prediccion, nota_cambio)
+			fascista_entries.append((predicted_uid, texto))
+			continue
+
+		# Liberal (o rol desconocido): flujo completo
 		guessed_fascist_uids = [u for u in guess.get("fascists", []) if u in game.playerlist]
 		guessed_hitler_uid = guess.get("hitler")
 
 		aciertos_fascistas = [u for u in guessed_fascist_uids if u in fascist_uids]
 		hitler_acierto = guessed_hitler_uid is not None and guessed_hitler_uid == hitler_uid
 		score = len(aciertos_fascistas) + (1 if hitler_acierto else 0)
+		liberal_scores[guesser_uid] = score
 
 		nombres_fascistas = ", ".join(game.playerlist[u].name for u in guessed_fascist_uids) or "nadie"
 		nombre_hitler = game.playerlist[guessed_hitler_uid].name if guessed_hitler_uid in game.playerlist else "nadie"
-		nota_cambio = " _(cambió su palpito una vez)_" if len(history) > 1 else ""
 
 		texto = "*{}* sospechó de: {} y dijo que Hitler era *{}*{}\n   ↳ Acertó {}/{} fascistas comunes, {} a Hitler".format(
 			guesser.name, nombres_fascistas, nombre_hitler, nota_cambio,
 			len(aciertos_fascistas), total_fascists,
 			"acertó ✅" if hitler_acierto else "no acertó ❌"
 		)
-		resultados.append((score, guesser.name, texto))
+		liberal_resultados.append((score, guesser.name, texto))
 
-	if not resultados:
+	if not liberal_resultados and not hitler_lineas and not fascista_entries:
 		return None
 
 	lineas = ["🔮 *Resultados de las adivinanzas* 🔮\n"]
-	for _, _, texto in resultados:
-		lineas.append(texto)
 
-	max_score = max(r[0] for r in resultados)
-	ganadores = [nombre for score, nombre, _ in resultados if score == max_score]
-	lineas.append("\n🏆 Más cerca de la verdad: *{}* ({} de {} aciertos)".format(
-		", ".join(ganadores), max_score, total_fascists + 1))
+	mejores_liberales = set()
+	if liberal_resultados:
+		for _, _, texto in liberal_resultados:
+			lineas.append(texto)
+		max_score = max(r[0] for r in liberal_resultados)
+		mejores_liberales = {u for u, score in liberal_scores.items() if score == max_score}
+		ganadores = [nombre for score, nombre, _ in liberal_resultados if score == max_score]
+		lineas.append("\n🏆 Más cerca de la verdad: *{}* ({} de {} aciertos)".format(
+			", ".join(ganadores), max_score, total_fascists + 1))
+
+	if hitler_lineas:
+		lineas.append("")
+		lineas.extend(hitler_lineas)
+
+	if fascista_entries:
+		lineas.append("")
+		for predicted_uid, texto in fascista_entries:
+			acierto = predicted_uid in mejores_liberales
+			lineas.append(texto + "\n   ↳ {}".format("Predijo correctamente ✅" if acierto else "No acertó ❌"))
 
 	return "\n".join(lineas)
 

--- a/SecretHitler/Constants/Achievements.py
+++ b/SecretHitler/Constants/Achievements.py
@@ -136,6 +136,19 @@ def _check_companeros_de_ideologia(ctx):
     return set(guess.get("fascists", [])) == ctx["fascist_uids"]
 
 
+def _check_prediccion_certera(ctx):
+    # Solo Fascista: el /guess de Fascista predice quien sera el mejor adivinando (los liberales).
+    if ctx["role"] != "Fascista":
+        return False
+    guess = ctx["guess"]
+    if guess is None:
+        return False
+    predicted = guess.get("predicted")
+    if predicted is None:
+        return False
+    return predicted in ctx["best_guessers"]
+
+
 def _check_mvp_una_vez(ctx):
     return ctx.mvp_count() >= 1
 
@@ -168,6 +181,8 @@ LOGROS = [
           "😩", "roles", False, _check_no_debi_dudar),
     Logro("companeros_de_ideologia", "Compañeros de ideología", "Como Hitler, identificaste correctamente a todos tus compañeros fascistas con /guess.",
           "🥸", "roles", False, _check_companeros_de_ideologia),
+    Logro("prediccion_certera", "Ojo fascista", "Como fascista, predijiste correctamente quién sería el jugador que más acertaría con /guess.",
+          "👁️", "roles", False, _check_prediccion_certera),
 
     # Muerte y ejecuciones
     Logro("bala_certera", "Bala certera", "Ejecutaste a Hitler y los liberales ganaron.",

--- a/SecretHitler/Constants/Achievements.py
+++ b/SecretHitler/Constants/Achievements.py
@@ -118,6 +118,18 @@ def _check_no_debi_dudar(ctx):
     return primer_intento.get("hitler") == hitler_uid and segundo_intento.get("hitler") != hitler_uid
 
 
+def _check_mvp_una_vez(ctx):
+    return ctx.mvp_count() >= 1
+
+
+def _check_mvp_cinco_veces(ctx):
+    return ctx.mvp_count() >= 5
+
+
+def _check_mvp_mas_de_diez(ctx):
+    return ctx.mvp_count() > 10
+
+
 LOGROS = [
     # Roles y victorias
     Logro("hitler_ganador", "Canciller Supremo", "Ganaste una partida siendo Hitler.",
@@ -168,6 +180,12 @@ LOGROS = [
           "🤖", "social", False, _check_piloto_automatico),
     Logro("me_toco_lo_que_pedi", "Me tocó lo que pedí", "Te tocó el rol que pediste y ganaste.",
           "🎲", "social", False, _check_me_toco_lo_que_pedi),
+    Logro("mvp_una_vez", "MVP", "Te votaron como MVP de la partida.",
+          "🌟", "social", False, _check_mvp_una_vez),
+    Logro("mvp_cinco_veces", "MVP Recurrente", "Te votaron como MVP en 5 partidas.",
+          "🏆", "social", False, _check_mvp_cinco_veces),
+    Logro("mvp_mas_de_diez", "El MVP de Siempre", "Te votaron como MVP en más de 10 partidas.",
+          "💫", "social", False, _check_mvp_mas_de_diez),
 ]
 
 LOGROS_BY_CODE = {logro.code: logro for logro in LOGROS}

--- a/SecretHitler/Constants/Achievements.py
+++ b/SecretHitler/Constants/Achievements.py
@@ -98,11 +98,17 @@ def _check_me_toco_lo_que_pedi(ctx):
 
 
 def _check_lo_sabia(ctx):
+    # Solo Liberal: Hitler y Fascista ya conocen la respuesta de antemano por su rol,
+    # asi que su /guess ni siquiera les pide adivinar quien es Hitler.
+    if ctx["role"] != "Liberal":
+        return False
     guess = ctx["guess"]
     return guess is not None and ctx["hitler_uid"] is not None and guess.get("hitler") == ctx["hitler_uid"]
 
 
 def _check_detective(ctx):
+    if ctx["role"] != "Liberal":
+        return False
     guess = ctx["guess"]
     if guess is None:
         return False
@@ -110,12 +116,24 @@ def _check_detective(ctx):
 
 
 def _check_no_debi_dudar(ctx):
+    if ctx["role"] != "Liberal":
+        return False
     history = ctx["guess_history"]
     hitler_uid = ctx["hitler_uid"]
     if hitler_uid is None or len(history) < 2:
         return False
     primer_intento, segundo_intento = history[0], history[1]
     return primer_intento.get("hitler") == hitler_uid and segundo_intento.get("hitler") != hitler_uid
+
+
+def _check_companeros_de_ideologia(ctx):
+    # Solo Hitler: el /guess de Hitler solo pide adivinar a los compañeros fascistas.
+    if ctx["role"] != "Hitler":
+        return False
+    guess = ctx["guess"]
+    if guess is None:
+        return False
+    return set(guess.get("fascists", [])) == ctx["fascist_uids"]
 
 
 def _check_mvp_una_vez(ctx):
@@ -148,6 +166,8 @@ LOGROS = [
           "🔍", "roles", False, _check_detective),
     Logro("no_debi_dudar", "No debí dudar", "En tu primer /guess acertaste quién era Hitler, pero en el segundo te equivocaste.",
           "😩", "roles", False, _check_no_debi_dudar),
+    Logro("companeros_de_ideologia", "Compañeros de ideología", "Como Hitler, identificaste correctamente a todos tus compañeros fascistas con /guess.",
+          "🥸", "roles", False, _check_companeros_de_ideologia),
 
     # Muerte y ejecuciones
     Logro("bala_certera", "Bala certera", "Ejecutaste a Hitler y los liberales ganaron.",

--- a/SecretHitler/DBCreate.sql
+++ b/SecretHitler/DBCreate.sql
@@ -70,6 +70,7 @@ CREATE TABLE IF NOT EXISTS stats_secret_hitler_players (
     killed_by_uid BIGINT, -- NULL si no lo mataron o si el dato no se pudo reconstruir al migrar
     UNIQUE (game_id, uid)
 );
+ALTER TABLE stats_secret_hitler_players ADD COLUMN IF NOT EXISTS mvp BOOLEAN NOT NULL DEFAULT FALSE;
 
 -- Logros desbloqueados por jugador. El catalogo (nombre, descripcion, condicion)
 -- vive en SecretHitler/Constants/Achievements.py; aca solo se guarda quien

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -1317,6 +1317,7 @@ def main():
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameGuess\*(.*)\*(-?[0-9]*)", callback=Commands.callback_guess_game))
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guessf_(-?[0-9]*)", callback=Commands.callback_guess_fascist))
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guessh_(-?[0-9]*)", callback=Commands.callback_guess_hitler))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guesspred_(-?[0-9]*)", callback=Commands.callback_guess_prediction))
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guessconfirm", callback=Commands.callback_guess_confirm))
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guessrestart", callback=Commands.callback_guess_restart))
 	dp.add_handler(CommandHandler("mvp", Commands.command_mvp))

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -968,6 +968,12 @@ def end_game(bot, game, game_endcode):
 				bot.send_message(cid, reveal, ParseMode.MARKDOWN)
 		except Exception as e:
 			log.error("No se pudo mostrar los resultados de las adivinanzas: %s" % str(e))
+		try:
+			mvp_reveal = Commands.format_mvp_reveal(game)
+			if mvp_reveal is not None:
+				bot.send_message(cid, mvp_reveal, ParseMode.MARKDOWN)
+		except Exception as e:
+			log.error("No se pudo mostrar la votación de MVP: %s" % str(e))
 		showHiddenhistory(bot, game)
 		try:
 			anuncio = Achievements.format_unlock_announcement(nuevos_logros, game)
@@ -1313,6 +1319,9 @@ def main():
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guessh_(-?[0-9]*)", callback=Commands.callback_guess_hitler))
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guessconfirm", callback=Commands.callback_guess_confirm))
 	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_guessrestart", callback=Commands.callback_guess_restart))
+	dp.add_handler(CommandHandler("mvp", Commands.command_mvp))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*chooseGameMvp\*(.*)\*(-?[0-9]*)", callback=Commands.callback_mvp_game))
+	dp.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)_mvpvote_(-?[0-9]*)", callback=Commands.callback_mvp_vote))
 	dp.add_handler(CommandHandler("vincularstats", Commands.command_vincularstats))
 	dp.add_handler(CommandHandler("vincularstats2", Commands.command_vincularstats2))
 	dp.add_handler(CommandHandler("newgame", Commands.command_newgame))
@@ -1405,6 +1414,7 @@ def main():
 			BotCommand("stats2", "Muestra tus estadisticas nuevas vinculadas a tu ID"),
 			BotCommand("logros", "Muestra tus logros desbloqueados"),
 			BotCommand("guess", "Adivina en privado quienes son los fascistas y Hitler"),
+			BotCommand("mvp", "Vota en privado al mejor jugador de la partida"),
 		])
 	except Exception as e:
 		log.error(str(e))

--- a/SecretHitler/StatsExtended.py
+++ b/SecretHitler/StatsExtended.py
@@ -42,6 +42,8 @@ def save_extended_game_stats(game, game_endcode):
         )
         game_id = cur.fetchone()[0]
 
+        mvp_uid = game.compute_mvp()
+
         for uid, player in game.playerlist.items():
             if player.party == "liberal":
                 won = won_liberal
@@ -51,11 +53,11 @@ def save_extended_game_stats(game, game_endcode):
                 won = False
             cur.execute(
                 "INSERT INTO stats_secret_hitler_players"
-                "(game_id, uid, name, role, party, won, died, killed_by_uid) "
-                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) "
+                "(game_id, uid, name, role, party, won, died, killed_by_uid, mvp) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) "
                 "ON CONFLICT (game_id, uid) DO NOTHING;",
                 (game_id, uid, player.name, player.role, player.party, won,
-                 player.is_dead, getattr(player, "killed_by_uid", None))
+                 player.is_dead, getattr(player, "killed_by_uid", None), uid == mvp_uid)
             )
 
         nuevos_por_uid = Achievements.evaluate_and_store(cur, game, game_endcode, game_id)


### PR DESCRIPTION
## Summary
- Adds a private `/mvp` command: each player votes (in DM, one vote each, changeable until the game ends, no self-voting) for the best player of the match. The MVP is the strict majority winner; ties mean no MVP for that game. Adds three achievements for being voted MVP 1, 5, and >10 times.
- Reworks `/guess` to be role-aware, since Fascista/Hitler already know these answers from their private role reveal, which made the original guessing achievements trivial for them:
  - **Liberal**: unchanged — guesses fascists + Hitler, up to 2 attempts, second is definitive.
  - **Hitler**: only guesses fascist teammates (the "who is Hitler" step is skipped). New achievement **"Compañeros de ideología"** for a perfect guess.
  - **Fascista**: instead predicts which Liberal player will score best guessing Hitler/fascists — a genuinely uncertain question even though they know the truth. New achievement **"Ojo fascista"** for a correct prediction.
  - "¡Lo sabía!", "Detective" and "No debí dudar" are now explicitly restricted to Liberal players.
- End-game reveal now shows all three kinds of results (Liberal ranking, Hitler's teammate-guess accuracy, Fascista prediction correctness) instead of one uniform format.
- Adds `Game.compute_mvp()` and `Game.compute_best_guessers()` helpers so the end-game reveal text and the achievement checks share one source of truth.
- Adds an `mvp` column to `stats_secret_hitler_players` (idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, runs automatically on bot startup via the existing `DBCreate.sql` init flow).

## Test plan
- [x] `python3 -m py_compile` on all changed files
- [ ] Manual playtest: run a game with players in all three roles, have each use `/guess` and confirm the role-specific flow and end-game reveal; have players use `/mvp` (including changing a vote) and confirm the tally/winner announcement; check `/logros` for the new achievements

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_