### PR TITLE
Fix /mvp rejecting the game after liberals win by killing Hitler

### DIFF
--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.0.0"
+VERSION = "1.0.1"

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -594,6 +594,7 @@ def choose_kill(update: Update, context: CallbackContext):
         bot.edit_message_text("Has matado a %s!" % chosen.name, callback.from_user.id, callback.message.message_id)
         if chosen.role == "Hitler":
             bot.send_message(game.cid, "El Presidente " + game.board.state.president.name + " ha matado a " + chosen.name + ". ")
+            game.board.state.game_endcode = 2
             end_game(bot, game, 2)
         else:
             bot.send_message(game.cid,


### PR DESCRIPTION
## Summary
- Bug: after liberals win by killing Hitler, `/mvp` (and `/end`, `/calltovote`'s MVP reminder) incorrectly said "Todavía no terminó la partida" even though the game had genuinely ended.
- Root cause: `choose_kill()` calls `end_game(bot, game, 2)` with a literal `game_endcode` but never sets `game.board.state.game_endcode` to match. Every other win path (`-2`, `-1`, `1`) sets that field before calling `end_game()`; this one didn't. Since `/mvp`/`/end`/`/calltovote`'s post-game gating checks `game.board.state.game_endcode != 0`, this specific win condition was silently treated as "still in progress."
- Fix: set `game.board.state.game_endcode = 2` right before the `end_game(bot, game, 2)` call in `choose_kill()`, matching the other three win paths.
- Bumps `VERSION` to `1.0.1` per the versioning convention.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual playtest: win a game by killing Hitler as the liberal team, then confirm `/mvp` accepts votes immediately afterward

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_