### PR TITLE
Add /version command backed by a hardcoded VERSION constant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,8 @@ Key helpers used everywhere:
 
 `SecretHitler/` is a **self-contained** bot with its own `MainController`, `Commands`, `GamesController`, `Boardgamebox/`, `Constants/`, and DB connection. It shares only `Utils.command_status` from the root. It has its own `DBCreate.sql`, `requirements.txt`, and formerly its own Heroku/Jenkins deployment (`Procfile`, `Jenkinsfile`, `app.json`). It also has its own player stats layer: `PlayerStats.py` (per-user, per-game-type stats/achievements dict, persisted separately from game state) and `EstadisticsCalculator.py` (hypergeometric-distribution helpers for role-probability stats). At startup `main()` registers the bot's `/`-menu via `set_my_commands` — keep that list in sync when adding/removing commands.
 
+`Constants/Config.py` has a hardcoded `VERSION` string (starting at `1.0.0`), shown by `/version`. Bump it (semver) on every change committed to this bot — patch for fixes, minor for new commands/features, major for breaking changes.
+
 ### Config (`Constants/Config.py`)
 
 - `TOKEN`: main bot token (or set via DB)

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -17,7 +17,7 @@ from collections import namedtuple
 
 import SecretHitler.MainController as MainController
 import SecretHitler.GamesController as GamesController
-from SecretHitler.Constants.Config import ADMIN
+from SecretHitler.Constants.Config import ADMIN, VERSION
 from SecretHitler.Constants.Cards import opciones_choose_posible_role, playerSets
 from SecretHitler.Boardgamebox.Board import Board
 from SecretHitler.Boardgamebox.Game import Game
@@ -58,7 +58,8 @@ commands = [  # command description used in the "help" command
     '/logros - Muestra tus logros desbloqueados',
     '/guess - Adivina en privado quiénes son los fascistas y Hitler',
     '/mvp - Vota en privado al mejor jugador de la partida',
-    '/end - Cierra la votación de MVP sin esperar a que voten todos'
+    '/end - Cierra la votación de MVP sin esperar a que voten todos',
+    '/version - Muestra la versión actual del bot'
 ]
 
 symbols = [
@@ -156,6 +157,11 @@ def command_ping(update: Update, context: CallbackContext):
 	bot = context.bot
 	cid = update.message.chat_id
 	bot.send_message(cid, 'pong - v0.3')
+
+def command_version(update: Update, context: CallbackContext):
+	bot = context.bot
+	cid = update.message.chat_id
+	bot.send_message(cid, "Secret Hitler bot v%s" % VERSION)
 
 
 def get_stat_query(query, partidas_totales, partidas_fascista, partidas_hitler, partidas_liberal, partidas_murio, partidas_fascista_gano, partidas_hitler_gano, partidas_liberal_gano):

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -1,1 +1,5 @@
 ADMIN = 387393551 #your telegram ID
+
+# Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
+# despliegue (ver convencion en CLAUDE.md).
+VERSION = "1.0.0"

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -1313,6 +1313,7 @@ def main():
 	dp.add_handler(CommandHandler("board", Commands.command_board))
 	dp.add_handler(CommandHandler("rules", Commands.command_rules))
 	dp.add_handler(CommandHandler("ping", Commands.command_ping))
+	dp.add_handler(CommandHandler("version", Commands.command_version))
 	dp.add_handler(CommandHandler("symbols", Commands.command_symbols))
 	dp.add_handler(CommandHandler("stats", Commands.command_stats))
 	dp.add_handler(CommandHandler("stats2", Commands.command_stats2))
@@ -1422,6 +1423,7 @@ def main():
 			BotCommand("guess", "Adivina en privado quienes son los fascistas y Hitler"),
 			BotCommand("mvp", "Vota en privado al mejor jugador de la partida"),
 			BotCommand("end", "Cierra la votacion de MVP sin esperar a que voten todos"),
+			BotCommand("version", "Muestra la version actual del bot"),
 		])
 	except Exception as e:
 		log.error(str(e))


### PR DESCRIPTION
## Summary
- Adds `/version`, which replies with a hardcoded version string.
- Adds `VERSION = "1.0.0"` to `SecretHitler/Constants/Config.py` as the source of truth.
- Documents the convention in `CLAUDE.md`: bump `VERSION` (semver) on every future change to the SecretHitler bot.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual check: run `/version` in the bot and confirm it replies "Secret Hitler bot v1.0.0"

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_