### PR TITLE
Registra fecha/hora de cada /guess y ajusta el puntaje de Liberales

### DIFF
--- a/SecretHitler/Achievements.py
+++ b/SecretHitler/Achievements.py
@@ -168,7 +168,7 @@ def backfill_primera_partida():
         cur = conn.cursor()
         cur.execute(
             "INSERT INTO achievements_secret_hitler_players (uid, achievement_code, game_id) "
-            "SELECT DISTINCT uid, 'primera_partida', NULL "
+            "SELECT DISTINCT uid, 'primera_partida', NULL::integer "
             "FROM stats_secret_hitler_players "
             "ON CONFLICT (uid, achievement_code) DO NOTHING "
             "RETURNING uid;"

--- a/SecretHitler/Boardgamebox/Game.py
+++ b/SecretHitler/Boardgamebox/Game.py
@@ -60,12 +60,31 @@ class Game(object):
 			return None
 		return top[0]
 
-	def compute_best_guessers(self):
-		# Devuelve el conjunto de uids de Liberales con mas aciertos en el /guess
-		# "completo" (fascistas comunes + Hitler). Vacio si ningun liberal adivino.
+	def compute_guess_score(self, guess):
+		# Puntaje de un palpito "completo" (fascistas comunes + Hitler) de /guess.
+		# +1 por cada acierto de equipo fascista (fascista comun o el propio Hitler),
+		# sin importar si se lo marco en la lista de fascistas o en la casilla de
+		# Hitler; +2 puntos adicionales si se acierta exactamente a Hitler en su casilla.
+		# Compartido entre el ranking de /guess y el texto de revelacion de fin de
+		# partida para que no puedan desincronizarse.
 		hitler = self.get_hitler()
 		hitler_uid = hitler.uid if hitler else None
 		fascist_uids = {f.uid for f in self.get_fascists()}
+		fascist_team_uids = fascist_uids | ({hitler_uid} if hitler_uid is not None else set())
+
+		guessed_fascist_uids = {u for u in guess.get("fascists", []) if u in self.playerlist}
+		guessed_hitler_uid = guess.get("hitler")
+
+		score = len([u for u in guessed_fascist_uids if u in fascist_team_uids])
+		if guessed_hitler_uid in fascist_team_uids:
+			score += 1
+		if guessed_hitler_uid is not None and guessed_hitler_uid == hitler_uid:
+			score += 2
+		return score
+
+	def compute_best_guessers(self):
+		# Devuelve el conjunto de uids de Liberales con mas puntaje en el /guess
+		# "completo" (fascistas comunes + Hitler). Vacio si ningun liberal adivino.
 		guesses = getattr(self, "guesses", {})
 
 		scores = {}
@@ -75,12 +94,7 @@ class Game(object):
 			guesser = self.playerlist.get(guesser_uid)
 			if guesser is None or guesser.role != "Liberal":
 				continue
-			guess = history[-1]
-			guessed_fascist_uids = [u for u in guess.get("fascists", []) if u in self.playerlist]
-			guessed_hitler_uid = guess.get("hitler")
-			aciertos = len([u for u in guessed_fascist_uids if u in fascist_uids])
-			acierto_hitler = 1 if (guessed_hitler_uid is not None and guessed_hitler_uid == hitler_uid) else 0
-			scores[guesser_uid] = aciertos + acierto_hitler
+			scores[guesser_uid] = self.compute_guess_score(history[-1])
 
 		if not scores:
 			return set()

--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -2037,6 +2037,8 @@ def callback_guess_confirm(update: Update, context: CallbackContext):
 			return
 		entry = {"fascists": list(progress["fascists"]), "hitler": progress["hitler"]}
 
+	entry["timestamp"] = datetime.datetime.now()
+
 	if not hasattr(game, "guesses"):
 		game.guesses = {}
 	history = list(game.guesses.get(uid, []))
@@ -2045,12 +2047,14 @@ def callback_guess_confirm(update: Update, context: CallbackContext):
 	save_game(game.cid, game.groupName, game)
 	del GamesController.guess_progress[(cid, uid)]
 
+	fecha_registro = entry["timestamp"].strftime("%d/%m/%Y %H:%M")
 	if len(history) >= 2:
 		texto_final = ("✅ ¡Listo! Esta era tu segunda vez, así que tu palpito quedó *definitivo* y ya no se puede cambiar. "
-			"Se revelará al final de la partida quién estuvo más cerca de la verdad.")
+			"Quedó registrado el {}. "
+			"Se revelará al final de la partida quién estuvo más cerca de la verdad.").format(fecha_registro)
 	else:
