### PR TITLE
Fix /admin "first" backfill NULL type error

### DIFF
--- a/SecretHitler/Achievements.py
+++ b/SecretHitler/Achievements.py
@@ -168,7 +168,7 @@ def backfill_primera_partida():
         cur = conn.cursor()
         cur.execute(
             "INSERT INTO achievements_secret_hitler_players (uid, achievement_code, game_id) "
-            "SELECT DISTINCT uid, 'primera_partida', NULL "
+            "SELECT DISTINCT uid, 'primera_partida', NULL::integer "
             "FROM stats_secret_hitler_players "
             "ON CONFLICT (uid, achievement_code) DO NOTHING "
             "RETURNING uid;"

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.3.0"
+VERSION = "1.3.1"


### PR DESCRIPTION
## Summary
- `/admin` → **first** was failing with `column "game_id" is of type integer but expression is of type text`.
- Postgres couldn't infer the type of the bare `NULL` in `SELECT DISTINCT uid, 'primera_partida', NULL FROM ...` and defaulted it to `text`, which then failed to insert into the integer `game_id` column.
- Fix: explicit `NULL::integer` cast.
- Bumps `VERSION` to `1.3.1`.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual check: run `/admin` → **first** again and confirm it succeeds instead of erroring

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_