### PR TITLE
BSG: Sonda "mirar Destino" ahora mira el mazo de Destino de Salto real

### DIFF
--- a/BattlestarGalactica/Boardgamebox/State.py
+++ b/BattlestarGalactica/Boardgamebox/State.py
@@ -41,7 +41,10 @@ class State(BaseState):
         # --- Mazos ---
         self.skill_decks = {}             # color -> lista de cartas
         self.skill_discards = {}          # color -> lista de descartes
-        self.destiny_deck = []            # cartas de destino (mezcla de colores)
+        self.destiny_deck = []            # mazo de Destino de HABILIDAD (secreto, para chequeos; mezcla de colores)
+        self.destination_deck = []        # mazo de Destino de SALTO (Destination Cards): distancia/combustible/efectos
+        self.destination_discard = []
+        self.destino_especial_pendiente = None  # dict {tipo, carta} esperando la decisión opcional del Almirante
         self.crisis_deck = []
         self.crisis_discard = []
         self.crisis_actual = None         # dict de la crisis en curso

--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -1749,6 +1749,38 @@ async def callback_bsg_free(update: Update, context: CallbackContext):
         await bot.send_message(ADMIN[0], f"BSG free error: {e}")
 
 
+async def callback_bsg_destino_especial(update: Update, context: CallbackContext):
+    """Resuelve la decisión opcional del Almirante ofrecida tras un salto
+    (Ragnar Anchorage / Cylon Refinery / Icy Moon / Tylium Planet)."""
+    bot = context.bot
+    callback = update.callback_query
+    presser = callback.from_user.id
+    try:
+        regex = re.search(r"(-?[0-9]*)\*bsgDestinoEsp\*(si|no)\*(-?[0-9]*)", callback.data)
+        cid = int(regex.group(1))
+        quiere = regex.group(2) == "si"
+        game = get_game(cid)
+        if not _validar(game):
+            await callback.answer("Partida no encontrada.")
+            return
+        error = await BSGController.resolver_destino_especial(bot, game, presser, quiere)
+        if error:
+            await callback.answer(error)
+            return
+        await callback.answer()
+        try:
+            await bot.edit_message_reply_markup(cid, callback.message.message_id, reply_markup=None)
+        except Exception:
+            pass
+    except Exception as e:
+        logger.error(f"callback_bsg_destino_especial error: {e}")
+        try:
+            await callback.answer("Error.")
+        except Exception:
+            pass
+        await bot.send_message(ADMIN[0], f"BSG destino especial error: {e}")
+
+
 # ---- Panel de Admin: correcciones manuales cuando algo salió mal ----
 # (usamos "bsgadmin" y no "admin": ese comando ya existe a nivel global,
 # para listar/eliminar partidas — Commands.command_admin_games)

