### PR TITLE
Add /admin command with a "first" backfill button for Primera vez

### DIFF
--- a/SecretHitler/Achievements.py
+++ b/SecretHitler/Achievements.py
@@ -147,6 +147,30 @@ def evaluate_and_store(cur, game, game_endcode, game_id):
     return nuevos_por_uid
 
 
+def backfill_primera_partida():
+    # Otorga retroactivamente "primera_partida" a todo uid con al menos una
+    # partida registrada que todavia no lo tenga. El check de ese logro paso
+    # de ==1 a >=1 (ver Constants/Achievements.py), pero esa correccion solo
+    # se evalua en la proxima partida de cada jugador; esto lo resuelve ya
+    # mismo para quienes no vuelvan a jugar pronto. game_id queda NULL
+    # porque no esta atado a ninguna partida puntual (uso admin, ver /admin).
+    conn = _connect()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO achievements_secret_hitler_players (uid, achievement_code, game_id) "
+            "SELECT DISTINCT uid, 'primera_partida', NULL "
+            "FROM stats_secret_hitler_players "
+            "ON CONFLICT (uid, achievement_code) DO NOTHING "
+            "RETURNING uid;"
+        )
+        nuevos_uids = [row[0] for row in cur.fetchall()]
+        conn.commit()
+        return nuevos_uids
+    finally:
+        conn.close()
+
+
 def get_unlocked_codes(uid):
     conn = _connect()
     try:

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -458,6 +458,38 @@ def command_vincularstats2(update: Update, context: CallbackContext):
 
 	bot.send_message(cid, "\n".join(resultados))
 
+def command_admin(update: Update, context: CallbackContext):
+	bot = context.bot
+	cid = update.message.chat_id
+	uid = update.message.from_user.id
+	if uid != ADMIN:
+		return
+	btns = [
+		[InlineKeyboardButton("first", callback_data="admin_first")],
+	]
+	markup = InlineKeyboardMarkup(btns)
+	bot.send_message(cid, "🛠 *Panel de administración*", reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
+def callback_admin_first(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_admin_first called')
+	callback = update.callback_query
+	uid = callback.from_user.id
+	if uid != ADMIN:
+		return
+	try:
+		nuevos_uids = Achievements.backfill_primera_partida()
+	except Exception as e:
+		bot.send_message(uid, "Error al correr el backfill: %s" % str(e))
+		return
+	if nuevos_uids:
+		texto = "✅ Se otorgó *Primera vez* retroactivamente a {} jugador{}.".format(
+			len(nuevos_uids), "" if len(nuevos_uids) == 1 else "es")
+	else:
+		texto = "✅ No había nadie pendiente, todos los que califican ya tenían el logro."
+	bot.edit_message_text(texto, chat_id=callback.message.chat_id, message_id=callback.message.message_id,
+		parse_mode=ParseMode.MARKDOWN)
+
 # help page
 def command_help(update: Update, context: CallbackContext):
 	bot = context.bot

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.1.0"
+VERSION = "1.2.0"

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -1332,6 +1332,8 @@ def main():
 	dp.add_handler(CommandHandler("end", Commands.command_end))
 	dp.add_handler(CommandHandler("vincularstats", Commands.command_vincularstats))
 	dp.add_handler(CommandHandler("vincularstats2", Commands.command_vincularstats2))
+	dp.add_handler(CommandHandler("admin", Commands.command_admin))
+	dp.add_handler(CallbackQueryHandler(pattern=r"^admin_first$", callback=Commands.callback_admin_first))
 	dp.add_handler(CommandHandler("newgame", Commands.command_newgame))
 	dp.add_handler(CommandHandler("startgame", Commands.command_startgame))
 	dp.add_handler(CommandHandler("cancelgame", Commands.command_cancelgame))


### PR DESCRIPTION
## Summary
- Adds `/admin`, restricted to `ADMIN` (matches the existing `/fix*` admin-only pattern — silently no-ops for anyone else, not listed in the public commands help or the Telegram `/` menu).
- First button: **first** — runs a one-shot SQL backfill (`Achievements.backfill_primera_partida()`) that retroactively grants "Primera vez" to every uid with at least one recorded game who doesn't already have it.
- Why this is needed: the earlier fix to `_check_primera_partida` (`>=1` instead of `==1`, #212) only takes effect the next time each affected player finishes a game — it doesn't retroactively grant the achievement to players who are already eligible but haven't played since. This button closes that gap immediately via a single `INSERT ... SELECT DISTINCT ... ON CONFLICT DO NOTHING` (with `game_id` left `NULL`, per the existing schema comment for backfills-outside-a-game).
- Bumps `VERSION` to `1.2.0`.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual check: run `/admin` as the bot admin, tap **first**, confirm it reports how many players got backfilled, and that `/logros` shows "Primera vez" unlocked for a previously-affected player without them needing to play another game

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_