### PR TITLE
Make /mvp a post-game vote that waits for all players before revealing

### DIFF
--- a/SecretHitler/Boardgamebox/Game.py
+++ b/SecretHitler/Boardgamebox/Game.py
@@ -21,8 +21,11 @@ class Game(object):
 		self.tipo = 'SecretHitler'
 		# {guesser_uid: [{"fascists": [uid, ...], "hitler": uid}, ...]} - historial de palpitos de /guess (maximo 2 intentos, el ultimo es definitivo)
 		self.guesses = {}
-		# {voter_uid: voted_uid} - voto de /mvp, uno por jugador, se puede cambiar hasta el fin de la partida
+		# {voter_uid: voted_uid} - voto de /mvp, uno por jugador, se puede cambiar hasta que todos hayan votado
 		self.mvp_votes = {}
+		# id de stats_secret_hitler_games para esta partida, seteado por end_game(); lo usa
+		# la finalizacion de /mvp post-partida para actualizar la columna mvp en la fila correcta
+		self.stats_game_id = None
 
 	def add_player(self, uid, player):
 		if any([True for k,v in self.playerlist.items() if v.name.strip() == player.name.strip()]):

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -1015,6 +1015,9 @@ def load_game(cid):
 			temp_mvp_votes[int(voter_uid)] = int(game.mvp_votes[voter_uid])
 		game.mvp_votes = temp_mvp_votes
 
+		if not hasattr(game, "stats_game_id"):
+			game.stats_game_id = None
+
 		if game.board is not None and game.board.state is not None:
 			temp_last_votes = {}	
 			for uid in game.board.state.last_votes:
@@ -2101,6 +2104,9 @@ def command_mvp(update: Update, context: CallbackContext):
 		if uid not in game.playerlist:
 			bot.send_message(cid, "Debes ser un jugador de la partida para usar /mvp.")
 			return
+		if game.board.state.game_endcode == 0:
+			bot.send_message(cid, "Todavía no terminó la partida. Esperá a que termine para votar al MVP.")
+			return
 		bot.send_message(cid, "Te mandé un mensaje privado para que votes al MVP. ¡Revisa tu chat privado conmigo!")
 		_send_mvp_buttons(bot, game, uid)
 	else:
@@ -2108,10 +2114,10 @@ def command_mvp(update: Update, context: CallbackContext):
 		all_games = {
 			key: "{}: {}".format(game.groupName, game.tipo)
 			for key, game in all_games_unfiltered.items()
-			if uid in game.playerlist and game.board is not None
+			if uid in game.playerlist and game.board is not None and game.board.state.game_endcode != 0
 		}
 		if not all_games:
-			bot.send_message(cid, "No tienes partidas activas de Secret Hitler.")
+			bot.send_message(cid, "No tenés partidas recién terminadas donde votar al MVP.")
 			return
 		if len(all_games) == 1:
 			game_cid = int(next(iter(all_games)))
@@ -2135,11 +2141,17 @@ def callback_mvp_game(update: Update, context: CallbackContext):
 	_send_mvp_buttons(bot, game, uid)
 
 def _send_mvp_buttons(bot, game, uid):
+	if game.board.state.game_endcode == 0:
+		bot.send_message(uid, "Todavía no terminó la partida. Esperá a que termine para votar al MVP.")
+		return
 	strcid = str(game.cid)
 	current_vote = getattr(game, "mvp_votes", {}).get(uid)
 	texto = "🏅 *¿Quién fue el MVP de la partida?*\n(No podés votarte a vos mismo)"
 	if current_vote in game.playerlist:
-		texto += "\n\nVotaste actualmente a: *{}*. Podés cambiarlo eligiendo otro jugador.".format(game.playerlist[current_vote].name)
+		texto += "\n\nVotaste actualmente a: *{}*. Podés cambiarlo eligiendo otro jugador mientras falten votos.".format(game.playerlist[current_vote].name)
+	faltan = [p.name for u, p in game.playerlist.items() if u not in getattr(game, "mvp_votes", {})]
+	if faltan:
+		texto += "\n\nTodavía no votaron: {}".format(", ".join(faltan))
 	btns = []
 	for player_uid, player in game.playerlist.items():
 		if player_uid == uid:
@@ -2167,6 +2179,9 @@ def callback_mvp_vote(update: Update, context: CallbackContext):
 	if uid not in game.playerlist:
 		bot.send_message(uid, "Debes ser un jugador de la partida para votar.")
 		return
+	if game.board.state.game_endcode == 0:
+		bot.send_message(uid, "Todavía no terminó la partida. Esperá a que termine para votar al MVP.")
+		return
 	if candidate_uid == uid:
 		bot.send_message(uid, "No podés votarte a vos mismo como MVP.")
 		return
