### PR TITLE
Add /admin button to revoke wrongly-granted Misión Imposible unlocks

### DIFF
--- a/SecretHitler/Achievements.py
+++ b/SecretHitler/Achievements.py
@@ -180,6 +180,38 @@ def backfill_primera_partida():
         conn.close()
 
 
+def cleanup_mision_imposible():
+    # Revoca "mision_imposible" a quien lo tenga sin cumplir la regla actual
+    # (ganar Y estar en el mismo equipo que MISION_IMPOSIBLE_UID, sin contar
+    # a esa misma uid). El logro se otorgaba antes solo por compartir
+    # partida con esa uid sin chequear equipo; esto limpia lo mal otorgado
+    # con esa regla vieja. Uso admin, ver /admin.
+    conn = _connect()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "DELETE FROM achievements_secret_hitler_players a "
+            "USING stats_secret_hitler_players sp "
+            "WHERE a.achievement_code = 'mision_imposible' "
+            "AND sp.uid = a.uid AND sp.game_id = a.game_id "
+            "AND ("
+            "  a.uid = %(mi_uid)s "
+            "  OR NOT sp.won "
+            "  OR NOT EXISTS ("
+            "    SELECT 1 FROM stats_secret_hitler_players mi "
+            "    WHERE mi.game_id = sp.game_id AND mi.uid = %(mi_uid)s AND mi.party = sp.party"
+            "  )"
+            ") "
+            "RETURNING a.uid;",
+            {"mi_uid": MISION_IMPOSIBLE_UID}
+        )
+        removed_uids = [row[0] for row in cur.fetchall()]
+        conn.commit()
+        return removed_uids
+    finally:
+        conn.close()
+
+
 def get_unlocked_codes(uid):
     conn = _connect()
     try:

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -466,6 +466,7 @@ def command_admin(update: Update, context: CallbackContext):
 		return
 	btns = [
 		[InlineKeyboardButton("first", callback_data="admin_first")],
+		[InlineKeyboardButton("cleanup mision imposible", callback_data="admin_cleanup_mision")],
 	]
 	markup = InlineKeyboardMarkup(btns)
 	bot.send_message(cid, "🛠 *Panel de administración*", reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
@@ -487,6 +488,26 @@ def callback_admin_first(update: Update, context: CallbackContext):
 			len(nuevos_uids), "" if len(nuevos_uids) == 1 else "es")
 	else:
 		texto = "✅ No había nadie pendiente, todos los que califican ya tenían el logro."
+	bot.edit_message_text(texto, chat_id=callback.message.chat_id, message_id=callback.message.message_id,
+		parse_mode=ParseMode.MARKDOWN)
+
+def callback_admin_cleanup_mision(update: Update, context: CallbackContext):
+	bot = context.bot
+	log.info('callback_admin_cleanup_mision called')
+	callback = update.callback_query
+	uid = callback.from_user.id
+	if uid != ADMIN:
+		return
+	try:
+		removed_uids = Achievements.cleanup_mision_imposible()
+	except Exception as e:
+		bot.send_message(uid, "Error al correr la limpieza: %s" % str(e))
+		return
+	if removed_uids:
+		texto = "🧹 Se quitó *Misión Imposible* a {} jugador{} que no cumplían la regla correcta.".format(
+			len(removed_uids), "" if len(removed_uids) == 1 else "es")
+	else:
+		texto = "🧹 No había nadie con el logro mal otorgado."
 	bot.edit_message_text(texto, chat_id=callback.message.chat_id, message_id=callback.message.message_id,
 		parse_mode=ParseMode.MARKDOWN)
 

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.2.1"
+VERSION = "1.3.0"

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -1334,6 +1334,7 @@ def main():
 	dp.add_handler(CommandHandler("vincularstats2", Commands.command_vincularstats2))
 	dp.add_handler(CommandHandler("admin", Commands.command_admin))
 	dp.add_handler(CallbackQueryHandler(pattern=r"^admin_first$", callback=Commands.callback_admin_first))
+	dp.add_handler(CallbackQueryHandler(pattern=r"^admin_cleanup_mision$", callback=Commands.callback_admin_cleanup_mision))
 	dp.add_handler(CommandHandler("newgame", Commands.command_newgame))
 	dp.add_handler(CommandHandler("startgame", Commands.command_startgame))
 	dp.add_handler(CommandHandler("cancelgame", Commands.command_cancelgame))


### PR DESCRIPTION
## Summary
- Before the team-membership fix (#215), "Misión Imposible" unlocked for any winner as long as `MISION_IMPOSIBLE_UID` played the game at all, regardless of team.
- Adds a second `/admin` button, **cleanup mision imposible**, backed by `Achievements.cleanup_mision_imposible()`: a single `DELETE ... USING` join against `stats_secret_hitler_players` that removes every existing grant unless the holder actually won while on the same team as `MISION_IMPOSIBLE_UID` (and isn't that uid themselves).
- Bumps `VERSION` to `1.3.0`.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual check: run `/admin` → **cleanup mision imposible**, confirm it reports how many were revoked, and that `/logros` no longer shows the achievement for players who only shared a game with `MISION_IMPOSIBLE_UID` without being on their team

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_