### PR TITLE
BSG: opción Cancelar en el panel de Admin

### DIFF
--- a/BattlestarGalactica/Commands.py
+++ b/BattlestarGalactica/Commands.py
@@ -2074,6 +2074,7 @@ async def command_bsgadmin(update: Update, context: CallbackContext):
         [InlineKeyboardButton("🃏 Quitar carta a un jugador", callback_data=f"{cid}*bsgAdmin*quitar_carta*{uid}")],
         [InlineKeyboardButton("🔭 Dar resultado de Sonda exitosa", callback_data=f"{cid}*bsgAdmin*dar_scout*{uid}")],
         [InlineKeyboardButton("🎲 Reiniciar pedido de cartas (crisis activa)", callback_data=f"{cid}*bsgAdmin*reabrir_chequeo*{uid}")],
+        [InlineKeyboardButton("❌ Cancelar", callback_data=f"{cid}*bsgAdmin*cancelar*{uid}")],
     ]
     await bot.send_message(cid, "🛠️ *Panel de Admin (BSG)* — ¿qué querés corregir?",
                            reply_markup=InlineKeyboardMarkup(btns), parse_mode=ParseMode.MARKDOWN)
@@ -2096,6 +2097,15 @@ async def callback_bsg_admin(update: Update, context: CallbackContext):
         if presser != ordenante or presser != ADMIN[0]:
             await callback.answer("No puedes usar este panel.")
             return
+
+        if opcion == "cancelar":
+            await callback.answer("Cancelado.")
+            try:
+                await bot.delete_message(cid, callback.message.message_id)
+            except Exception:
+                pass
+            return
+
         await callback.answer()
         st = game.board.state
 


### PR DESCRIPTION
## Summary
- Agrega un botón "❌ Cancelar" al final de `/bsgadmin` que borra el mensaje del panel en vez de dejarlo abierto sin usar, ensuciando el chat.

## Test plan
- [x] `python -m py_compile BattlestarGalactica/Commands.py`
- [x] Probado manualmente con un `Game`/callback simulados: al elegir "Cancelar" se llama `delete_message` sobre el mensaje del panel.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am

---
_Generated by [Claude Code](https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am)_