@@ -2177,12 +2192,44 @@ def callback_mvp_vote(update: Update, context: CallbackContext):
 	if not hasattr(game, "mvp_votes"):
 		game.mvp_votes = {}
 	game.mvp_votes[uid] = candidate_uid
-	save_game(game.cid, game.groupName, game)
+	todos_votaron = len(game.mvp_votes) >= len(game.playerlist)
+	if not todos_votaron:
+		save_game(game.cid, game.groupName, game)
 
 	bot.edit_message_text(
-		"✅ ¡Listo! Votaste a *{}* como MVP de la partida. Podés cambiar tu voto en cualquier momento con /mvp.".format(
-			game.playerlist[candidate_uid].name),
+		"✅ ¡Listo! Votaste a *{}* como MVP de la partida.{}".format(
+			game.playerlist[candidate_uid].name,
+			"" if todos_votaron else " Podés cambiar tu voto en cualquier momento con /mvp mientras falten votos."),
 		chat_id=callback.message.chat_id, message_id=callback.message.message_id, parse_mode=ParseMode.MARKDOWN)
+
+	if todos_votaron:
+		_finalize_mvp(bot, game)
+
+def _finalize_mvp(bot, game):
+	cid = game.cid
+	try:
+		reveal = format_mvp_reveal(game)
+		if reveal is not None:
+			bot.send_message(cid, reveal, ParseMode.MARKDOWN)
+	except Exception as e:
+		log.error("No se pudo mostrar la votación de MVP: %s" % str(e))
+
+	try:
+		nuevos_logros = StatsExtended.finalize_mvp_stats(game)
+	except Exception as e:
+		log.error("No se pudo finalizar las stats de MVP: %s" % str(e))
+		nuevos_logros = {}
+
+	try:
+		anuncio = Achievements.format_unlock_announcement(nuevos_logros, game)
+		if anuncio is not None:
+			bot.send_message(cid, anuncio, ParseMode.MARKDOWN)
+	except Exception as e:
+		log.error("No se pudo anunciar los logros de MVP: %s" % str(e))
+
+	if cid in GamesController.games:
+		del GamesController.games[cid]
+	delete_game(cid)
 
 def format_mvp_reveal(game):
 	votes = getattr(game, "mvp_votes", {})

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -935,9 +935,10 @@ def end_game(bot, game, game_endcode):
 	
 	# Grabo detalles de la partida
 	nuevos_logros = {}
+	game.stats_game_id = None
 	if game_endcode != 99:
 		save_game_details(bot, game.print_roles(), game_endcode, game.board.state.liberal_track, game.board.state.fascist_track, game.board.num_players)
-		nuevos_logros = StatsExtended.save_extended_game_stats(game, game_endcode)
+		nuevos_logros, game.stats_game_id = StatsExtended.save_extended_game_stats(game, game_endcode)
 
 
 	#bot.send_message(cid, "Datos a guardar %s %s %s %s %s" % (game.print_roles(), str(game_endcode), str(game.board.state.liberal_track), str(game.board.state.fascist_track), str(game.board.num_players)))
@@ -968,12 +969,6 @@ def end_game(bot, game, game_endcode):
 				bot.send_message(cid, reveal, ParseMode.MARKDOWN)
 		except Exception as e:
 			log.error("No se pudo mostrar los resultados de las adivinanzas: %s" % str(e))
-		try:
-			mvp_reveal = Commands.format_mvp_reveal(game)
-			if mvp_reveal is not None:
-				bot.send_message(cid, mvp_reveal, ParseMode.MARKDOWN)
-		except Exception as e:
-			log.error("No se pudo mostrar la votación de MVP: %s" % str(e))
 		showHiddenhistory(bot, game)
 		try:
 			anuncio = Achievements.format_unlock_announcement(nuevos_logros, game)
@@ -981,8 +976,17 @@ def end_game(bot, game, game_endcode):
 				bot.send_message(cid, anuncio, ParseMode.MARKDOWN)
 		except Exception as e:
 			log.error("No se pudo anunciar los logros nuevos: %s" % str(e))
-	del GamesController.games[cid]
-	Commands.delete_game(cid)
+		bot.send_message(cid,
+			"🏅 ¡Ahora podés usar /mvp para votar en privado quién fue el MVP de esta partida! "
+			"Cuando todos los jugadores hayan votado se revela el resultado.")
+
+	if game_endcode == 99:
+		del GamesController.games[cid]
+		Commands.delete_game(cid)
+	else:
+		# La partida sigue viva (en memoria y en BD) hasta que todos voten su /mvp;
+		# recien ahi callback_mvp_vote la termina de borrar.
+		Commands.save_game(cid, game.groupName, game)
 	
 def showHiddenhistory(bot, game):	
 	#game.pedrote = 3

