### PR TITLE
Add early-guess achievements for Liberal, Fascista and Hitler

### DIFF
--- a/SecretHitler/Commands.py
+++ b/SecretHitler/Commands.py
@@ -2040,6 +2040,7 @@ def callback_guess_confirm(update: Update, context: CallbackContext):
 		entry = {"fascists": list(progress["fascists"]), "hitler": progress["hitler"]}
 
 	entry["timestamp"] = datetime.datetime.now()
+	entry["round"] = game.board.state.currentround
 
 	if not hasattr(game, "guesses"):
 		game.guesses = {}

--- a/SecretHitler/Constants/Achievements.py
+++ b/SecretHitler/Constants/Achievements.py
@@ -171,6 +171,50 @@ def _check_prediccion_certera(ctx):
     return predicted in ctx["best_guessers"]
 
 
+DEADLINE_PRESIDENCIA = 7  # currentround es 0-indexed: 7 == arranco la 8va presidencia
+
+
+def _check_detective_precoz(ctx):
+    # Como detective, pero el /guess definitivo tiene que haber quedado
+    # registrado antes de que arranque la 8va presidencia (currentround < 7).
+    if ctx["role"] != "Liberal":
+        return False
+    guess = ctx["guess"]
+    if guess is None:
+        return False
+    guess_round = guess.get("round")
+    if guess_round is None or guess_round >= DEADLINE_PRESIDENCIA:
+        return False
+    return guess.get("hitler") == ctx["hitler_uid"] and set(guess.get("fascists", [])) == ctx["fascist_uids"]
+
+
+def _check_companeros_de_ideologia_precoz(ctx):
+    if ctx["role"] != "Hitler":
+        return False
+    guess = ctx["guess"]
+    if guess is None:
+        return False
+    guess_round = guess.get("round")
+    if guess_round is None or guess_round >= DEADLINE_PRESIDENCIA:
+        return False
+    return set(guess.get("fascists", [])) == ctx["fascist_uids"]
+
+
+def _check_prediccion_certera_precoz(ctx):
+    if ctx["role"] != "Fascista":
+        return False
+    guess = ctx["guess"]
+    if guess is None:
+        return False
+    guess_round = guess.get("round")
+    if guess_round is None or guess_round >= DEADLINE_PRESIDENCIA:
+        return False
+    predicted = guess.get("predicted")
+    if predicted is None:
+        return False
+    return predicted in ctx["best_guessers"]
+
+
 def _check_mision_imposible(ctx):
     # ctx["mision_imposible_party"] es None si MISION_IMPOSIBLE_UID no jugo
     # esta partida, o si el jugador evaluado es el mismo MISION_IMPOSIBLE_UID.
@@ -211,6 +255,12 @@ LOGROS = [
           "🥸", "roles", False, _check_companeros_de_ideologia),
     Logro("prediccion_certera", "Ojo fascista", "Como fascista, predijiste correctamente quién sería el jugador que más acertaría con /guess.",
           "👁️", "roles", False, _check_prediccion_certera),
+    Logro("detective_precoz", "Detective precoz", "Adivinaste correctamente a todos los fascistas y a Hitler con /guess antes de la 8va presidencia.",
+          "⏱️", "roles", False, _check_detective_precoz),
+    Logro("companeros_de_ideologia_precoz", "Complicidad instantánea", "Como Hitler, identificaste a todos tus compañeros fascistas con /guess antes de la 8va presidencia.",
+          "⏱️", "roles", False, _check_companeros_de_ideologia_precoz),
+    Logro("prediccion_certera_precoz", "Vidente fascista", "Como fascista, predijiste correctamente quién sería el mejor adivinando con /guess antes de la 8va presidencia.",
+          "⏱️", "roles", False, _check_prediccion_certera_precoz),
 
     # Muerte y ejecuciones
     Logro("bala_certera", "Bala certera", "Ejecutaste a Hitler y los liberales ganaron.",

--- a/SecretHitler/Constants/Config.py
+++ b/SecretHitler/Constants/Config.py
@@ -2,4 +2,4 @@ ADMIN = 387393551 #your telegram ID
 
 # Version hardcodeada, mostrada por /version. Bumpear en cada cambio que se
 # despliegue (ver convencion en CLAUDE.md).
-VERSION = "1.8.1"
+VERSION = "1.9.0"


### PR DESCRIPTION
## Summary
- `/guess` entries now record the presidency round they were confirmed in (`entry["round"] = game.board.state.currentround`).
- Adds three new "early guess" achievements that require the definitive guess to be fully correct *and* locked in before the 8th presidency (`currentround < 7`):
  - **Detective precoz** ⏱️ (Liberal) — the existing "Detective" condition, plus the early deadline.
  - **Complicidad instantánea** ⏱️ (Hitler) — the existing "Compañeros de ideología" condition, plus the early deadline.
  - **Vidente fascista** ⏱️ (Fascista) — the existing "Ojo fascista" condition, plus the early deadline.
- Bumps `VERSION` to `1.9.0`.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [ ] Manual playtest: confirm all three roles can unlock their early-guess achievement when the definitive `/guess` is both fully correct and confirmed before the 8th presidency, and that guessing correctly later (8th presidency or beyond) does not unlock it

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrGWJwrotEYNkH7CWsDC1c)_