### PR TITLE
Fix /role preference never getting persisted before game start

### DIFF
--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -1662,6 +1662,7 @@ def callback_choose_posible_role(update: Update, context: CallbackContext):
 			if uid in game.playerlist:
 				mensaje_edit = 'Mensaje Editado: Has elegido el Rol: %s' % opcion
 				game.playerlist[uid].preference_rol = opcion
+				save_game(cid, game.groupName, game)
 				choose_posible_role(bot, cid, uid)
 			else:
 				mensaje_edit = 'No estas unido a esta partida, intentalo cuando te hayas unido'			

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.8.0"
+VERSION = "1.8.1"


### PR DESCRIPTION
## Summary
- `callback_choose_posible_role` set `game.playerlist[uid].preference_rol` on the in-memory game object but never called `save_game()`.
- If the game got reloaded from DB for any reason before `/startgame` (bot restart, redeploy — which currently happens manually and often), the preference was silently lost — even though `inform_players()` (role assignment) and `print_roles()` (the reveal text) both correctly read/display it when present.
- This explains a real report: of several players who picked a role preference via `/role`, only one ("queria ser Liberal") actually showed up at game start — the rest had almost certainly been wiped by a redeploy that happened between them picking and the game starting.
- Fix: `save_game(cid, game.groupName, game)` right after setting the preference, matching the same pattern already used elsewhere (e.g. `command_join`).
- Bumps `VERSION` to `1.8.1`.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual check: have a player pick a role preference via `/role`, restart/redeploy the bot, then `/startgame` and confirm the preference is still honored and shown

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_