--- a/SecretHitler/StatsExtended.py
+++ b/SecretHitler/StatsExtended.py
@@ -25,10 +25,12 @@ def _connect():
 def save_extended_game_stats(game, game_endcode):
     # Guarda, ademas de lo que ya se guarda hoy, un registro por jugador vinculado a su uid,
     # y evalua/otorga logros nuevos con ese mismo registro ya escrito.
+    # El MVP todavia no se conoce en este punto (se vota despues de que termina la partida,
+    # ver finalize_mvp_stats), asi que la columna mvp arranca en False para todos.
     # No propaga excepciones: un fallo aca nunca debe impedir que end_game() termine su flujo normal.
-    # Devuelve {uid: [Logro nuevo, ...]} (vacio si no hubo logros nuevos, error, o game_endcode==99).
+    # Devuelve ({uid: [Logro nuevo, ...]}, game_id); ({}, None) si error o game_endcode==99.
     if game_endcode == 99:
-        return {}
+        return {}, None
     conn = None
     try:
         won_liberal = game_endcode in (1, 2)
@@ -41,8 +43,6 @@ def save_extended_game_stats(game, game_endcode):
             (game_endcode,)
         )
         game_id = cur.fetchone()[0]
-
-        mvp_uid = game.compute_mvp()
 
         for uid, player in game.playerlist.items():
             if player.party == "liberal":
@@ -57,15 +57,44 @@ def save_extended_game_stats(game, game_endcode):
                 "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) "
                 "ON CONFLICT (game_id, uid) DO NOTHING;",
                 (game_id, uid, player.name, player.role, player.party, won,
-                 player.is_dead, getattr(player, "killed_by_uid", None), uid == mvp_uid)
+                 player.is_dead, getattr(player, "killed_by_uid", None), False)
             )
 
         nuevos_por_uid = Achievements.evaluate_and_store(cur, game, game_endcode, game_id)
 
         conn.commit()
-        return nuevos_por_uid
+        return nuevos_por_uid, game_id
     except Exception as e:
         log.error("save_extended_game_stats failed: %s" % str(e))
+        return {}, None
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def finalize_mvp_stats(game):
+    # Se corre una vez que todos los jugadores de la partida ya votaron su /mvp
+    # (post-partida): marca al ganador en su fila de stats y recien ahi evalua
+    # los logros que dependen de mvp_count(), ya con el resultado definitivo de
+    # la votacion. No propaga excepciones.
+    # Devuelve {uid: [Logro nuevo, ...]} (vacio si no hubo, hubo empate, o error).
+    game_id = getattr(game, "stats_game_id", None)
+    mvp_uid = game.compute_mvp()
+    if game_id is None or mvp_uid is None:
+        return {}
+    conn = None
+    try:
+        conn = _connect()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE stats_secret_hitler_players SET mvp = TRUE WHERE game_id = %s AND uid = %s;",
+            (game_id, mvp_uid)
+        )
+        nuevos_por_uid = Achievements.evaluate_and_store(cur, game, game.board.state.game_endcode, game_id)
+        conn.commit()
+        return nuevos_por_uid
+    except Exception as e:
+        log.error("finalize_mvp_stats failed: %s" % str(e))
         return {}
     finally:
         if conn is not None:


### PR DESCRIPTION
## Summary
- `/mvp` now only works once a game has actually ended (rejects with a message if used mid-game).
- The game is no longer deleted the instant it ends — it now stays alive (in memory and DB) until every player has cast their MVP vote, so `/mvp` is genuinely usable after the match finishes. Votes stay changeable while votes are still missing.
- Once the last player votes, the group gets the full vote tally + MVP announcement (or a tie notice), the `mvp` column on that game's stats row is set, and the MVP-count achievements are evaluated against the now-final result — only then is the game actually deleted.
- `StatsExtended.save_extended_game_stats` no longer guesses the MVP at game-end time (the votes don't exist yet); the `mvp` column starts `False` for everyone. New `finalize_mvp_stats(game)` runs once voting completes to set the real winner and re-run achievement evaluation (idempotent — safe to re-run since already-unlocked achievements are skipped via the existing `ON CONFLICT DO NOTHING`).

## Test plan
- [x] `python3 -m py_compile` on all changed files
- [ ] Manual playtest: finish a game, confirm `/mvp` is rejected before it ends and accepted after; have all players vote and confirm the reveal + achievement announcement fire on the last vote, and that the game is cleaned up afterward

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_