--- a/BattlestarGalactica/Constants/Destinations.py
+++ b/BattlestarGalactica/Constants/Destinations.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""
+Mazo de Destino de SALTO del JUEGO BASE (10 cartas, hoja "Destination Cards"
+Module=B). No confundir con el mazo de Destino de HABILIDAD (State.destiny_deck):
+ese es un mazo secreto de cartas de habilidad usado para chequeos; este es el
+que se roba al ejecutar un salto FTL y determina a dónde llega la flota.
+
+Cada carta:
+  - "distancia": cuánto avanza la distancia al ejecutar el salto.
+  - "combustible": delta de combustible (siempre <= 0, salvo Ragnar Anchorage).
+  - "efectos" (opcional): lista de efectos automáticos, resueltos por
+    Controller._aplicar_efectos_destino. Tipos soportados: recurso
+    (recurso/delta), destruir_civil, raptor (delta sobre raptors_reserva),
+    basestar (cantidad), raiders (cantidad), civiles (cantidad).
+  - "especial" (opcional): id de una decisión OPCIONAL del Almirante tras
+    llegar (reparar en Ragnar, o arriesgar Vipers/un Raptor por una tirada),
+    resuelta por Controller.resolver_destino_especial. "especial_texto" es
+    el texto que se ofrece con la decisión.
+
+Nota: la carga exacta de "Cylon Ambush" (naves civiles que llegan junto a la
+emboscada) no estaba clara en los datos de origen; se usa el valor más
+consistente con el resto de la carta (4 civiles), a falta de confirmarlo
+contra la carta física.
+"""
+
+DESTINATION_DECK = [
+    {
+        "titulo": "Asteroid Field",
+        "distancia": 3,
+        "combustible": -2,
+        "efectos": [{"tipo": "destruir_civil"}],
+    },
+    {
+        "titulo": "Deep Space",
+        "distancia": 2,
+        "combustible": -1,
+        "efectos": [{"tipo": "recurso", "recurso": "moral", "delta": -1}],
+    },
+    {
+        "titulo": "Ragnar Anchorage",
+        "distancia": 1,
+        "combustible": 0,
+        "especial": "ragnar",
+        "especial_texto": "🔧 El Almirante puede reparar hasta 3 Vipers y 1 Raptor.",
+    },
+    {
+        "titulo": "Barren Planet",
+        "distancia": 2,
+        "combustible": -2,
+    },
+    {
+        "titulo": "Remote Planet",
+        "distancia": 2,
+        "combustible": -1,
+        "efectos": [{"tipo": "raptor", "delta": -1}],
+    },
+    {
+        "titulo": "Desolate Moon",
+        "distancia": 3,
+        "combustible": -3,
+    },
+    {
+        "titulo": "Cylon Refinery",
+        "distancia": 2,
+        "combustible": -1,
+        "especial": "cylon_refinery",
+        "especial_texto": "🎲 El Almirante puede arriesgar 2 Vipers: 1-5 → se dañan; 6-8 → +2 combustible.",
+    },
+    {
+        "titulo": "Icy Moon",
+        "distancia": 1,
+        "combustible": -1,
+        "especial": "icy_moon",
+        "especial_texto": "🎲 El Almirante puede arriesgar 1 Raptor: 1-2 → se pierde; 3-8 → +1 comida.",
+    },
+    {
+        "titulo": "Cylon Ambush",
+        "distancia": 3,
+        "combustible": -1,
+        "efectos": [
+            {"tipo": "basestar", "cantidad": 1},
+            {"tipo": "raiders", "cantidad": 3},
+            {"tipo": "civiles", "cantidad": 4},
+        ],
+    },
+    {
+        "titulo": "Tylium Planet",
+        "distancia": 1,
+        "combustible": -1,
+        "especial": "tylium_planet",
+        "especial_texto": "🎲 El Almirante puede arriesgar 1 Raptor: 1-2 → se pierde; 3-8 → +2 combustible.",
+    },
+]

--- a/BattlestarGalactica/Controller.py
+++ b/BattlestarGalactica/Controller.py
@@ -66,7 +66,7 @@ from telegram.ext import CallbackContext
 from Utils import get_game, save, simple_choose_buttons, player_call
 from Constants.Config import ADMIN
 from BattlestarGalactica.Boardgamebox.Game import Game
-from BattlestarGalactica.Constants import Characters, Locations, Skills, Crisis, Loyalty, Quorum, Space
+from BattlestarGalactica.Constants import Characters, Locations, Skills, Crisis, Loyalty, Quorum, Space, Destinations
 
 import GamesController
 
@@ -89,6 +89,12 @@ def asegurar_estado(game):
             for k, v in ref.__dict__.items():
                 if not hasattr(st, k):
                     setattr(st, k, copy.deepcopy(v))
+            # Partida vieja que nunca tuvo mazo de Destino de Salto: se nota
+            # porque tanto el mazo como su descarte están vacíos (uno de los
+            # dos siempre tiene cartas en una partida que sí lo usó).
+            if not st.destination_deck and not st.destination_discard:
+                st.destination_deck = [dict(c) for c in Destinations.DESTINATION_DECK]
+                random.shuffle(st.destination_deck)
         for p in list(getattr(game, "playerlist", {}).values()):
             try:
                 refp = type(p)(p.name, p.uid)
@@ -141,6 +147,13 @@ async def init_game(bot, game):
         st.crisis_deck = [dict(c) for c in Crisis.CRISIS_DECK]
         random.shuffle(st.crisis_deck)
         st.crisis_discard = []
+
+        # Mazo de Destino de Salto (Destination Cards): se roba al ejecutar un
+        # salto FTL. No confundir con el mazo de arriba (destiny_deck), que es
+        # de habilidad y sirve para los chequeos.
+        st.destination_deck = [dict(c) for c in Destinations.DESTINATION_DECK]
+        random.shuffle(st.destination_deck)
+        st.destination_discard = []
 
         # Mazo de súper crisis (para Cylons revelados)
         st.super_crisis_deck = [dict(c) for c in Crisis.SUPER_CRISIS_DECK]
@@ -3200,7 +3213,7 @@ async def elegir_mazo_scout(bot, game, uid, mazo_key):
         return False
     player = game.playerlist[uid]
     etiqueta = "Crisis" if mazo_key == "crisis" else "Destino"
-    mazo = st.crisis_deck if mazo_key == "crisis" else st.destiny_deck
+    mazo = st.crisis_deck if mazo_key == "crisis" else st.destination_deck
     await bot.send_message(game.cid, f"🔭 {player_call(player)} decide mirar el mazo de *{etiqueta}*.", parse_mode=ParseMode.MARKDOWN)
     if not mazo:
         st.play_pending = None
@@ -3211,8 +3224,8 @@ async def elegir_mazo_scout(bot, game, uid, mazo_key):
     if mazo_key == "crisis":
         txt = f"🔭 Próxima carta de Crisis: *{top['titulo']}*\n_{top['texto'][:180]}_"
     else:
-        txt = (f"🔭 Próxima carta de Destino: {Skills.EMOJI_COLOR[top['color']]} "
-               f"{top['color']} {top['valor']} — {top.get('nombre', '')}")
+        txt = (f"🔭 Próxima carta de Destino: *{top['titulo']}* "
+               f"(distancia {top['distancia']}, combustible {top['combustible']:+d})")
     st.play_pending = {"tipo": "scout", "uid": uid, "mazo": mazo_key}
     btns = [[InlineKeyboardButton("⬆️ Mantener arriba", callback_data=f"{game.cid}*bsgJugar*ls_keep*{uid}"),
              InlineKeyboardButton("⬇️ Enviar al fondo", callback_data=f"{game.cid}*bsgJugar*ls_bottom*{uid}")]]
@@ -3230,7 +3243,7 @@ async def carta_scout_resolve(bot, game, uid, mantener):
     if not pp or pp.get("tipo") != "scout" or pp.get("uid") != uid:
         return
     mazo_key = pp.get("mazo", "crisis")
-    mazo = st.crisis_deck if mazo_key == "crisis" else st.destiny_deck
+    mazo = st.crisis_deck if mazo_key == "crisis" else st.destination_deck
     etiqueta = "Crisis" if mazo_key == "crisis" else "Destino"
     st.play_pending = None
     if mazo and not mantener:
@@ -3903,22 +3916,163 @@ async def modificar_recurso(bot, game, recurso, delta):
 
 # ===================== SALTO / SLEEPER =====================
 
+async def _robar_destino_salto(st):
+    """Roba la carta de arriba del mazo de Destino de Salto (Destination
+    Cards), rebarajando el descarte si hace falta. None si no hay ninguna."""
+    if not st.destination_deck:
+        st.destination_deck = st.destination_discard
+        st.destination_discard = []
+        random.shuffle(st.destination_deck)
+    if not st.destination_deck:
+        return None
+    return st.destination_deck.pop()
+
+
+async def _aplicar_efectos_destino(bot, game, efectos):
+    """Efectos automáticos de una carta de Destino de Salto: subconjunto de
+    los de Crisis (mismos helpers de bajo nivel), más 'raptor'."""
+    st = game.board.state
+    for ef in efectos or []:
+        tipo = ef.get("tipo")
+        if tipo == "recurso":
+            await modificar_recurso(bot, game, ef["recurso"], ef["delta"])
+        elif tipo == "destruir_civil":
+            await _destruir_civil(bot, game)
+        elif tipo == "raptor":
+            st.raptors_reserva = max(0, st.raptors_reserva + ef["delta"])
+            await bot.send_message(game.cid, f"🚀 Se pierde 1 Raptor en el salto (quedan {st.raptors_reserva}).")
+        elif tipo == "basestar":
+            for _ in range(ef["cantidad"]):
+                st.areas[Space.AREA_PROA]["basestars"].append(0)
+            await bot.send_message(game.cid, f"🛸 Aparece(n) {ef['cantidad']} Basestar(s) en {Space.nombre(Space.AREA_PROA)}.")
+        elif tipo == "raiders":
+            st.areas[Space.AREA_PROA]["raiders"] += ef["cantidad"]
+            await bot.send_message(game.cid, f"👾 Aparecen {ef['cantidad']} Raiders en {Space.nombre(Space.AREA_PROA)}.")
+        elif tipo == "civiles":
+            n = _colocar_civiles(st, ef.get("cantidad", 1))
+            await bot.send_message(game.cid, f"🛰️ Aparece(n) {n} nave(s) civil(es) tras Galactica.")
+
+
+async def _ofrecer_destino_especial(bot, game, carta):
+    """Si la carta de Destino trae una decisión opcional del Almirante
+    (reparar en Ragnar, o arriesgar Vipers/un Raptor por una tirada), la
+    ofrece con botones públicos."""
+    especial = carta.get("especial")
+    if not especial:
+        return
+    st = game.board.state
+    st.destino_especial_pendiente = {"tipo": especial, "carta": carta["titulo"]}
+    btns = [[InlineKeyboardButton("✅ Sí", callback_data=f"{game.cid}*bsgDestinoEsp*si*{st.almirante_uid or 0}"),
+             InlineKeyboardButton("❌ No", callback_data=f"{game.cid}*bsgDestinoEsp*no*{st.almirante_uid or 0}")]]
+    await bot.send_message(
+        game.cid,
+        f"📍 *{carta['titulo']}*: {carta.get('especial_texto', '')}\n¿El Almirante lo usa?",
+        reply_markup=InlineKeyboardMarkup(btns),
+        parse_mode=ParseMode.MARKDOWN,
+    )
+
+
+async def resolver_destino_especial(bot, game, presser_uid, quiere):
+    """Resuelve la decisión opcional del Almirante ofrecida tras un salto
+    (Ragnar Anchorage / Cylon Refinery / Icy Moon / Tylium Planet). Devuelve
+    un texto de error para mostrarle a quien presionó, o None si se resolvió."""
+    st = game.board.state
+    pend = st.destino_especial_pendiente
+    if not pend:
+        return "Ya no hay ninguna decisión de Destino pendiente."
+    if presser_uid != st.almirante_uid and presser_uid != ADMIN[0]:
+        return "Solo el Almirante puede decidir esto."
+    st.destino_especial_pendiente = None
+    tipo = pend["tipo"]
+    if not quiere:
+        await bot.send_message(game.cid, f"📍 El Almirante no usa la opción de *{pend['carta']}*.", parse_mode=ParseMode.MARKDOWN)
+        await save(bot, game.cid)
+        return None
+
+    if tipo == "ragnar":
+        rep_v = min(3, st.vipers_danados)
+        st.vipers_danados -= rep_v
+        st.vipers_reserva += rep_v
+        st.raptors_reserva += 1
+        await bot.send_message(
+            game.cid,
+            f"🔧 *Ragnar Anchorage*: se reparan {rep_v} Viper(s) y 1 Raptor "
+            f"(Vipers dañados: {st.vipers_danados}, Raptors: {st.raptors_reserva}).",
+            parse_mode=ParseMode.MARKDOWN,
+        )
+    elif tipo == "cylon_refinery":
+        if st.vipers_reserva < 2:
+            await bot.send_message(game.cid, "🎲 No hay 2 Vipers en la reserva para arriesgar en la Refinería Cylon.")
+            await save(bot, game.cid)
+            return None
+        st.vipers_reserva -= 2
+        r = _d8()
+        if r <= 5:
+            st.vipers_danados += 2
+            await bot.send_message(game.cid, f"🎲 *Refinería Cylon*: tirada {r} — los 2 Vipers se dañan (dañados: {st.vipers_danados}).", parse_mode=ParseMode.MARKDOWN)
+        else:
+            st.vipers_reserva += 2
+            await modificar_recurso(bot, game, "combustible", 2)
+            await bot.send_message(game.cid, f"🎲 *Refinería Cylon*: tirada {r} — los Vipers vuelven ilesos.", parse_mode=ParseMode.MARKDOWN)
+    elif tipo == "icy_moon":
+        if st.raptors_reserva < 1:
+            await bot.send_message(game.cid, "🎲 No hay Raptors disponibles para arriesgar en la Luna Helada.")
+            await save(bot, game.cid)
+            return None
+        r = _d8()
+        if r <= 2:
+            st.raptors_reserva -= 1
+            await bot.send_message(game.cid, f"🎲 *Luna Helada*: tirada {r} — se pierde el Raptor (quedan {st.raptors_reserva}).", parse_mode=ParseMode.MARKDOWN)
+        else:
+            await modificar_recurso(bot, game, "comida", 1)
+            await bot.send_message(game.cid, f"🎲 *Luna Helada*: tirada {r} — el Raptor vuelve con provisiones.", parse_mode=ParseMode.MARKDOWN)
+    elif tipo == "tylium_planet":
+        if st.raptors_reserva < 1:
+            await bot.send_message(game.cid, "🎲 No hay Raptors disponibles para arriesgar en el Planeta de Tylium.")
+            await save(bot, game.cid)
+            return None
+        r = _d8()
+        if r <= 2:
+            st.raptors_reserva -= 1
+            await bot.send_message(game.cid, f"🎲 *Planeta de Tylium*: tirada {r} — se pierde el Raptor (quedan {st.raptors_reserva}).", parse_mode=ParseMode.MARKDOWN)
+        else:
+            await modificar_recurso(bot, game, "combustible", 2)
+            await bot.send_message(game.cid, f"🎲 *Planeta de Tylium*: tirada {r} — el Raptor vuelve con Tylium.", parse_mode=ParseMode.MARKDOWN)
+    await _chequear_fin(bot, game)
+    await save(bot, game.cid)
+    return None
+
+
 async def ejecutar_salto(bot, game, auto=False):
     st = game.board.state
     st.jump_prep = 0
-    # La carta de destino del salto avanza 1 o 2 unidades de distancia.
-    avance = random.choice([1, 1, 2])
-    # Poder presidencial "Especialista de Misión": elige el destino (mejor avance)
-    # en este salto y luego cesa en el cargo.
+    st.destino_especial_pendiente = None   # una carta nueva reemplaza cualquier oferta anterior sin resolver
+
+    carta = await _robar_destino_salto(st)
+    # Poder presidencial "Especialista de Misión": mira las 2 cartas de arriba
+    # y se queda con la de mayor distancia (la otra vuelve al descarte); luego
+    # cesa en el cargo.
     esp = game.playerlist.get(st.especialista_uid)
-    if esp:
-        avance = 2
+    if esp and carta:
+        carta2 = await _robar_destino_salto(st)
+        if carta2:
+            peor, mejor = (carta, carta2) if carta["distancia"] <= carta2["distancia"] else (carta2, carta)
+            st.destination_discard.append(peor)
+            carta = mejor
         st.especialista_uid = None
         await bot.send_message(
             game.cid,
-            f"🧭 *{esp.name}* (Especialista de Misión) guía el salto y elige el mejor destino.",
+            f"🧭 *{esp.name}* (Especialista de Misión) guía el salto: mira 2 Destinos y elige *{carta['titulo']}* "
+            f"(distancia {carta['distancia']}).",
             parse_mode=ParseMode.MARKDOWN,
         )
+
+    if carta:
+        avance = carta["distancia"]
+        st.destination_discard.append(carta)
+    else:
+        # No debería pasar (el descarte se rebaraja solo), pero por las dudas.
+        avance = random.choice([1, 1, 2])
     st.distancia = min(st.objetivo_distancia, st.distancia + avance)
 
     # Tras el salto: las naves Cylon no siguen a la flota; los Vipers regresan a
@@ -3939,15 +4093,34 @@ async def ejecutar_salto(bot, game, auto=False):
             st.vipers_reserva += 1
 
     etiqueta = "AUTOMÁTICO" if auto else "FTL"
-    await bot.send_message(
-        game.cid,
-        f"🌌 *¡SALTO {etiqueta}!* La flota avanza y deja atrás a los Cylons. "
-        f"Distancia: *{st.distancia}/{st.objetivo_distancia}*.",
-        parse_mode=ParseMode.MARKDOWN,
-    )
+    if carta:
+        await bot.send_message(
+            game.cid,
+            f"🌌 *¡SALTO {etiqueta}!* Destino: *{carta['titulo']}* (distancia +{carta['distancia']}, "
+            f"combustible {carta['combustible']:+d}). La flota avanza y deja atrás a los Cylons. "
+            f"Distancia: *{st.distancia}/{st.objetivo_distancia}*.",
+            parse_mode=ParseMode.MARKDOWN,
+        )
+        if carta.get("combustible"):
+            await modificar_recurso(bot, game, "combustible", carta["combustible"])
+        await _aplicar_efectos_destino(bot, game, carta.get("efectos"))
+        if await _chequear_fin(bot, game):
+            return
+        await _ofrecer_destino_especial(bot, game, carta)
+    else:
+        await bot.send_message(
+            game.cid,
+            f"🌌 *¡SALTO {etiqueta}!* La flota avanza y deja atrás a los Cylons. "
+            f"Distancia: *{st.distancia}/{st.objetivo_distancia}*.",
+            parse_mode=ParseMode.MARKDOWN,
+        )
+
+    if await _chequear_fin(bot, game):
+        return
     # Fase del Agente Durmiente
     if not st.sleeper_hecho and st.distancia >= Loyalty.DISTANCIA_SLEEPER:
         await fase_durmiente(bot, game)
+    await save(bot, game.cid)
 
 
 async def fase_durmiente(bot, game):

--- a/MainController.py
+++ b/MainController.py
@@ -869,6 +869,7 @@ def main(stop_event):
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgCylon\*([a-z0-9_]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_cylon))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgBrig\*(-?[0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_brig))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgFree\*(-?[0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_free))
+	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgDestinoEsp\*(si|no)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_destino_especial))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgQuorum\*([0-9]*)\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_quorum))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgQTarget\*[a-z]*\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_qtarget))
 	app.add_handler(CallbackQueryHandler(pattern=r"(-?[0-9]*)\*bsgQDraw\*(-?[0-9]*)", callback=BSGCommands.callback_bsg_qdraw))


### PR DESCRIPTION
## Bug reported
Choosing "Destino" after a successful Sonda (Launch Scout) showed a skill card (e.g. "🔴 Pilotaje 2 — Evasive Maneuvers") instead of an actual travel/jump destination card.

## Root cause
This engine never had a real Destination Cards deck (the one drawn on an FTL jump). `state.destiny_deck` — despite its Spanish name "mazo de destino" — is actually the secret skill Destiny deck used in checks. Since Spanish "destino" covers both English "destiny" and "destination", the Scout mechanic's "Destino" branch was wired to that unrelated deck for lack of a real one, and jumps themselves just advanced distance by `random.choice([1,1,2])` with no card involved at all.

## Fix
- New `BattlestarGalactica/Constants/Destinations.py`: the 10 base-game Destination Cards (hoja "Destination Cards", Module=B, from the reference spreadsheet), each with its real distance, fuel cost, and effects/decisions transcribed from the official card text.
- New `state.destination_deck` / `destination_discard`, initialized and shuffled in `init_game`; `asegurar_estado` seeds them for already-in-progress games too (empty deck **and** empty discard is the signal a game never had one — a game that legitimately emptied its deck mid-play always has cards in the discard).
- `elegir_mazo_scout` / `carta_scout_resolve` now peek and reorder `destination_deck` (not `destiny_deck`) when "Destino" is chosen.
- `ejecutar_salto` now draws the top card of the real deck and applies its distance/fuel/effects instead of the old placeholder random 1/1/2 advance. "Especialista de Misión" now looks at the top 2 cards and picks the one with the higher distance (its old behavior of forcing a flat +2 no longer makes sense against real cards that can reach 3).
- The 4 cards with an optional Admiral decision (Ragnar Anchorage: repair Vipers/a Raptor; Cylon Refinery/Icy Moon/Tylium Planet: risk Vipers or a Raptor on a roll) are offered with public buttons after the jump, resolved by `Controller.resolver_destino_especial` via the new `bsgDestinoEsp` callback.

Documented in `Destinations.py`: "Cylon Ambush"'s exact civilian-ship count wasn't clear from the source data's shorthand ("Civ(3x4)"); used 4 as the most consistent reading, flagged for anyone who can check the physical card.

## Test plan
- [x] `python3 -m py_compile` clean on all changed/new files.
- [x] Verified all 10 `DESTINATION_DECK` entries match the spreadsheet's title/distance/fuel exactly.
- [x] Verified the new `bsgDestinoEsp` callback pattern doesn't cross-match any of the other 115 registered patterns.
- [x] Reproduced the exact reported bug against the *old* code path (Scout → Destino showed a skill card) and confirmed the fix: the DM now shows the real top Destination card (title/distance/fuel), and top/bottom reordering operates on `destination_deck`.
- [x] Simulated all 10 destination cards through `ejecutar_salto`: correct distance/fuel applied for each; Asteroid Field destroys a civilian ship (recycled to the pile, not lost forever); Cylon Ambush deploys 1 Basestar + 3 Raiders + 4 civilians; the 4 "especial" cards correctly flag `destino_especial_pendiente`.
- [x] Simulated `resolver_destino_especial` for all 4 special types: Ragnar repairs Vipers/Raptor correctly; Cylon Refinery/Icy Moon/Tylium Planet rolls resolve both outcomes correctly (seeded `_d8`); insufficient-resource guard blocks the risky option cleanly; non-Almirante presses are rejected.
- [x] Simulated "Especialista de Misión": correctly draws 2 cards and picks the higher-distance one.
- [x] Simulated the `asegurar_estado` migration path for an old in-progress game (real `State` instance missing the new fields): gets seeded with a fresh shuffled 10-card deck exactly once (idempotent on repeat calls), while a game already legitimately mid-deck (empty deck, non-empty discard) is left untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am)_