### PR TITLE
BSG: /bsgadmin - dar a un jugador el resultado de una Sonda exitosa

### DIFF
--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -1788,6 +1788,7 @@ async def command_bsgadmin(update: Update, context: CallbackContext):
         [InlineKeyboardButton("🛸 Corregir Raiders en un área", callback_data=f"{cid}*bsgAdmin*fix_raiders*{uid}")],
         [InlineKeyboardButton("🤖 Activar naves Cylon", callback_data=f"{cid}*bsgAdmin*activar_cylon*{uid}")],
         [InlineKeyboardButton("🃏 Quitar carta a un jugador", callback_data=f"{cid}*bsgAdmin*quitar_carta*{uid}")],
+        [InlineKeyboardButton("🔭 Dar resultado de Sonda exitosa", callback_data=f"{cid}*bsgAdmin*dar_scout*{uid}")],
     ]
     await bot.send_message(cid, "🛠️ *Panel de Admin (BSG)* — ¿qué querés corregir?",
                            reply_markup=InlineKeyboardMarkup(btns), parse_mode=ParseMode.MARKDOWN)
@@ -1833,6 +1834,13 @@ async def callback_bsg_admin(update: Update, context: CallbackContext):
                 await bot.send_message(cid, "No hay jugadores en la partida.")
                 return
             texto = "🃏 ¿A qué jugador le querés quitar una carta?"
+        elif opcion == "dar_scout":
+            btns = [[InlineKeyboardButton(p.name, callback_data=f"{cid}*bsgAdminScout*{p_uid}*{presser}")]
+                    for p_uid, p in game.playerlist.items()]
+            if not btns:
+                await bot.send_message(cid, "No hay jugadores en la partida.")
+                return
+            texto = "🔭 ¿A qué jugador le das el resultado de una Sonda exitosa?"
         else:
             return
 
@@ -1968,6 +1976,44 @@ async def callback_bsg_admin_cylon(update: Update, context: CallbackContext):
         except Exception:
             pass
         await bot.send_message(ADMIN[0], f"BSG admin cylon error: {e}")
+
+
+async def callback_bsg_admin_scout(update: Update, context: CallbackContext):
+    """Elegido el jugador: le otorga el resultado de una Sonda exitosa
+    (mirar el mazo de Crisis o de Destino), sin tirada ni gasto de Raptor."""
+    bot = context.bot
+    callback = update.callback_query
+    presser = callback.from_user.id
+    try:
+        regex = re.search(r"(-?[0-9]*)\*bsgAdminScout\*(-?[0-9]*)\*(-?[0-9]*)", callback.data)
+        cid = int(regex.group(1))
+        objetivo = int(regex.group(2))
+        ordenante = int(regex.group(3))
+        game = get_game(cid)
+        if not _validar(game):
+            await callback.answer("Partida no encontrada.")
+            return
+        if presser != ordenante or presser != ADMIN[0]:
+            await callback.answer("No puedes usar este panel.")
+            return
+        p = game.playerlist.get(objetivo)
+        if not p:
+            await callback.answer("Jugador no encontrado.")
+            return
+        await callback.answer()
+        try:
+            await bot.edit_message_text(f"🔭 Dando a {p.name} el resultado de una Sonda exitosa…",
+                                        cid, callback.message.message_id)
+        except Exception:
+            pass
+        await BSGController.otorgar_resultado_scout(bot, game, objetivo)
+    except Exception as e:
+        logger.error(f"callback_bsg_admin_scout error: {e}")
+        try:
+            await callback.answer("Error.")
+        except Exception:
+            pass
+        await bot.send_message(ADMIN[0], f"BSG admin scout error: {e}")
 
 
 async def callback_bsg_admin_carta_jugador(update: Update, context: CallbackContext):

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -3168,6 +3168,28 @@ async def resolver_scout_roll(bot, game, uid):
     return True
 
 
+async def otorgar_resultado_scout(bot, game, uid):
+    """Herramienta de admin: le da a un jugador el resultado de una Sonda
+    exitosa (elegir el mazo de Crisis o de Destino y decidir si la carta de
+    arriba se mantiene o va al fondo), sin tirada ni gasto de Raptor — para
+    cuando la carta no llegó a jugarse en la partida pero corresponde
+    dársela igual. Reusa el mismo paso que sigue a una tirada exitosa real."""
+    st = game.board.state
+    player = game.playerlist[uid]
+    st.play_pending = {"tipo": "scout_deck", "uid": uid}
+    btns = [[InlineKeyboardButton("⚠️ Mazo de Crisis", callback_data=f"{game.cid}*bsgScoutMazo*crisis*{uid}"),
+             InlineKeyboardButton("🔮 Mazo de Destino", callback_data=f"{game.cid}*bsgScoutMazo*destino*{uid}")]]
+    await bot.send_message(
+        game.cid,
+        f"🔭 El admin le da a {player_call(player)} el resultado de una *Sonda exitosa*: puede mirar la carta "
+        f"de arriba del mazo de *Crisis* o de *Destino* y decidir si la deja arriba o la manda al fondo. "
+        f"¿Qué mazo mira?",
+        reply_markup=InlineKeyboardMarkup(btns),
+        parse_mode=ParseMode.MARKDOWN,
+    )
+    await save(bot, game.cid)
+
+
 async def elegir_mazo_scout(bot, game, uid, mazo_key):
     """Elegido el mazo a mirar tras una Sonda exitosa: anuncia la elección en
     público y revela la carta de arriba por privado, con la elección de

--- a/MainController.py
+++ b/MainController.py
@@ -860,6 +860,7 @@ def main(stop_event):
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgAdminCylon\*(raiders|heavy_raiders|launch_raiders)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_admin_cylon))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgAdminCartaJug\*(-?[0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_admin_carta_jugador))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgAdminCarta\*(-?[0-9]+)_([0-9]+)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_admin_carta))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgAdminScout\*(-?[0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_admin_scout))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgPick\*([a-z_]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_pick))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgDraw\*([A-Za-z]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_draw))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgSetup\*([A-Za-z]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_setup))


### PR DESCRIPTION
## Summary
- Adds a new option to the `/bsgadmin` panel: **"🔭 Dar resultado de Sonda exitosa"**, for when a player was owed a successful Sonda (Launch Scout) result that never came up in the actual game session, and it has to be granted manually.
- Flow: pick the player → they're directly granted the step that follows a successful roll (choose Crisis or Destino deck, see the top card privately, decide keep-on-top or send-to-bottom) — **no roll, no Raptor spent**.
- `Controller.otorgar_resultado_scout(bot, game, uid)` sets up the exact same `play_pending` state and `bsgScoutMazo` buttons that the real post-success flow uses, so the rest of the interaction (deck choice, peek, top/bottom decision) is handled entirely by the existing Sonda code — no duplicated logic.
- New callback `callback_bsg_admin_scout` wired in `MainController.py` alongside the rest of the `bsgAdmin` panel.

## Test plan
- [x] `python3 -m py_compile` clean on all three changed files.
- [x] Verified the new `bsgAdminScout` callback pattern doesn't cross-match any of the other 114 registered callback patterns.
- [x] Simulated end-to-end: admin menu → dar_scout → pick a player → public announcement mentioning that player, `raptors_reserva` unchanged (no cost) → the player picks Crisis/Destino via the normal existing flow → gets the private peek DM → decides top/bottom via the existing `carta_scout_resolve`, which correctly clears `play_pending`. Also verified non-admin rejection.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am)_