### PR TITLE
Add "Más muerto que Alee" achievement

### DIFF
--- a/SecretHitler/Constants/Achievements.py
+++ b/SecretHitler/Constants/Achievements.py
@@ -77,6 +77,10 @@ def _check_alma_en_pena(ctx):
     return sum(1 for row in ctx.history() if row[3]) >= 10
 
 
+def _check_mas_muerto_que_alee(ctx):
+    return sum(1 for row in ctx.history() if row[3]) > 10  # row[3] = died
+
+
 def _check_primera_partida(ctx):
     # >=1 (no ==1): si el primer registro de un jugador vino de una migracion
     # legacy (/vincularstats) o de antes de que existiera este logro, el
@@ -227,6 +231,8 @@ LOGROS = [
           "⚰️", "muerte", False, _check_carne_de_canon),
     Logro("alma_en_pena", "Alma en pena", "Te ejecutaron 10 veces en total.",
           "👻", "muerte", False, _check_alma_en_pena),
+    Logro("mas_muerto_que_alee", "Más muerto que Alee", "Te ejecutaron más de 10 veces en total.",
+          "🪦", "muerte", False, _check_mas_muerto_que_alee),
 
     # Hitos
     Logro("primera_partida", "Primera vez", "Jugaste tu primera partida.",

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.6.0"
+VERSION = "1.7.0"


### PR DESCRIPTION
## Summary
- Adds a fourth tier to the execution-count achievement family: **Más muerto que Alee** 🪦 — executed more than 10 times total (Gafe=3, Carne de cañón=5, Alma en pena=10, this one=>10).
- Same pattern as its siblings, via `ctx.history()`.
- Bumps `VERSION` to `1.7.0`.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual check: a player executed 11+ times total unlocks it on their next finished game, visible in `/logros`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_