-		texto_final = ("✅ ¡Listo! Tu palpito quedó guardado. Podés usar /guess una vez más para cambiarlo "
-			"(la segunda vez es definitiva). Se revelará al final de la partida quién estuvo más cerca de la verdad.")
+		texto_final = ("✅ ¡Listo! Tu palpito quedó guardado (registrado el {}). Podés usar /guess una vez más para cambiarlo "
+			"(la segunda vez es definitiva). Se revelará al final de la partida quién estuvo más cerca de la verdad.").format(fecha_registro)
 
 	bot.edit_message_text(texto_final, chat_id=callback.message.chat_id, message_id=callback.message.message_id,
 		parse_mode=ParseMode.MARKDOWN)
@@ -2098,6 +2102,9 @@ def format_guesses_reveal(game):
 		if guesser is None:
 			continue
 		nota_cambio = " _(cambió su palpito una vez)_" if len(history) > 1 else ""
+		timestamp = guess.get("timestamp")
+		nota_fecha = " _({})_".format(timestamp.strftime("%d/%m/%Y %H:%M")) if timestamp else ""
+		nota_cambio += nota_fecha
 
 		if guesser.role == "Hitler":
 			guessed_fascist_uids = [u for u in guess.get("fascists", []) if u in game.playerlist]
@@ -2122,15 +2129,16 @@ def format_guesses_reveal(game):
 
 		aciertos_fascistas = [u for u in guessed_fascist_uids if u in fascist_uids]
 		hitler_acierto = guessed_hitler_uid is not None and guessed_hitler_uid == hitler_uid
-		score = len(aciertos_fascistas) + (1 if hitler_acierto else 0)
+		score = game.compute_guess_score(guess)
 
 		nombres_fascistas = ", ".join(game.playerlist[u].name for u in guessed_fascist_uids) or "nadie"
 		nombre_hitler = game.playerlist[guessed_hitler_uid].name if guessed_hitler_uid in game.playerlist else "nadie"
 
-		texto = "*{}* sospechó de: {} y dijo que Hitler era *{}*{}\n   ↳ Acertó {}/{} fascistas comunes, {} a Hitler".format(
+		texto = "*{}* sospechó de: {} y dijo que Hitler era *{}*{}\n   ↳ Acertó {}/{} fascistas comunes, {} a Hitler ({} pts)".format(
 			guesser.name, nombres_fascistas, nombre_hitler, nota_cambio,
 			len(aciertos_fascistas), total_fascists,
-			"acertó ✅" if hitler_acierto else "no acertó ❌"
+			"acertó ✅" if hitler_acierto else "no acertó ❌",
+			score
 		)
 		liberal_resultados.append((score, guesser.name, texto))
 
@@ -2145,8 +2153,8 @@ def format_guesses_reveal(game):
 			lineas.append(texto)
 		max_score = max(r[0] for r in liberal_resultados)
 		ganadores = [nombre for score, nombre, _ in liberal_resultados if score == max_score]
-		lineas.append("\n🏆 Más cerca de la verdad: *{}* ({} de {} aciertos)".format(
-			", ".join(ganadores), max_score, total_fascists + 1))
+		lineas.append("\n🏆 Más cerca de la verdad: *{}* ({} de {} pts)".format(
+			", ".join(ganadores), max_score, total_fascists + 3))
 
 	if hitler_lineas:
 		lineas.append("")

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.3.1"
+VERSION = "1.4.0"

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.3.0"
+VERSION = "1.3.1"


### PR DESCRIPTION
## Summary
- Cada palpito de `/guess` ahora guarda un timestamp, mostrado en la confirmación privada y en la revelación de fin de partida.
- El puntaje del `/guess` completo (Liberal) ahora suma 1 punto por cada acierto de equipo fascista (fascista común o Hitler) marcado en cualquiera de las dos casillas, más 2 puntos adicionales si se acierta a Hitler específicamente en su casilla. La lógica vive en `Game.compute_guess_score`, compartida entre el ranking y el texto de revelación para que no se desincronicen.
- Bump de `VERSION` a `1.4.0` en `SecretHitler/Constants/Config.py`.

## Test plan
- [x] `python3 -m py_compile` sobre los módulos modificados
- [x] Casos manuales de `compute_guess_score` (aciertos completos, Hitler adivinado dentro de la lista de fascistas, fascista adivinado en la casilla de Hitler, ningún acierto)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_