### PR TITLE
Self-heal stuck kill-Hitler games and fix "Primera vez" achievement

### DIFF
--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -664,7 +664,7 @@ def command_calltovote(update: Update, context: CallbackContext):
 		#Check if there is a current game
 		game = get_game(cid)
 		if game:
-			if game.board is not None and game.board.state.game_endcode != 0:
+			if game.board is not None and _game_has_ended(game):
 				# La partida ya termino y esta esperando los votos de /mvp.
 				faltan = [p for u, p in game.playerlist.items() if u not in getattr(game, "mvp_votes", {})]
 				if not faltan:
@@ -2108,6 +2108,28 @@ def format_guesses_reveal(game):
 	return "\n".join(lineas)
 
 
+def _repair_game_endcode_if_needed(game):
+	# Cura partidas afectadas por un bug historico (choose_kill no seteaba
+	# game.board.state.game_endcode) donde la partida ya termino y sus stats
+	# ya se guardaron (stats_game_id seteado), pero el codigo quedo en 0.
+	if game.board is None or game.board.state is None:
+		return
+	if game.board.state.game_endcode != 0:
+		return
+	game_id = getattr(game, "stats_game_id", None)
+	if game_id is None:
+		return
+	real_endcode = StatsExtended.get_game_endcode(game_id)
+	if real_endcode:
+		game.board.state.game_endcode = real_endcode
+		save_game(game.cid, game.groupName, game)
+
+def _game_has_ended(game):
+	if game.board is None or game.board.state is None:
+		return False
+	_repair_game_endcode_if_needed(game)
+	return game.board.state.game_endcode != 0
+
 def command_mvp(update: Update, context: CallbackContext):
 	bot = context.bot
 	uid = update.message.from_user.id
@@ -2122,7 +2144,7 @@ def command_mvp(update: Update, context: CallbackContext):
 		if uid not in game.playerlist:
 			bot.send_message(cid, "Debes ser un jugador de la partida para usar /mvp.")
 			return
-		if game.board.state.game_endcode == 0:
+		if not _game_has_ended(game):
 			bot.send_message(cid, "Todavía no terminó la partida. Esperá a que termine para votar al MVP.")
 			return
 		bot.send_message(cid, "Te mandé un mensaje privado para que votes al MVP. ¡Revisa tu chat privado conmigo!")
@@ -2132,7 +2154,7 @@ def command_mvp(update: Update, context: CallbackContext):
 		all_games = {
 			key: "{}: {}".format(game.groupName, game.tipo)
 			for key, game in all_games_unfiltered.items()
-			if uid in game.playerlist and game.board is not None and game.board.state.game_endcode != 0
+			if uid in game.playerlist and game.board is not None and _game_has_ended(game)
 		}
 		if not all_games:
 			bot.send_message(cid, "No tenés partidas recién terminadas donde votar al MVP.")
@@ -2159,7 +2181,7 @@ def callback_mvp_game(update: Update, context: CallbackContext):
 	_send_mvp_buttons(bot, game, uid)
 
 def _send_mvp_buttons(bot, game, uid):
-	if game.board.state.game_endcode == 0:
+	if not _game_has_ended(game):
 		bot.send_message(uid, "Todavía no terminó la partida. Esperá a que termine para votar al MVP.")
 		return
 	strcid = str(game.cid)
@@ -2197,7 +2219,7 @@ def callback_mvp_vote(update: Update, context: CallbackContext):
 	if uid not in game.playerlist:
 		bot.send_message(uid, "Debes ser un jugador de la partida para votar.")
 		return
-	if game.board.state.game_endcode == 0:
+	if not _game_has_ended(game):
 		bot.send_message(uid, "Todavía no terminó la partida. Esperá a que termine para votar al MVP.")
 		return
 	if candidate_uid == uid:
@@ -2266,7 +2288,7 @@ def command_end(update: Update, context: CallbackContext):
 	if uid not in game.playerlist:
 		bot.send_message(cid, "Debes ser un jugador de la partida para usar /end.")
 		return
-	if game.board.state.game_endcode == 0:
+	if not _game_has_ended(game):
 		bot.send_message(cid, "La partida todavía no terminó, no hay nada que cerrar.")
 		return
 

--- a/SecretHitler/Constants/Achievements.py
+++ b/SecretHitler/Constants/Achievements.py
@@ -66,7 +66,11 @@ def _check_cazador_de_hitler(ctx):
 
 
 def _check_primera_partida(ctx):
-    return len(ctx.history()) == 1
+    # >=1 (no ==1): si el primer registro de un jugador vino de una migracion
+    # legacy (/vincularstats) o de antes de que existiera este logro, el
+    # momento exacto en que history() valia 1 nunca se evaluo, y con ==1
+    # el logro quedaba inalcanzable para siempre.
+    return len(ctx.history()) >= 1
 
 
 def _check_veterano(ctx):

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.0.1"
+VERSION = "1.0.2"

--- a/SecretHitler/StatsExtended.py
+++ b/SecretHitler/StatsExtended.py
@@ -72,6 +72,20 @@ def save_extended_game_stats(game, game_endcode):
             conn.close()
 
 
+def get_game_endcode(game_id):
+    # Consulta el game_endcode real guardado para una partida ya finalizada.
+    # Se usa para reparar partidas donde game.board.state.game_endcode quedo
+    # en 0 pese a haber terminado (ver Commands._repair_game_endcode_if_needed).
+    conn = _connect()
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT game_endcode FROM stats_secret_hitler_games WHERE id = %s;", (game_id,))
+        row = cur.fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
 def finalize_mvp_stats(game):
     # Se corre una vez que todos los jugadores de la partida ya votaron su /mvp
     # (post-partida): marca al ganador en su fila de stats y recien ahi evalua


### PR DESCRIPTION
## Summary
- Follow-up to #211: that fix only covers new kill-Hitler wins going forward. Games that already ended that way before the fix deployed are still persisted with `game.board.state.game_endcode == 0`, so `/mvp`, `/end`, and `/calltovote` kept rejecting them.
- `/mvp`-related gating now goes through a new `_game_has_ended(game)` helper. It detects this exact situation — `game_endcode == 0` but `stats_game_id` already set (meaning `end_game()` genuinely ran and stats were saved using the correct code) — and repairs the field by looking up the real `game_endcode` from `stats_secret_hitler_games`. No manual admin action needed; it self-heals the next time anyone touches `/mvp`, `/end`, or `/calltovote` on that game.
- Fixes **"Primera vez"**: it checked `len(history) == 1`, which only ever evaluates true on the exact game where a player's history first reaches length 1. Anyone whose first tracked row came from a `/vincularstats` legacy migration (inserts directly, skips achievement evaluation) or predates this achievement's existence could never unlock it — even with Veterano/Leyenda already earned, which is exactly the inconsistency reported. Changed to `>= 1` to match the same pattern `Veterano`/`Leyenda` already use.
- Bumps `VERSION` to `1.0.2`.

## Test plan
- [x] `python3 -m py_compile` on all changed files
- [ ] Manual check: run `/mvp` on the already-stuck kill-Hitler game and confirm it now accepts votes; confirm a player with Veterano/Leyenda gets "Primera vez" on their next completed game

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_