### PR TITLE
Send one pinned role-reveal message per player instead of up to 3

### DIFF
--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -620,7 +620,6 @@ def command_startgame(update: Update, context: CallbackContext):
 	else:
 		player_number = len(game.playerlist)
 		MainController.inform_players(bot, game, game.cid, player_number)
-		MainController.inform_fascists(bot, game, player_number)
 		game.board = Board(player_number, game)
 		log.info(game.board)
 		log.info("len(games) Command_startgame: " + str(len(GamesController.games)))

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.5.0"
+VERSION = "1.6.0"

--- a/SecretHitler/MainController.py
+++ b/SecretHitler/MainController.py
@@ -1048,12 +1048,22 @@ def inform_players(bot, game, cid, player_number):
 		party = get_membership(role)
 		game.playerlist[uid].role = role
 		game.playerlist[uid].party = party
-		
+
+	# Recien aca, con los roles de TODOS los jugadores ya asignados (get_private_info necesita
+	# poder consultar game.get_fascists()/game.get_hitler() completos), mando un unico mensaje
+	# por jugador con toda su info y lo pinneo en su chat privado con el bot.
+	for uid in player_ids:
 		# I comment so tyhe player aren't discturbed in testing, uncomment when deploy to production
 		if not game.is_debugging:
-			bot.send_message(uid, "Tu rol secreto es: %s\nTu afiliación política es: %s" % (role, party))
+			msg = game.playerlist[uid].get_private_info(game)
+			sent = bot.send_message(uid, msg, parse_mode=ParseMode.MARKDOWN)
+			try:
+				bot.pin_chat_message(uid, sent.message_id, disable_notification=True)
+			except Exception as e:
+				log.error("No se pudo pinnear el mensaje de rol de %s: %s" % (game.playerlist[uid].name, str(e)))
 		else:
-			bot.send_message(ADMIN, "El jugador %s es %s y su afiliación política es: %s" % (game.playerlist[uid].name, role, party))
+			bot.send_message(ADMIN, "El jugador %s es %s y su afiliación política es: %s" % (
+				game.playerlist[uid].name, game.playerlist[uid].role, game.playerlist[uid].party))
 
 
 def print_player_info(player_number):
@@ -1069,35 +1079,6 @@ def print_player_info(player_number):
         return "Hay  5 Liberales, 3 Fascistas y Hitler. Hitler no conoce quienes son los Fascistas."
     elif player_number == 10:
         return "Hay  6 Liberales, 3 Fascistas y Hitler. Hitler no conoce quienes son los Fascistas."
-
-
-def inform_fascists(bot, game, player_number):
-	log.info('inform_fascists called')
-
-	for uid in game.playerlist:
-		role = game.playerlist[uid].role
-		if role == "Fascista":
-			fascists = game.get_fascists()
-			if player_number > 6:
-				fstring = ""
-				for f in fascists:
-					if f.uid != uid:
-						fstring += f.name + ", "
-				fstring = fstring[:-2]
-				if not game.is_debugging:
-					bot.send_message(uid, "Tus compañeros fascistas son: %s" % fstring)
-			hitler = game.get_hitler()
-			if not game.is_debugging:
-				bot.send_message(uid, "Hitler es: %s" % hitler.name) #Uncoomend on production
-		elif role == "Hitler":
-			if player_number <= 6:
-				fascists = game.get_fascists()
-				if not game.is_debugging:
-					bot.send_message(uid, "Tu compañero fascista es: %s" % fascists[0].name)
-		elif role == "Liberal":
-			pass
-		else:
-			log.error("inform_fascists: can\'t handle the role %s" % role)
 
 
 def get_membership(role):


### PR DESCRIPTION
## Summary
- At game start, players used to get 1-3 separate DMs revealing their role: `inform_players()` sent role+party, then `inform_fascists()` sent 0-2 more depending on role (fellow fascists, Hitler's identity for Fascista, or the fascist teammate for Hitler in ≤6-player games).
- Now all roles are assigned in a first pass (required before any messaging, since the fascist/Hitler info needs every player's role already set), then a second pass sends each player a single consolidated message via `Player.get_private_info()` — the same method `/info` already uses — and pins it in their private chat with the bot (`bot.pin_chat_message`, `disable_notification=True`; wrapped in try/except so a pin failure never breaks game start).
- Removes the now-unused `inform_fascists()` and its call site in `command_startgame`.
- Bumps `VERSION` to `1.6.0`.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual playtest: start a game with 5-6 and with 7+ players, confirm every player gets exactly one DM with their full role info, and that it shows up pinned in their private chat with the bot

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_