### PR TITLE
Add achievements for being executed 3, 5, and 10 times

### DIFF
--- a/SecretHitler/Constants/Achievements.py
+++ b/SecretHitler/Constants/Achievements.py
@@ -65,6 +65,18 @@ def _check_cazador_de_hitler(ctx):
     return sum(1 for role in ctx.kills_history() if role == "Hitler") >= 2
 
 
+def _check_gafe(ctx):
+    return sum(1 for row in ctx.history() if row[3]) >= 3  # row[3] = died
+
+
+def _check_carne_de_canon(ctx):
+    return sum(1 for row in ctx.history() if row[3]) >= 5
+
+
+def _check_alma_en_pena(ctx):
+    return sum(1 for row in ctx.history() if row[3]) >= 10
+
+
 def _check_primera_partida(ctx):
     # >=1 (no ==1): si el primer registro de un jugador vino de una migracion
     # legacy (/vincularstats) o de antes de que existiera este logro, el
@@ -207,6 +219,12 @@ LOGROS = [
           "🛡", "muerte", False, _check_intocable),
     Logro("cazador_de_hitler", "Cazador de Hitler", "Ejecutaste a Hitler en 2 partidas distintas.",
           "🎯", "muerte", False, _check_cazador_de_hitler),
+    Logro("gafe", "Gafe", "Te ejecutaron 3 veces en total.",
+          "💀", "muerte", False, _check_gafe),
+    Logro("carne_de_canon", "Carne de cañón", "Te ejecutaron 5 veces en total.",
+          "⚰️", "muerte", False, _check_carne_de_canon),
+    Logro("alma_en_pena", "Alma en pena", "Te ejecutaron 10 veces en total.",
+          "👻", "muerte", False, _check_alma_en_pena),
 
     # Hitos
     Logro("primera_partida", "Primera vez", "Jugaste tu primera partida.",

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.0.2"
+VERSION = "1.1.0"


### PR DESCRIPTION
## Summary
- Adds three new "muerte" achievements based on cumulative execution count across a player's history:
  - **Gafe** 💀 — executed 3 times total
  - **Carne de cañón** ⚰️ — executed 5 times total
  - **Alma en pena** 👻 — executed 10 times total
- Same pattern already used by `Veterano`/`Leyenda` (cumulative counts via `ctx.history()`), plugged into the existing achievements pipeline (`/logros`, unlock announcements).
- Bumps `VERSION` to `1.1.0` per the versioning convention.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual check: a player executed 3+/5+/10+ times across games unlocks the corresponding achievement on their next finished game, visible in `/logros`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_