### PR TITLE
Agrega comando /version

### DIFF
--- a/Commands.py
+++ b/Commands.py
@@ -19,7 +19,7 @@ from telegram.ext import (CallbackContext)
 import MainController
 import GamesController
 
-from Constants.Config import STATS
+from Constants.Config import STATS, VERSION
 from Boardgamebox.Board import Board
 
 from Boardgamebox.Game import Game
@@ -341,6 +341,11 @@ async def command_start(update: Update, context: CallbackContext):
 	cid = update.message.chat_id
 	await bot.send_message(cid,"Bot para multiples juegos. Preguntar al ADMIN por los juegos disponibles")
     #command_help(bot, update)
+
+async def command_version(update: Update, context: CallbackContext):
+	bot = context.bot
+	cid = update.message.chat_id
+	await bot.send_message(cid, f"🤖 Versión del bot: {VERSION}")
 
 async def command_rules(update: Update, context: CallbackContext):
 	bot = context.bot

--- a/Constants/Config.py
+++ b/Constants/Config.py
@@ -3,6 +3,9 @@ ADMIN = [387393551, 441820689, 445782140] #your telegram ID
 #Leviatas Ale Cadogan
 STATS = "../stats.json"
 
+# Se incrementa manualmente (semver) con cada cambio relevante que se despliega.
+VERSION = "1.0.0"
+
 JUEGOS_DISPONIBLES = {
         "LostExpedition" : {
                 "comandos" : {

--- a/MainController.py
+++ b/MainController.py
@@ -598,6 +598,7 @@ def main(stop_event):
 
 	# on different commands - answer in Telegram
 	app.add_handler(CommandHandler("start", Commands.command_start))
+	app.add_handler(CommandHandler("version", Commands.command_version))
 	app.add_handler(CommandHandler("help", Commands.command_help))
 	app.add_handler(CommandHandler("board", Commands.command_board))
 	app.add_handler(CommandHandler("rules", Commands.command_rules))


### PR DESCRIPTION
## Summary
- Agrega `Constants.Config.VERSION` (semver, formato `1.0.0`) como versión actual del bot principal, para incrementar manualmente con cada cambio relevante que se despliegue.
- Agrega el comando `/version`, que responde en el chat con la versión actual.

## Test plan
- [x] `python -m py_compile Commands.py MainController.py Constants/Config.py`
- [x] Probado `command_version` con un `update`/`context` simulados, verificando que responde `🤖 Versión del bot: 1.0.0`.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am

---
_Generated by [Claude Code](https://claude.ai/code/session_014DChTLjajSCpdzg2cWA2Am)_