### PR TITLE
Add "Misión Imposible" achievement

### DIFF
--- a/SecretHitler/Achievements.py
+++ b/SecretHitler/Achievements.py
@@ -109,6 +109,7 @@ def build_context(cur, game, game_endcode, uid, player):
         hitler_uid=hitler_player.uid if hitler_player else None,
         fascist_uids=frozenset(f.uid for f in game.get_fascists()),
         best_guessers=frozenset(game.compute_best_guessers()),
+        game_player_uids=frozenset(game.playerlist.keys()),
     )
 
 

--- a/SecretHitler/Constants/Achievements.py
+++ b/SecretHitler/Constants/Achievements.py
@@ -16,6 +16,8 @@ CATEGORIA_TITULOS = {
     "social": "Social",
 }
 
+MISION_IMPOSIBLE_UID = 863684947
+
 
 def _check_hitler_ganador(ctx):
     return ctx["role"] == "Hitler" and ctx["won"]
@@ -149,6 +151,10 @@ def _check_prediccion_certera(ctx):
     return predicted in ctx["best_guessers"]
 
 
+def _check_mision_imposible(ctx):
+    return ctx["won"] and MISION_IMPOSIBLE_UID in ctx["game_player_uids"]
+
+
 def _check_mvp_una_vez(ctx):
     return ctx.mvp_count() >= 1
 
@@ -221,6 +227,8 @@ LOGROS = [
           "🏆", "social", False, _check_mvp_cinco_veces),
     Logro("mvp_mas_de_diez", "El MVP de Siempre", "Te votaron como MVP en más de 10 partidas.",
           "💫", "social", False, _check_mvp_mas_de_diez),
+    Logro("mision_imposible", "Misión Imposible", "Ganaste una partida jugando junto a un jugador muy particular.",
+          "🕶️", "social", True, _check_mision_imposible),
 ]
 
 LOGROS_BY_CODE = {logro.code: logro for logro in LOGROS}


### PR DESCRIPTION
## Summary
- Adds a new secret achievement, **Misión Imposible** 🕶️: unlocks for any winning player in a game that included the player with Telegram ID `863684947`.
- Plugs into the existing `Logro`/`build_context`/`evaluate_and_store` achievements pipeline (`/logros`, unlock announcements) — no schema changes needed.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual playtest: play and win a game that includes player 863684947, confirm the achievement unlocks and shows in `/logros`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_